### PR TITLE
Make EdDSA work as documented

### DIFF
--- a/include/mega/crypto/sodium.h
+++ b/include/mega/crypto/sodium.h
@@ -34,8 +34,6 @@ using namespace std;
 class MEGA_API EdDSA
 {
 public:
-    static CryptoPP::AutoSeededRandomPool rng;
-
     EdDSA() : keySeed(NULL) {}
 
     unsigned char* keySeed;

--- a/include/mega/crypto/sodium.h
+++ b/include/mega/crypto/sodium.h
@@ -60,7 +60,7 @@ public:
      * @return Number of bytes for signed message (msg length + signature),
      *     0 on failure.
      */
-    int sign(unsigned char* msg, unsigned long long msglen, char* sig);
+    int sign(unsigned char* msg, unsigned long long msglen, unsigned char* sig);
 
     /**
      * @brief Verifies the signature of a message.

--- a/src/crypto/sodium.cpp
+++ b/src/crypto/sodium.cpp
@@ -75,7 +75,7 @@ int EdDSA::verify(const unsigned char* msg, unsigned long long msglen,
 int EdDSA::genKeySeed(unsigned char* privKey) {
     // Make space for a new key seed (if not present).
     if (!this->keySeed) {
-        this->keySeed = (unsigned char*)malloc(crypto_sign_SEEDBYTES);
+        this->keySeed = (unsigned char*)sodium_malloc(crypto_sign_SEEDBYTES);
         if (this->keySeed == NULL) {
             // Something went wrong allocating the memory.
             return(0);

--- a/src/crypto/sodium.cpp
+++ b/src/crypto/sodium.cpp
@@ -94,19 +94,13 @@ int EdDSA::genKeySeed(unsigned char* privKey) {
 
 // Derives the Ed25519 public key from the stored private key seed.
 int EdDSA::publicKey(unsigned char* pubKey) {
-    unsigned char* privKey = (unsigned char*)malloc(crypto_sign_SECRETKEYBYTES);
-    if (privKey == NULL) {
-        // Something went wrong allocating the memory.
-        return(0);
-    }
+    unsigned char privKey[crypto_sign_SECRETKEYBYTES];
     int check = crypto_sign_seed_keypair(pubKey, privKey,
                                          (const unsigned char*)this->keySeed);
+    sodium_memzero(privKey, sizeof privKey);
     if (check != 0) {
-        // Something went wrong deriving keys.
-        free(privKey);
         return(0);
     }
-    free(privKey);
     return(1);
 }
 

--- a/src/crypto/sodium.cpp
+++ b/src/crypto/sodium.cpp
@@ -38,74 +38,31 @@ void EdDSA::setKeySeed(const char* data) {
 
 
 // Computes the signature of a message.
-int EdDSA::sign(unsigned char* msg, unsigned long long msglen, char* sig) {
-    unsigned char* pubKey = (unsigned char*)malloc(crypto_sign_PUBLICKEYBYTES);
-    if (pubKey == NULL) {
-        // Something went wrong allocating the memory.
-        return(0);
-    }
-    unsigned char* privKey = (unsigned char*)malloc(crypto_sign_SECRETKEYBYTES);
-    if (privKey == NULL) {
-        // Something went wrong allocating the memory.
-        free(pubKey);
-        return(0);
-    }
-    int check = 0;
+int EdDSA::sign(unsigned char* msg, unsigned long long msglen, unsigned char* sig) {
+    unsigned char pubKey[crypto_sign_PUBLICKEYBYTES];
+    unsigned char privKey[crypto_sign_SECRETKEYBYTES];
+    int check;
+
     check = crypto_sign_seed_keypair(pubKey, privKey,
                                      (const unsigned char*)this->keySeed);
     if (check != 0) {
         // Something went wrong deriving keys.
         return(0);
     }
-    unsigned long long bufferlen = 0;
-    unsigned char* sigbuffer = (unsigned char*)malloc(msglen + crypto_sign_BYTES);
-    if (sigbuffer == NULL) {
-        // Something went wrong allocating the memory.
-        free(pubKey);
-        free(privKey);
-        return(0);
-    }
-    check = crypto_sign(sigbuffer, &bufferlen, (const unsigned char*)msg, msglen,
-                        (const unsigned char*)privKey);
+    check = crypto_sign_detached(sig, NULL, msg, msglen, privKey);
     if (check != 0) {
         // Something went wrong signing the message.
-        free(sigbuffer);
-        free(pubKey);
-        free(privKey);
         return(0);
     }
-    free(sigbuffer);
-    free(pubKey);
-    free(privKey);
-    return(bufferlen);
+    return(crypto_sign_BYTES + msglen);
 }
 
 
 // Verifies the signature of a message.
 int EdDSA::verify(const unsigned char* msg, unsigned long long msglen,
                   const unsigned char* sig, const unsigned char* pubKey) {
-    unsigned char* msgbuffer = (unsigned char*)malloc(msglen + crypto_sign_BYTES);
-    if (msgbuffer == NULL) {
-        // Something went wrong allocating the memory.
-        return(0);
-    }
-    unsigned char* signedmsg = (unsigned char*)malloc(msglen + crypto_sign_BYTES);
-    if (signedmsg == NULL) {
-        // Something went wrong allocating the memory.
-        free(msgbuffer);
-        return(0);
-    }
-
-    // Assemble signed message in one array.
-    memcpy(signedmsg, msg, msglen);
-    memcpy(signedmsg + msglen, sig, crypto_sign_BYTES);
-
-    unsigned long long bufferlen = 0;
-    int result = crypto_sign_open(msgbuffer, &bufferlen,
-                                  signedmsg, msglen + crypto_sign_BYTES, pubKey);
-    free(msgbuffer);
-    free(signedmsg);
-    if (result) {
+    int result = crypto_sign_verify_detached(sig, msg, msglen, pubKey);
+    if (result == 0) {
         return(1);
     } else {
         // crypto_sign_open() returns -1 on failure.

--- a/src/crypto/sodium.cpp
+++ b/src/crypto/sodium.cpp
@@ -25,8 +25,6 @@
 #ifdef USE_SODIUM
 namespace mega {
 
-CryptoPP::AutoSeededRandomPool EdDSA::rng;
-
 // Initialise libsodium crypto system.
 void EdDSA::init() {
     sodium_init();
@@ -127,7 +125,7 @@ int EdDSA::genKeySeed(unsigned char* privKey) {
         }
     }
     // Now make the new key seed.
-    this->rng.GenerateBlock(this->keySeed, crypto_sign_SEEDBYTES);
+    randombytes_buf(this->keySeed, crypto_sign_SEEDBYTES);
     // Copy it to privKey before returning.
     if (privKey)
     {


### PR DESCRIPTION
Hi,

I'm a bit confused by the `EdDSA` class. It doesn't seem to do what the headers suggest.

For example, `EdDSA::sign()` computes a signature but doesn't store it anywhere.
Here are a few changes to simplify the code and make it work as advertised.