### PR TITLE
Tags for transfers - #include fix

### DIFF
--- a/include/mega/win32/meganet.h
+++ b/include/mega/win32/meganet.h
@@ -22,7 +22,7 @@
 #ifndef HTTPIO_CLASS
 #define HTTPIO_CLASS WinHttpIO
 
-#include "../megaclient.h"
+#include "mega/megaclient.h"
 
 #include "megawait.h"
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -81,7 +81,7 @@ Node::Node(MegaClient* cclient, node_vector* dp, handle h, handle ph, nodetype t
 Node::~Node()
 {
 	// remove node's fingerprint from hash
-	if (client && type == FILENODE && fingerprint_it != client->fingerprints.end()) client->fingerprints.erase(fingerprint_it);
+	if (type == FILENODE && fingerprint_it != client->fingerprints.end()) client->fingerprints.erase(fingerprint_it);
 
 	// delete outshares, including pointers from users for this node
 	for (share_map::iterator it = outshares.begin(); it != outshares.end(); it++) delete it->second;
@@ -331,7 +331,7 @@ void Node::setfingerprint()
 {
 	if (type == FILENODE)
 	{
-		if (client && fingerprint_it != client->fingerprints.end()) client->fingerprints.erase(fingerprint_it);
+		if (fingerprint_it != client->fingerprints.end()) client->fingerprints.erase(fingerprint_it);
 
 		attr_map::iterator it = attrs.map.find('c');
 
@@ -344,7 +344,7 @@ void Node::setfingerprint()
 			mtime = clienttimestamp;
 		}
 
-		if(client) fingerprint_it = client->fingerprints.insert((FileFingerprint*)this);
+		fingerprint_it = client->fingerprints.insert((FileFingerprint*)this);
 	}
 }
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -273,7 +273,7 @@ void Sync::procscanq(int q)
 			// fopen() signals that the failure is potentially transient - do nothing, but request a recheck
 			localpath->resize(localpath->size()-client->fsaccess->localseparator.size()-localname->size());
 			queuescan(RETRY,localpath,localname,l,si->parent,true);
-
+			
 			l = NULL;	// make no changes yet
 		}
 		else if (l)
@@ -303,6 +303,7 @@ void Sync::procscanq(int q)
 			if (l->type == FILENODE) client->app->syncupdate_local_file_addition(this,tmpname.c_str());
 			else client->app->syncupdate_local_folder_addition(this,tmpname.c_str());
 		}
+		
 		client->syncactivity = true;
 	}
 

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -102,7 +102,7 @@ bool WinFileAccess::fopen(string* name, bool read, bool write)
 	if (hFile == INVALID_HANDLE_VALUE)
 	{
 		DWORD e = GetLastError();
-
+		
 		if (e == ERROR_ACCESS_DENIED)
 		{
 			// this could be a directory, try to enumerate...
@@ -116,7 +116,7 @@ bool WinFileAccess::fopen(string* name, bool read, bool write)
 				return true;
 			}
 		}
-
+		
 		retry = WinFileSystemAccess::istransient(e);
 		return false;
 	}
@@ -171,7 +171,7 @@ bool WinFileSystemAccess::istransient(DWORD e)
 bool WinFileSystemAccess::istransientorexists(DWORD e)
 {
 	target_exists = e == ERROR_FILE_EXISTS || e == ERROR_ALREADY_EXISTS;
-
+	
 	return istransient(e);
 }
 
@@ -299,7 +299,7 @@ bool WinFileSystemAccess::renamelocal(string* oldname, string* newname)
 	oldname->resize(oldname->size()-1);
 
 	if (!r) transient_error = istransientorexists(GetLastError());
-
+	
 	return r;
 }
 
@@ -349,13 +349,13 @@ bool WinFileSystemAccess::rubbishlocal(string* name)
 	fileop.hNameMappings = NULL;
 
 	int e = SHFileOperationW(&fileop);
-
+	
 	if (!e) return true;
 
 	transient_error = istransient(e);
-
+	
 	return false;
-
+	
 	// FIXME: fall back to recursive DeleteFile()/RemoveDirectory() if SHFileOperation() fails, e.g. because of excessive path length
 }
 
@@ -366,7 +366,7 @@ bool WinFileSystemAccess::rmdirlocal(string* name)
 	name->resize(name->size()-1);
 
 	if (!r) transient_error = istransient(GetLastError());
-
+	
 	return r;
 }
 


### PR DESCRIPTION
- Tag for transfers working just like the tag in the requests. The client has to call nextreqtag() before starting a transfer and the current tag is added to the Transfer object when it's created.
- Changed the path of one header to build the SDK in Windows.
