### PR TITLE
Py packaging

### DIFF
--- a/bindings/java/.gitignore
+++ b/bindings/java/.gitignore
@@ -28,3 +28,6 @@ nz/mega/sdk/MegaUser.java
 nz/mega/sdk/mega.java
 nz/mega/sdk/megaJNI.java
 nz/mega/sdk/MegaUserList.java
+nz/mega/sdk/MegaContactRequest.java
+nz/mega/sdk/MegaContactRequestList.java
+nz/mega/sdk/SWIGTYPE_p_std__string.java

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -2,3 +2,6 @@
 mega.py
 megaapi_wrap.cpp
 megaapi_wrap.h
+build/
+dist/
+megasdk.egg-info/

--- a/bindings/python/DESCRIPTION.rst
+++ b/bindings/python/DESCRIPTION.rst
@@ -1,0 +1,8 @@
+Mega SDK Python Bindings
+========================
+
+This package contains the Python bindings to the Mega SDK for interfacing the
+Mega cloud storage platform.
+
+Please see ``README.md`` for further information on how to build and install
+the Python bindings package.

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include DESCRIPTION.rst

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -49,6 +49,12 @@ the Mega API from Python.
 
     python setup.py bdist_wheel
 
+The package created will be located in folder `dist/`.
+
+**Note:** You may need to install the `wheel` package for Python, if your Python
+is not by default equipped for it, yet. This could be the (Linux) `python-wheel`
+distribution package, or by using e. g. `pip install wheel`.
+
 
 Install Python Distribution Package
 -----------------------------------

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,67 @@
+Build/Install Python Bindings
+=============================
+
+These things need to be done to build and install Python bindings usable in a
+normal fashion:
+
+* The Mega SDK needs to be built with the Python bindings.
+
+* A Python distribution package (a "Wheel") needs to be built, which then can
+  be installed.
+
+* Install the Python package.
+
+The instructions given here are strictly only valid for Linux. The may need
+adaptation for other platforms.
+
+
+Prerequisites
+-------------
+
+To build the Python bindings, you will need to have some things installed on
+your system:
+
+* SWIG (to generate the bindings automatically from interface code)
+* A suitable C++ compiler tool chain
+* Autotools
+* A Python runtime along with the development headers to compile against
+
+
+Build Python Bindings
+---------------------
+
+* Configure the project for Python:
+
+    ./autogen.sh
+    ./configure --disable-silent-rules --enable-python --disable-examples
+
+* Build the shared libraries and packages:
+
+    make
+
+
+Build Python Distribution Package
+---------------------------------
+
+The Python package to be built will be a platform specific "Wheel" package,
+as it contains all native libraries (shared libraries, DLLs) required to use
+the Mega API from Python.
+
+    python setup.py bdist_wheel
+
+
+Install Python Distribution Package
+-----------------------------------
+
+The Wheel package should then be easy to install using `pip` in the common
+fashion, e. g.
+
+    pip install megasdk-2.6.0-py2.py3-none-any.whl
+
+
+Test Installed Package
+----------------------
+
+    import mega
+    api = mega.MegaApi('test')
+    print(dir(api)))

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -1,0 +1,2 @@
+# Get rid of the funny nested name space.
+from mega import *

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -9,29 +9,15 @@ import re
 
 from setuptools import setup
 
-# Utility function to read the README file.
-# Used for the long_description.  It's nice, because now 1) we have a
-# top level README file and 2) it's easier to type in the README file
-# than to put a raw string in below ...
 
 def read(fname):
+    """
+    Utility function to read the README file.
+    Used for the long_description.  It's nice, because now
+    1) we have a top level README file and
+    2) it's easier to type in the README file than to put a raw string in below ...
+    """
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-def make_symlink(src, dst):
-    try:
-        os.symlink(src, dst)
-    except OSError as e:
-        # Let's not complain if it's there already.
-        if e.strerror != 'File exists':
-            raise e
-
-def remove_file(fname):
-    try:
-        os.remove(fname)
-    except OSError as e:
-        # Let's not complain if it's not there.
-        if e.strerror != 'No such file or directory':
-            raise e
 
 def get_version():
     """
@@ -55,10 +41,21 @@ def get_version():
         release = 'raw_development'
     return version, release
 
-# solutions?
-# * put some import magic into the __init__.py
-# * fix it up in setup.py (preferable)
+def make_symlink(src, dst):
+    """Makes a symlink, ignores errors if it's there already."""
+    try:
+        os.symlink(src, dst)
+    except OSError as e:
+        if e.strerror != 'File exists':
+            raise e
 
