### PR TITLE
Fix invalid fingerprints after two downloads

### DIFF
--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -89,6 +89,9 @@ struct MEGA_API Transfer : public FileFingerprint
     
     // execute completion
     void completefiles();
+
+    // previous wrong fingerprint
+    FileFingerprint badfp;
    
     Transfer(MegaClient*, direction_t);
     virtual ~Transfer();

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -178,6 +178,11 @@ void Transfer::complete()
             }
         }
 
+        if (fingerprint.isvalid && fixfingerprint)
+        {
+            (*(FileFingerprint*)this) = fingerprint;
+        }
+
         if (missingattr)
         {
             // FIXME: do this while file is still open

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -127,6 +127,7 @@ void Transfer::complete()
         FileAccess* fa = client->fsaccess->newfileaccess();
         FileFingerprint fingerprint;
         Node* n;
+        bool fixfingerprint = false;
 
         if (fa->fopen(&localfilename, true, false))
         {
@@ -134,9 +135,17 @@ void Transfer::complete()
 
             if (isvalid && !(fingerprint == *(FileFingerprint*)this))
             {
-                delete fa;
-                client->fsaccess->unlinklocal(&localfilename);
-                return failed(API_EWRITE);
+                if (!badfp.isvalid || !(badfp == fingerprint))
+                {
+                    badfp = fingerprint;
+                    delete fa;
+                    client->fsaccess->unlinklocal(&localfilename);
+                    return failed(API_EWRITE);
+                }
+                else
+                {
+                    fixfingerprint = true;
+                }
             }
         }
         delete fa;
@@ -159,7 +168,7 @@ void Transfer::complete()
                     symmcipher = n->nodecipher();
                 }
 
-                if (!n->isvalid && fingerprint.isvalid)
+                if (fingerprint.isvalid && (!n->isvalid || fixfingerprint))
                 {
                     *(FileFingerprint*)n = fingerprint;
 


### PR DESCRIPTION
This prevents infinite download loops for nodes with invalid fingerprints