### PR TITLE
Tag propagation for account creation. Minor changes in WinHTTPIO and purgenodesusersabortsc()

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -143,7 +143,7 @@ class MEGA_API CommandResumeEphemeralSession : public Command
 public:
     void procresult();
 
-    CommandResumeEphemeralSession(MegaClient*, handle, const byte*);
+    CommandResumeEphemeralSession(MegaClient*, handle, const byte*, int);
 };
 
 class MEGA_API CommandSendSignupLink : public Command

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -68,7 +68,7 @@ public:
 
     // ephemeral session support
     void createephemeral();
-    void resumeephemeral(handle, const byte*);
+    void resumeephemeral(handle, const byte*, int = 0);
 
     // full account confirmation/creation support
     void sendsignuplink(const char*, const char*, const byte*);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1956,11 +1956,11 @@ void CommandCreateEphemeralSession::procresult()
     }
     else
     {
-        client->resumeephemeral(client->json.gethandle(MegaClient::USERHANDLE), pw);
+        client->resumeephemeral(client->json.gethandle(MegaClient::USERHANDLE), pw, tag);
     }
 }
 
-CommandResumeEphemeralSession::CommandResumeEphemeralSession(MegaClient* client, handle cuh, const byte* cpw)
+CommandResumeEphemeralSession::CommandResumeEphemeralSession(MegaClient* client, handle cuh, const byte* cpw, int ctag)
 {
     memcpy(pw, cpw, sizeof pw);
     uh = cuh;
@@ -1968,7 +1968,7 @@ CommandResumeEphemeralSession::CommandResumeEphemeralSession(MegaClient* client,
     cmd("us");
     arg("user", (byte*)&uh, MegaClient::USERHANDLE);
 
-    tag = client->reqtag;
+    tag = ctag;
 }
 
 void CommandResumeEphemeralSession::procresult()

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4343,9 +4343,9 @@ void MegaClient::createephemeral()
     reqs[r].add(new CommandCreateEphemeralSession(this, keybuf, pwbuf, sscbuf));
 }
 
-void MegaClient::resumeephemeral(handle uh, const byte* pw)
+void MegaClient::resumeephemeral(handle uh, const byte* pw, int ctag)
 {
-    reqs[r].add(new CommandResumeEphemeralSession(this, uh, pw));
+    reqs[r].add(new CommandResumeEphemeralSession(this, uh, pw, ctag ? ctag : reqtag));
 }
 
 void MegaClient::sendsignuplink(const char* email, const char* name, const byte* pwhash)
@@ -4502,13 +4502,12 @@ void MegaClient::purgenodesusersabortsc()
 
     syncs.clear();
 
-    todebris.clear();
-
     for (node_map::iterator it = nodes.begin(); it != nodes.end(); it++)
     {
         delete it->second;
     }
 
+    todebris.clear();
     nodes.clear();
 
     for (newshare_list::iterator it = newshares.begin(); it != newshares.end(); it++)

--- a/src/win32/net.cpp
+++ b/src/win32/net.cpp
@@ -167,7 +167,7 @@ VOID CALLBACK WinHttpIO::asynccallback(HINTERNET hInternet, DWORD_PTR dwContext,
             DWORD statusCode = 0;
             DWORD statusCodeSize = sizeof( statusCode );
 
-            if (!WinHttpQueryHeaders(((WinHttpContext*)req->httpiohandle )->hRequest,
+            if (!WinHttpQueryHeaders(httpctx->hRequest,
                                      WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
                                      WINHTTP_HEADER_NAME_BY_INDEX,
                                      &statusCode,
@@ -181,7 +181,7 @@ VOID CALLBACK WinHttpIO::asynccallback(HINTERNET hInternet, DWORD_PTR dwContext,
             {
                 req->httpstatus = statusCode;
 
-                if (!WinHttpQueryDataAvailable(((WinHttpContext*)req->httpiohandle )->hRequest, NULL))
+                if (!WinHttpQueryDataAvailable(httpctx->hRequest, NULL))
                 {
                     httpio->cancel(req);
                     httpio->httpevent();
@@ -290,7 +290,7 @@ void WinHttpIO::post(HttpReq* req, const char* data, unsigned len)
 
             if (httpctx->hRequest)
             {
-                WinHttpSetTimeouts(httpctx->hRequest, 0, 20000, 20000, 1800000);
+                WinHttpSetTimeouts(httpctx->hRequest, 0, 20000, 20000, 300000);
 
                 WinHttpSetStatusCallback(httpctx->hRequest, asynccallback,
                                          WINHTTP_CALLBACK_FLAG_DATA_AVAILABLE


### PR DESCRIPTION
- Propagate tag from CommandCreateEphemeralSession to CommandResumeEphemeralSession
- Clear 'todebris' set after the deletion of nodes because Node destructors access iterators of that set.
- Changed "req->httpiohandle" by "httpctx". As "httpctx" is a parameter of the callback, it's only deleted in the last one, and it's not recycled for different POSTs, it should always be valid.
- Reduced read timeout from 30 min to 5 min to minimize the impact of missing responses.