+def remove_file(fname):
+    """Removes a file/link, ignores errors if it's not there any more."""
+    try:
+        os.remove(fname)
+    except OSError as e:
+        if e.strerror != 'No such file or directory':
+            raise e
 
 # Put native library modules into a "good place" for the package.
 make_symlink('../../src/.libs/libmega.so', 'libmega.so')

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,0 +1,113 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This setup is loosely following the instructions adapted from
+https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
+"""
+import os
+import re
+
+from setuptools import setup
+
+# Utility function to read the README file.
+# Used for the long_description.  It's nice, because now 1) we have a
+# top level README file and 2) it's easier to type in the README file
+# than to put a raw string in below ...
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+def make_symlink(src, dst):
+    try:
+        os.symlink(src, dst)
+    except OSError as e:
+        # Let's not complain if it's there already.
+        if e.strerror != 'File exists':
+            raise e
+
+def remove_file(fname):
+    try:
+        os.remove(fname)
+    except OSError as e:
+        # Let's not complain if it's not there.
+        if e.strerror != 'No such file or directory':
+            raise e
+
+def get_version():
+    """
+    Grabs and returns the version and release numbers from autotools.
+    """
+    configure_ac = open(os.path.join('..', '..', 'configure.ac')).read()
+    major = re.search('m4_define\(\[mega_major_version\], \[([0-9]+)\]',
+                      configure_ac)
+    minor = re.search('m4_define\(\[mega_minor_version\], \[([0-9]+)\]',
+                      configure_ac)
+    micro = re.search('m4_define\(\[mega_micro_version\], \[(.+?)\]',
+                      configure_ac)
+    if major:
+        major, minor, micro = major.group(1), minor.group(1), micro.group(1)
+        version = '.'.join([major, minor])
+    else:
+        version = 'raw_development'
+    if micro:
+        release = '.'.join([major, minor, micro])
+    else:
+        release = 'raw_development'
+    return version, release
+
+# solutions?
+# * put some import magic into the __init__.py
+# * fix it up in setup.py (preferable)
+
+
+# Put native library modules into a "good place" for the package.
+make_symlink('../../src/.libs/libmega.so', 'libmega.so')
+make_symlink('.libs/_mega.so', '_mega.so')
+
+# Create a dummy __init__.py if not present.
+_init_file = '__init__.py'
+_init_file_created = False
+if not os.path.exists(_init_file):
+    with open(_init_file, 'wb') as fd:
+        _init_file_created = True
+
+setup(
+    name='megasdk',
+    version=get_version()[1],
+    description='Python bindings to the Mega file storage SDK.',
+    long_description=read('DESCRIPTION.rst'),
+    url='http://github.com/meganz/sdk/',
+    license='Simplified BSD',
+    author='Guy Kloss',
+    author_email='gk@mega.co.nz',
+    packages=['mega'],
+    package_dir={'mega': '.'},
+    package_data = {
+        'mega': ['libmega.so', '_mega.so'],
+    },
+    exclude_package_data = {'': ['test_libmega.py']},
+    include_package_data=True,
+    keywords=['MEGA', 'privacy', 'cloud', 'storage', 'API'],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+)
+
+# Clean up some temporary stuff.
+remove_file('libmega.so')
+remove_file('_mega.so')
+if _init_file_created:
+    remove_file(_init_file)

--- a/bindings/python/test_libmega.py
+++ b/bindings/python/test_libmega.py
@@ -23,7 +23,8 @@ import sys
 import os
 import pprint
 
-_wrapper_dir = os.path.join(os.getcwd(), '..', '..', 'bindings', 'python')
+_here = os.path.abspath(os.path.dirname(__file__))
+_wrapper_dir = os.path.join(_here, '..', '..', 'bindings', 'python')
 _libs_dir = os.path.join(_wrapper_dir, '.libs')
 _shared_lib = os.path.join(_libs_dir, '_mega.so')
 if os.path.isdir(_wrapper_dir) and os.path.isfile(_shared_lib):

--- a/bindings/python/test_libmega.py
+++ b/bindings/python/test_libmega.py
@@ -21,6 +21,7 @@ __author__ = 'Paul Ionkin <pi@mega.co.nz>'
 
 import sys
 import os
+import pprint
 
 _wrapper_dir = os.path.join(os.getcwd(), '..', '..', 'bindings', 'python')
 _libs_dir = os.path.join(_wrapper_dir, '.libs')
@@ -34,8 +35,7 @@ import mega
 # TODO: extend test example
 def main():
     api = mega.MegaApi("test")
-    print api
-
+    pprint.pprint(dir(api))
 
 if __name__ == '__main__':
     main()

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,10 +1,19 @@
 # Example app using Python
 
+There are two basic examples contained here. A Mega Command Line Interface
+client (`megacli`), and a simple CRUD example (create, read, updaet, delete
+a file).
+
+To build the requiered (Python) modules, see the `README.md` in
+`bindings/python/`.
+
+## Mega Command Line Interface
+
 This is a console app that uses the Python bindings of the SDK.
 
 It shows a shell like the one in the `megacli` example that allows to:
 
-- Log in to a MEGA account (`login`, `logout`) 
+- Log in to a MEGA account (`login`, `logout`)
 - Browse folders (`cd`, `ls`, `pwd`)
 - Create new folders (`mkdir`)
 - Show the inbound shared folders (`mount`)
@@ -14,18 +23,31 @@ It shows a shell like the one in the `megacli` example that allows to:
 - Change the password of the account (`passwd`)
 - Get info about the account (`whoami`)
 
-## How to build and run the project:
+Prerequisite:
 
-To build and run the project, follow these steps:
+- Installed Mega SDK with Python bindings and the Python module `cmd` (or `cmd2`).
 
-1. Install SWIG in your system (it's required to generate Python
-   bindings)
-2. Build the SDK including the option `--enable-python` in the
-   `./configure` step
-3. Install the required Python dependency `cmd` (or `cmd2`).
-4. Run the `megacli.py` file in this folder
+To start the client just run `megacli.py` from this folder.
 
-If you want to create your own Python app. You can use the `MegaApi`
+
+## Mega CRUD Example
+
+Just run `crud_example.py` or `crud_example2.py` from this folder.
+
+To avoid typing in credentials, you may create a `credentials.json` file with
+the following content:
+
+```
+{
+    "user": "your.email@provider.org",
+    "password": "your_supersecret_password"
+}
+```
+
+
+## To Keep In Mind
+
+If you want to create your own Python app, you can use the `MegaApi`
 object. However, these bindings are still a work in progress and have
 some inconveniences:
 

--- a/examples/python/crud_example.py
+++ b/examples/python/crud_example.py
@@ -26,13 +26,6 @@ import time
 import json
 import getpass
 
-_wrapper_dir = os.path.join(os.getcwd(), '..', '..', 'bindings', 'python')
-_libs_dir = os.path.join(_wrapper_dir, '.libs')
-_shared_lib = os.path.join(_libs_dir, '_mega.so')
-if os.path.isdir(_wrapper_dir) and os.path.isfile(_shared_lib):
-    sys.path.insert(0, _wrapper_dir)  # mega.py
-    sys.path.insert(0, _libs_dir)     # _mega.so
-
 from mega import (MegaApi, MegaListener, MegaError, MegaRequest, MegaNode)
 
 APP_KEY = 'ox8xnQZL'

--- a/examples/python/crud_example2.py
+++ b/examples/python/crud_example2.py
@@ -17,18 +17,6 @@
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-"""
-* use api.dumpSession() to get session info
-
-* to resume session on a later invocation use api.fastLogin()
-
-* also possible to do an api.locallogout()
-  (e. g. to "juggle" multiple accounts)
-
-"""
-
-
-
 __author__ = 'Guy Kloss <gk@mega.co.nz>'
 
 import sys
@@ -38,13 +26,6 @@ import time
 import threading
 import json
 import getpass
-
-_wrapper_dir = os.path.join(os.getcwd(), '..', '..', 'bindings', 'python')
-_libs_dir = os.path.join(_wrapper_dir, '.libs')
-_shared_lib = os.path.join(_libs_dir, '_mega.so')
-if os.path.isdir(_wrapper_dir) and os.path.isfile(_shared_lib):
-    sys.path.insert(0, _wrapper_dir)  # mega.py
-    sys.path.insert(0, _libs_dir)     # _mega.so
 
 from mega import (MegaApi, MegaListener, MegaError, MegaRequest, MegaNode)
 

--- a/examples/python/crud_example2.py
+++ b/examples/python/crud_example2.py
@@ -17,6 +17,18 @@
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+"""
+* use api.dumpSession() to get session info
+
+* to resume session on a later invocation use api.fastLogin()
+
+* also possible to do an api.locallogout()
+  (e. g. to "juggle" multiple accounts)
+
+"""
+
+
+
 __author__ = 'Guy Kloss <gk@mega.co.nz>'
 
 import sys

--- a/examples/python/megacli.py
+++ b/examples/python/megacli.py
@@ -25,13 +25,6 @@ import cmd
 import logging
 import time
 
-_wrapper_dir = os.path.join(os.getcwd(), '..', '..', 'bindings', 'python')
-_libs_dir = os.path.join(_wrapper_dir, '.libs')
-_shared_lib = os.path.join(_libs_dir, '_mega.so')
-if os.path.isdir(_wrapper_dir) and os.path.isfile(_shared_lib):
-    sys.path.insert(0, _wrapper_dir)  # mega.py
-    sys.path.insert(0, _libs_dir)     # _mega.so
-
 from mega import (MegaApi, MegaListener, MegaError, MegaRequest,
                   MegaUser, MegaNode)
 


### PR DESCRIPTION
Initial Python packaging to a "wheel" format, which may include binary libraries. Examples and documentation are adapted to use packaged versions.

**Note:** Currently only works on Linux (but previous examples did so as well due to hard wired paths to `*.so` files)