### PR TITLE
Fixes for the management of inshares without a sharekey

### DIFF
--- a/include/mega/treeproc.h
+++ b/include/mega/treeproc.h
@@ -43,6 +43,12 @@ public:
     void proc(MegaClient*, Node*);
 };
 
+class MEGA_API TreeProcApplyKey : public TreeProc
+{
+public:
+    void proc(MegaClient*, Node*);
+};
+
 class MEGA_API TreeProcListOutShares : public TreeProc
 {
 public:

--- a/src/treeproc.cpp
+++ b/src/treeproc.cpp
@@ -77,6 +77,19 @@ void TreeProcDel::proc(MegaClient* client, Node* n)
     client->notifynode(n);
 }
 
+void TreeProcApplyKey::proc(MegaClient *client, Node *n)
+{
+    if (n->attrstring)
+    {
+        n->applykey();
+        if (!n->attrstring)
+        {
+            n->changed.attrs = true;
+            client->notifynode(n);
+        }
+    }
+}
+
 #ifdef ENABLE_SYNC
 // stop sync get
 void TreeProcDelSyncGet::proc(MegaClient*, Node* n)


### PR DESCRIPTION
With these changes, the SDK will receive those inshares as NO_KEY
Both cases has been fixed, when the inshare without a key is received in
an action packet, and when it's received in a full reload.
When the key is restored, it's applied and all decrypted nodes are saved
to the database.

If the app is closed when before the reception of the key, the inshare will still 
be lost because NO_KEY nodes are not saved to the local cache yet.