### PR TITLE
Fixes for some Clang static analyzer issues

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -52,9 +52,6 @@ public:
     // all users
     user_map users;
 
-    // Cached email to be read while client is logged in
-    string current_email;
-
     // process API requests and HTTP I/O
     void exec();
 

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -132,7 +132,7 @@ void GfxProc::gendimensionsputfa(FileAccess* fa, string* localfilename, handle t
 
             if (jpeg)
             {
-                free(jpeg);
+                delete jpeg;
             }
 
             freebitmap();

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -326,7 +326,6 @@ void MegaClient::init()
     fetchingnodes = false;
     chunkfailed = false;
     noinetds = 0;
-    current_email   = "";
 
     if (syncscanstate)
     {
@@ -1502,7 +1501,7 @@ bool MegaClient::dispatch(direction_t d)
                 : ts->fa->fopen(&nextit->second->localfilename, false, true))
             {
                 handle h = UNDEF;
-                bool hprivate;
+                bool hprivate = true;
 
                 nextit->second->pos = 0;
 
@@ -4416,8 +4415,6 @@ sessiontype_t MegaClient::loggedin()
     {
         return EPHEMERALACCOUNT;
     }
-
-    current_email = u->email;
 
     if (!asymkey.isvalid())
     {

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -67,9 +67,6 @@ Sync::Sync(MegaClient* cclient, string* crootpath, const char* cdebris,
     localroot.init(this, FOLDERNODE, NULL, crootpath);
     localroot.setnode(remotenode);
 
-    // obtain client->current_email
-    client->loggedin();
-
     // state cache table
     char local_id[12];
     FileAccess *fas = client->fsaccess->newfileaccess();
@@ -80,7 +77,9 @@ Sync::Sync(MegaClient* cclient, string* crootpath, const char* cdebris,
     char remote_id[12];
     Base64::btoa((byte *)&remotenode->nodehandle, MegaClient::NODEHANDLE, remote_id);
 
-    dbname = client->current_email + "_" + local_id + remote_id + "v2";
+    User *u = client->finduser(client->me);
+    string email = u ? u->email : "unknown_email";
+    dbname = email + "_" + local_id + remote_id + "v2";
 
     statecachetable = client->dbaccess ? client->dbaccess->open(client->fsaccess, &dbname) : NULL;
     sync_it = client->syncs.insert(client->syncs.end(), this);
@@ -363,15 +362,7 @@ bool Sync::scan(string* localpath, FileAccess* fa)
 	{
 		DirAccess* da;
 		string localname, name;
-		size_t baselen;
 		bool success;
-
-		baselen = localroot.localname.size() + client->fsaccess->localseparator.size();
-
-		if (baselen > localpath->size())
-		{
-			baselen = localpath->size();
-		}
 
 		da = client->fsaccess->newdiraccess();
 


### PR DESCRIPTION
gfx.cpp:135 - Changed free by delete
sync.cpp 373 - Removed baselen because it's never used
megaclient.cpp 4420 - Removed current_email. Now it's got when needed
(Sync() constructor)
megaclient.cpp 1555  - Initialize hprivate to 'true'. If hprivate doesn't get a value, 'h' will be UNDEF and the request will fail anyway.
