### PR TITLE
Update WP binding - Kill all sessions

### DIFF
--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -450,6 +450,16 @@ void MegaSDK::killSession(MegaHandle sessionHandle)
     megaApi->killSession(sessionHandle);
 }
 
+void MegaSDK::killAllSessions(MRequestListenerInterface^ listener)
+{
+    megaApi->killSession(mega::INVALID_HANDLE, createDelegateMRequestListener(listener));
+}
+
+void MegaSDK::killAllSessions()
+{
+    megaApi->killSession(mega::INVALID_HANDLE);
+}
+
 void MegaSDK::getOwnUserData(MRequestListenerInterface^ listener)
 {
 	megaApi->getUserData(createDelegateMRequestListener(listener));

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -153,6 +153,8 @@ namespace mega
         void fastLogin(String^ session);
         void killSession(MegaHandle sessionHandle, MRequestListenerInterface^ listener);
         void killSession(MegaHandle sessionHandle);
+        void killAllSessions(MRequestListenerInterface^ listener);
+        void killAllSessions();
         void getOwnUserData(MRequestListenerInterface^ listener);
         void getOwnUserData();
         void getUserData(MUser^ user, MRequestListenerInterface^ listener);


### PR DESCRIPTION
Added new method `killAllSessions` to close all sessions except the
current session.