### PR TITLE
Megaapi doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/contrib/QtCreator/megacli.creator.user
 # Compiled Object files
 *.slo
 *.lo

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -743,7 +743,7 @@ static DelegateMEGALogerListener *externalLogger = new DelegateMEGALogerListener
 }
 
 - (BOOL)areTransferPausedForDirection:(NSInteger)direction {
-    return self.megaApi->areTansfersPaused((int)direction);
+    return self.megaApi->areTransfersPaused((int)direction);
 }
 
 - (void)setUploadLimitWithBpsLimit:(NSInteger)bpsLimit {

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -4399,6 +4399,9 @@ class MegaApi
          * - MegaRequest::getText - Returns the text of the invitation
          * - MegaRequest::getNumber - Returns the action
          *
+         * Sending a reminder within a two week period since you started or your last reminder will
+         * fail the API returning the error code MegaError::API_EACCESS.
+         *
          * @param email Email of the new contact
          * @param message Message for the user (can be NULL)
          * @param action Action for this contact request. Valid values are:
@@ -4420,7 +4423,7 @@ class MegaApi
          *
          * The associated request type with this request is MegaRequest::TYPE_REPLY_CONTACT_REQUEST
          * Valid data in the MegaRequest object received on callbacks:
-         * - MegaRequest::getNodeHandle - Returns the handle of the contact request
+         * - MegaRequest::getHandle - Returns the handle of the contact request
          * - MegaRequest::getNumber - Returns the action
          *
          * @param listener MegaRequestListener to track this request
@@ -4672,7 +4675,7 @@ class MegaApi
          *
          * @return true if transfers on that direction are paused, false otherwise
          */
-        bool areTansfersPaused(int direction);
+        bool areTransfersPaused(int direction);
 
         /**
          * @brief Set the upload speed limit

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -621,7 +621,7 @@ class MegaNode
          * - MegaNode::CHANGE_TYPE_INSHARE         = 0x20
          * The node is a new or modified inshare
          *
-         * - MegaNode:: CHANGE_TYPE_OUTSHARE       = 0x40
+         * - MegaNode::CHANGE_TYPE_OUTSHARE       = 0x40
          * The node is a new or modified outshare
          *
          * - MegaNode::CHANGE_TYPE_PARENT          = 0x80
@@ -796,7 +796,7 @@ class MegaUser
 };
 
 /**
- * @brief Represents the outbound sharing of a folder with an user in MEGA
+ * @brief Represents the outbound sharing of a folder with a user in MEGA
  *
  * It allows to get all data related to the sharing. You can start sharing a folder with
  * a contact or cancel an existing sharing using MegaApi::share. A public link of a folder
@@ -1920,7 +1920,7 @@ public:
     virtual char* getSourceMessage() const;
 
     /**
-     * @brief Returns the email of the recipient or NULL if the current account of is the recipient
+     * @brief Returns the email of the recipient or NULL if the current account is the recipient
      * @return Email of the recipient or NULL if the request is for us
      */
     virtual char* getTargetEmail() const;
@@ -3828,7 +3828,7 @@ class MegaApi
          * To share a folder with an user, set the desired access level in the level parameter. If you
          * want to stop sharing a folder use the access level MegaShare::ACCESS_UNKNOWN
          *
-         * The associated request type with this request is MegaRequest::TYPE_COPY
+         * The associated request type with this request is MegaRequest::TYPE_SHARE
          * Valid data in the MegaRequest object received on callbacks:
          * - MegaRequest::getNodeHandle - Returns the handle of the folder to share
          * - MegaRequest::getEmail - Returns the email of the user that receives the shared folder
@@ -5390,15 +5390,38 @@ class MegaApi
         MegaNodeList *getInShares();
 
         /**
-         * @brief Check if a MegaNode is being shared
+         * @brief Check if a MegaNode is being shared by/with your own user
          *
-         * For nodes that are being shared, you can get a a list of MegaShare
-         * objects using MegaApi::getOutShares
+         * For nodes that are being shared, you can get a list of MegaShare
+         * objects using MegaApi::getOutShares, or a list of MegaNode objects
+         * using MegaApi::getInShares
          *
          * @param node Node to check
          * @return true is the MegaNode is being shared, otherwise false
          */
         bool isShared(MegaNode *node);
+
+        /**
+         * @brief Check if a MegaNode is being shared with other users
+         *
+         * For nodes that are being shared, you can get a list of MegaShare
+         * objects using MegaApi::getOutShares
+         *
+         * @param node Node to check
+         * @return true is the MegaNode is being shared, otherwise false
+         */
+        bool isOutShare(MegaNode *node);
+
+        /**
+         * @brief Check if a MegaNode belong to another User, but it is shared with you
+         *
+         * For nodes that are being shared, you can get a list of MegaNode
+         * objects using MegaApi::getInShares
+         *
+         * @param node Node to check
+         * @return true is the MegaNode is being shared, otherwise false
+         */
+        bool isInShare(MegaNode *node);
 
         /**
          * @brief Get a list with all active outbound sharings

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1067,6 +1067,8 @@ class MegaApiImpl : public MegaApp
         MegaNodeList *getInShares(MegaUser* user);
         MegaNodeList *getInShares();
         bool isShared(MegaNode *node);
+        bool isOutShare(MegaNode *node);
+        bool isInShare(MegaNode *node);
         MegaShareList *getOutShares();
         MegaShareList *getOutShares(MegaNode *node);
         MegaShareList *getPendingOutShares();

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1006,7 +1006,7 @@ class MegaApiImpl : public MegaApp
         void cancelTransferByTag(int transferTag, MegaRequestListener *listener = NULL);
         void cancelTransfers(int direction, MegaRequestListener *listener=NULL);
         void pauseTransfers(bool pause, int direction, MegaRequestListener* listener=NULL);
-        bool areTansfersPaused(int direction);
+        bool areTransfersPaused(int direction);
         void setUploadLimit(int bpslimit);
         void setDownloadMethod(int method);
         void setUploadMethod(int method);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1573,6 +1573,16 @@ bool MegaApi::isShared(MegaNode *node)
     return pImpl->isShared(node);
 }
 
+bool MegaApi::isOutShare(MegaNode *node)
+{
+    return pImpl->isOutShare(node);
+}
+
+bool MegaApi::isInShare(MegaNode *node)
+{
+    return pImpl->isInShare(node);
+}
+
 MegaShareList *MegaApi::getOutShares()
 {
     return pImpl->getOutShares();

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1317,9 +1317,9 @@ void MegaApi::pauseTransfers(bool pause, int direction, MegaRequestListener *lis
     pImpl->pauseTransfers(pause, direction, listener);
 }
 
-bool MegaApi::areTansfersPaused(int direction)
+bool MegaApi::areTransfersPaused(int direction)
 {
-    return pImpl->areTansfersPaused(direction);
+    return pImpl->areTransfersPaused(direction);
 }
 
 //-1 -> AUTO, 0 -> NONE, >0 -> b/s

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -3968,10 +3968,46 @@ bool MegaApiImpl::isShared(MegaNode *megaNode)
 		return false;
 	}
 
-    bool result = (node->outshares != NULL);
+    bool result = (node->outshares != NULL) || ((node->inshare != NULL) && !node->parent);
 	sdkMutex.unlock();
 
 	return result;
+}
+
+bool MegaApiImpl::isOutShare(MegaNode *megaNode)
+{
+    if(!megaNode) return false;
+
+    sdkMutex.lock();
+    Node *node = client->nodebyhandle(megaNode->getHandle());
+    if(!node)
+    {
+        sdkMutex.unlock();
+        return false;
+    }
+
+    bool result = (node->outshares != NULL);
+    sdkMutex.unlock();
+
+    return result;
+}
+
+bool MegaApiImpl::isInShare(MegaNode *megaNode)
+{
+    if(!megaNode) return false;
+
+    sdkMutex.lock();
+    Node *node = client->nodebyhandle(megaNode->getHandle());
+    if(!node)
+    {
+        sdkMutex.unlock();
+        return false;
+    }
+
+    bool result = (node->inshare != NULL) && !node->parent;
+    sdkMutex.unlock();
+
+    return result;
 }
 
 MegaShareList *MegaApiImpl::getOutShares()

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -3200,7 +3200,7 @@ void MegaApiImpl::pauseTransfers(bool pause, int direction, MegaRequestListener*
     waiter->notify();
 }
 
-bool MegaApiImpl::areTansfersPaused(int direction)
+bool MegaApiImpl::areTransfersPaused(int direction)
 {
     if(direction != MegaTransfer::TYPE_DOWNLOAD && direction != MegaTransfer::TYPE_UPLOAD)
     {


### PR DESCRIPTION
Auxiliar methods to check if a node is an incoming/outgoing share

Prototype changed: `areTansfersPaused()` --> `areTransfersPaused()`

Minor documentation fixes