### PR TITLE
Fix node <-> localnode associations

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5118,12 +5118,9 @@ bool MegaClient::syncdown(LocalNode* l, string* localpath, bool rubbish)
             }
             else if (ll->type == FILENODE)
             {
-                if (!ll->node ||
-                    (ll->node != rit->second && rit->second->mtime > ll->node->mtime))
-                {
-                    ll->setnode(rit->second);
+                if (ll->node != rit->second)
                     ll->sync->statecacheadd(ll);
-                }
+                ll->setnode(rit->second);
 
                 // file exists on both sides - do not overwrite if local version newer or same
                 if (ll->mtime > rit->second->mtime)
@@ -5394,12 +5391,9 @@ void MegaClient::syncup(LocalNode* l, dstime* nds)
                     continue;
                 }
 
-                if (!ll->node ||
-                    (ll->node != rit->second && rit->second->mtime > ll->node->mtime))
-                {
-                    ll->setnode(rit->second);
+                if (ll->node != rit->second)
                     ll->sync->statecacheadd(ll);
-                }
+                ll->setnode(rit->second);
 
                 if (ll->size == rit->second->size)
                 {


### PR DESCRIPTION
This commit fixes problems using several instances of MEGAsync at once.
When passive clients receive an updated file, localnode->node becomes NULL to trigger the download of the new version. When the dowload finishes, that connection was not restored due to the 'if' changed in this commit inside syncdown().
Now, the 'if' only serves to avoid the update of the local cache if it isn't needed. I think that it's not needed to avoid calls to setnode() there because duplicated nodes are already filtered some lines before using addchild().

Anyway, I think that this needs a review to ensure that it won't cause undesired effects.
