### PR TITLE
Don't call isgfx in gendimensionsputfa nor readbitmap

### DIFF
--- a/include/mega/gfx/GfxProcCG.h
+++ b/include/mega/gfx/GfxProcCG.h
@@ -22,7 +22,7 @@ class MEGA_API GfxProcCG : public mega::GfxProc
     CGImageRef createThumbnailWithMaxSize(int size);
     int maxSizeForThumbnail(const int rw, const int rh);
 private: // mega::GfxProc implementations
-    bool isgfx(mega::string* name);
+    const char* supportedformats();
     bool readbitmap(mega::FileAccess*, mega::string*, int);
     bool resizebitmap(int, int, mega::string*);
     void freebitmap();

--- a/src/gfx/GfxProcCG.cpp
+++ b/src/gfx/GfxProcCG.cpp
@@ -37,7 +37,7 @@ GfxProcCG::~GfxProcCG() {
     CFRelease(imageParams);
 }
 
-const char* GfxProcFreeImage::supportedformats() {
+const char* GfxProcCG::supportedformats() {
     return ".jpg.png.bmp.tif.tiff.jpeg.gif.pdf.";
 }
 

--- a/src/gfx/GfxProcCG.cpp
+++ b/src/gfx/GfxProcCG.cpp
@@ -37,24 +37,11 @@ GfxProcCG::~GfxProcCG() {
     CFRelease(imageParams);
 }
 
-bool GfxProcCG::isgfx(string* name) {
-    size_t p = name->find_last_of('.');
-
-    if (!(p + 1)) {
-        return false;
-    }
-
-    string ext(*name,p);
-    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-    return ext == ".png" || ext == ".jpg" || ext == ".tif" || ext == ".tiff"
-           || ext == ".gif" || ext == ".bmp" || ext == ".pdf";
+const char* GfxProcFreeImage::supportedformats() {
+    return ".jpg.png.bmp.tif.tiff.jpeg.gif.pdf.";
 }
 
 bool GfxProcCG::readbitmap(FileAccess* fa, string* name, int size) {
-    if (!isgfx(name)) {
-        return false;
-    }
-
     CGDataProviderRef dataProvider = CGDataProviderCreateWithFilename(name->c_str());
     if (!dataProvider) {
         return false;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1772,8 +1772,11 @@ bool MegaClient::dispatch(direction_t d)
                     {
                         nextit->second->uploadhandle = getuploadhandle();
 
-                        // we want all imagery to be safely tucked away before completing the upload, so we bump minfa
-                        nextit->second->minfa += gfx->gendimensionsputfa(ts->fa, &nextit->second->localfilename, nextit->second->uploadhandle, &nextit->second->key);
+                        if (gfx->isgfx(&nextit->second->localfilename))
+                        {
+                            // we want all imagery to be safely tucked away before completing the upload, so we bump minfa
+                            nextit->second->minfa += gfx->gendimensionsputfa(ts->fa, &nextit->second->localfilename, nextit->second->uploadhandle, &nextit->second->key);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
Because the file name could be of a temporary file (invalid extension)
Instead of using isgfx in those functions, it's called with the correct
name just before