### PR TITLE
Fix invite own email address

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2867,24 +2867,31 @@ static void process_line(char* l)
                     }
                     else if (words[0] == "invite")
                     {
-                        int del = words.size() == 3 && words[2] == "del";
-                        int rmd = words.size() == 3 && words[2] == "rmd";
-                        if (words.size() == 2 || words.size() == 3)
+                        if (client->finduser(client->me)->email.compare(words[1]))
                         {
-                            if (del || rmd)
+                            int del = words.size() == 3 && words[2] == "del";
+                            int rmd = words.size() == 3 && words[2] == "rmd";
+                            if (words.size() == 2 || words.size() == 3)
                             {
-                                client->setpcr(words[1].c_str(), del ? OPCA_DELETE : OPCA_REMIND);
-                            } 
-                            else 
+                                if (del || rmd)
+                                {
+                                    client->setpcr(words[1].c_str(), del ? OPCA_DELETE : OPCA_REMIND);
+                                }
+                                else
+                                {
+                                    // Original email is not required, but can be used if this account has multiple email addresses associated,
+                                    // to have the invite come from a specific email
+                                    client->setpcr(words[1].c_str(), OPCA_ADD, "Invite from MEGAcli", words.size() == 3 ? words[2].c_str() : NULL);
+                                }
+                            }
+                            else
                             {
-                                // Original email is not required, but can be used if this account has multiple email addresses associated,
-                                // to have the invite come from a specific email
-                                client->setpcr(words[1].c_str(), OPCA_ADD, "Invite from MEGAcli", words.size() == 3 ? words[2].c_str() : NULL);
+                                cout << "      invite dstemail [origemail|del|rmd]" << endl;
                             }
                         }
                         else
                         {
-                            cout << "      invite dstemail [origemail|del|rmd]" << endl;
+                            cout << "Cannot send invitation to your own user" << endl;
                         }
 
                         return;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8606,10 +8606,19 @@ void MegaApiImpl::sendPendingRequests()
 		case MegaRequest::TYPE_ADD_CONTACT:
 		{
             const char *email = request->getEmail();
+
+            if(client->loggedin() != FULLACCOUNT)
+            {
+                e = API_EACCESS;
+                break;
+            }
+
             if(!email || !client->finduser(client->me)->email.compare(email))
             {
-                e = API_EARGS; break;
+                e = API_EARGS;
+                break;
             }
+
 			e = client->invite(email, VISIBLE);
 			break;
 		}
@@ -8618,6 +8627,13 @@ void MegaApiImpl::sendPendingRequests()
             const char *email = request->getEmail();
             const char *message = request->getText();
             int action = request->getNumber();
+
+            if(client->loggedin() != FULLACCOUNT)
+            {
+                e = API_EACCESS;
+                break;
+            }
+
             if(!email || !client->finduser(client->me)->email.compare(email))
             {
                 e = API_EARGS;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8605,8 +8605,11 @@ void MegaApiImpl::sendPendingRequests()
 		}
 		case MegaRequest::TYPE_ADD_CONTACT:
 		{
-			const char *email = request->getEmail();
-			if(!email) { e = API_EARGS; break; }
+            const char *email = request->getEmail();
+            if(!email || client->finduser(client->me)->email.compare(email))
+            {
+                e = API_EARGS; break;
+            }
 			e = client->invite(email, VISIBLE);
 			break;
 		}
@@ -8615,7 +8618,7 @@ void MegaApiImpl::sendPendingRequests()
             const char *email = request->getEmail();
             const char *message = request->getText();
             int action = request->getNumber();
-            if(!email)
+            if(!email || client->finduser(client->me)->email.compare(email))
             {
                 e = API_EARGS;
                 break;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8606,7 +8606,7 @@ void MegaApiImpl::sendPendingRequests()
 		case MegaRequest::TYPE_ADD_CONTACT:
 		{
             const char *email = request->getEmail();
-            if(!email || client->finduser(client->me)->email.compare(email))
+            if(!email || !client->finduser(client->me)->email.compare(email))
             {
                 e = API_EARGS; break;
             }
@@ -8618,7 +8618,7 @@ void MegaApiImpl::sendPendingRequests()
             const char *email = request->getEmail();
             const char *message = request->getText();
             int action = request->getNumber();
-            if(!email || client->finduser(client->me)->email.compare(email))
+            if(!email || !client->finduser(client->me)->email.compare(email))
             {
                 e = API_EARGS;
                 break;


### PR DESCRIPTION
Avoid to invite your own user to become a contact.
Currently, API accepts the contact request, creating both the corresponding outgoing and incoming requests. The SDK, after accepting the request, tag the session user as a regular user.