### PR TITLE
Fix public links deletion

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6506,14 +6506,20 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
         break;
 
     case FOLDERNODE:
-        // exporting folder - create share
-        setshare(n, NULL, del ? ACCESS_UNKNOWN : RDONLY);
-
-        // exported folder's deletion also deletes the link automatically
-        if (!del)
+        if (del)
         {
+            // deletion of outgoing share also deletes the link automatically
+            // need to first remove the link and then the share
+            reqs.add(new CommandSetPH(this, n, del, ets));
+            setshare(n, NULL, ACCESS_UNKNOWN);
+        }
+        else
+        {
+            // exporting folder - need to create share first
+            setshare(n, NULL, RDONLY);
             reqs.add(new CommandSetPH(this, n, del, ets));
         }
+
         break;
 
     default:


### PR DESCRIPTION
Deletion of the outshare of a folder automatically deletes any public
link in the outshare, so the request to delete the link was not sent.
It's not convenient since the client apps don't receive the
`onRequestFinish()` as expected.
Now, when deleting a link, first the command to delete the link is sent,
and then the command to delete the outshare.