### PR TITLE
Lower logging level - mergenewshares

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -325,7 +325,10 @@ void MegaClient::mergenewshare(NewShare *s, bool notify)
                 }
                 else
                 {
-                    LOG_err << "Incomplete outshare info";
+                    LOG_debug << "Merging share without peer information.";
+                    // Outgoing shares received during fetchnodes are merged in two steps:
+                    // 1. From readok(), a NewShare is created with the 'sharekey'
+                    // 2. From readoutshares(), a NewShare is created with the 'peer' information
                 }
             }
             else


### PR DESCRIPTION
The specified log is not really an error, but a normal situation. A new
outgoing share needs two rounds of mergenewshares(). During the first
one, the 'sharekey' is set. The second one creates the Share itself and
adds it to the Node.