### PR TITLE
Unmatched `delete`

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -9876,7 +9876,7 @@ MegaSyncEventPrivate::MegaSyncEventPrivate(int type)
 
 MegaSyncEventPrivate::~MegaSyncEventPrivate()
 {
-    delete path;
+    delete [] path;
 }
 
 MegaSyncEvent *MegaSyncEventPrivate::copy()


### PR DESCRIPTION
The variable `const char* path;` is allocated by `MegaApi::strdup()` by
calling `new char[tam]`, so it's actually an array.