### PR TITLE
List of public links, existence of node related to a public link, email from #newsignup links

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -468,6 +468,7 @@ class MEGA_API CommandGetPH : public Command
     handle ph;
     byte key[FILENODEKEYLENGTH];
     int op;
+    bool havekey;
 
 public:
     void procresult();

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -4113,7 +4113,7 @@ class MegaApi
         void fastCreateAccount(const char* email, const char *base64pwkey, const char* name, MegaRequestListener *listener = NULL);
 
         /**
-         * @brief Get information about a confirmation link
+         * @brief Get information about a confirmation link or a new signup link
          *
          * The associated request type with this request is MegaRequest::TYPE_QUERY_SIGNUP_LINK.
          * Valid data in the MegaRequest object received on all callbacks:
@@ -4121,10 +4121,10 @@ class MegaApi
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
-         * - MegaRequest::getEmail - Return the email associated with the confirmation link
-         * - MegaRequest::getName - Returns the name associated with the confirmation link
+         * - MegaRequest::getEmail - Return the email associated with the link
+         * - MegaRequest::getName - Returns the name associated with the link (available only for confirmation links)
          *
-         * @param link Confirmation link
+         * @param link Confirmation link (#confirm) or new signup link (#newsignup)
          * @param listener MegaRequestListener to track this request
          */
         void querySignupLink(const char* link, MegaRequestListener *listener = NULL);

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6252,6 +6252,15 @@ class MegaApi
         MegaShareList *getPendingOutShares(MegaNode *node);
 
         /**
+         * @brief Get a list with all public links
+         *
+         * You take the ownership of the returned value
+         *
+         * @return List of MegaNode objects that are shared with everyone via public link
+         */
+        MegaNodeList *getPublicLinks();
+
+        /**
          * @brief Get a list with all incoming contact requests
          *
          * You take the ownership of the returned value

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -988,6 +988,18 @@ class PendingOutShareProcessor : public TreeProcessor
         vector<handle> handles;
 };
 
+class PublicLinkProcessor : public TreeProcessor
+{
+    public:
+        PublicLinkProcessor();
+        virtual bool processNode(Node* node);
+        virtual ~PublicLinkProcessor();
+        vector<Node *> &getNodes();
+
+    protected:
+        vector<Node *> nodes;
+};
+
 class SizeProcessor : public TreeProcessor
 {
     protected:
@@ -1236,6 +1248,7 @@ class MegaApiImpl : public MegaApp
         MegaShareList *getOutShares(MegaNode *node);
         MegaShareList *getPendingOutShares();
         MegaShareList *getPendingOutShares(MegaNode *megaNode);
+        MegaNodeList *getPublicLinks();
         MegaContactRequestList *getIncomingContactRequests();
         MegaContactRequestList *getOutgoingContactRequests();
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2701,7 +2701,11 @@ CommandGetPH::CommandGetPH(MegaClient* client, handle cph, const byte* ckey, int
     arg("p", (byte*)&cph, MegaClient::NODEHANDLE);
 
     ph = cph;
-    memcpy(key, ckey, sizeof key);
+    havekey = ckey ? true : false;
+    if (havekey)
+    {
+        memcpy(key, ckey, sizeof key);
+    }
     tag = client->reqtag;
     op = cop;
 }
@@ -2737,7 +2741,10 @@ void CommandGetPH::procresult()
                 if (s >= 0)
                 {
                     a.resize(Base64::atob(a.c_str(), (byte*)a.data(), a.size()));
-                    client->app->openfilelink_result(ph, key, s, &a, &fa, op);
+                    if (havekey)
+                        client->app->openfilelink_result(ph, key, s, &a, &fa, op);
+                    else
+                        client->app->openfilelink_result(ph, NULL, s, &a, &fa, op);
                 }
                 else
                 {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2742,9 +2742,13 @@ void CommandGetPH::procresult()
                 {
                     a.resize(Base64::atob(a.c_str(), (byte*)a.data(), a.size()));
                     if (havekey)
+                    {
                         client->app->openfilelink_result(ph, key, s, &a, &fa, op);
+                    }
                     else
+                    {
                         client->app->openfilelink_result(ph, NULL, s, &a, &fa, op);
+                    }
                 }
                 else
                 {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -767,6 +767,7 @@ int MegaTransfer::getFolderTransferTag() const
 MegaError::MegaError(int errorCode)
 {
     this->errorCode = errorCode;
+    this->value = 0;
 }
 
 MegaError::MegaError(int errorCode, long long value)

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1825,6 +1825,11 @@ MegaShareList *MegaApi::getPendingOutShares(MegaNode *node)
     return pImpl->getPendingOutShares(node);
 }
 
+MegaNodeList *MegaApi::getPublicLinks()
+{
+    return pImpl->getPublicLinks();
+}
+
 MegaContactRequestList *MegaApi::getIncomingContactRequests()
 {
     return pImpl->getIncomingContactRequests();

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -6739,6 +6739,13 @@ void MegaApiImpl::openfilelink_result(handle ph, const byte* key, m_off_t size, 
 		return;
 	}
 
+    // no key provided --> check only that the nodehandle is valid
+    if (!key && (request->getType() == MegaRequest::TYPE_GET_PUBLIC_NODE))
+    {
+        fireOnRequestFinish(request, MegaError(MegaError::API_EINCOMPLETE));
+        return;
+    }
+
     string attrstring;
     string fileName;
     string keystring;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -9463,7 +9463,14 @@ void MegaApiImpl::sendPendingRequests()
                 unsigned len = (strlen(link)-(ptr-link))*3/4+4;
                 byte *c = new byte[len];
                 len = Base64::atob(ptr,c,len);
-                client->querysignuplink(c,len);
+                if (len)
+                {
+                    client->querysignuplink(c,len);
+                }
+                else
+                {
+                    e = API_EARGS;
+                }
                 delete[] c;
                 break;
             }
@@ -9475,33 +9482,31 @@ void MegaApiImpl::sendPendingRequests()
                 byte *c = new byte[len];
                 len = Base64::atob(ptr,c,len);
 
-                // extract email and email_hash from link
-                byte *email = c;
-                byte *sha512bytes = c+len-8;    // last 11 chars
-
-                // get the hash for the received email
-                Hash sha512;
-                sha512.add(email, len-8);
-                string sha512str;
-                sha512.get(&sha512str);
-
-                // and finally check it
-                if (memcmp(sha512bytes, sha512str.data(), 8) == 0)
+                if (len > 8)
                 {
-                    email[len-8] = '\0';
-                    request->setEmail((const char *)email);
-                    delete[] c;
+                    // extract email and email_hash from link
+                    byte *email = c;
+                    byte *sha512bytes = c+len-8;    // last 11 chars
 
-                    client->restag = request->getTag();
-                    fireOnRequestFinish(request, API_OK);
-                    break;
+                    // get the hash for the received email
+                    Hash sha512;
+                    sha512.add(email, len-8);
+                    string sha512str;
+                    sha512.get(&sha512str);
+
+                    // and finally check it
+                    if (memcmp(sha512bytes, sha512str.data(), 8) == 0)
+                    {
+                        email[len-8] = '\0';
+                        request->setEmail((const char *)email);
+                        delete[] c;
+
+                        fireOnRequestFinish(request, MegaError(API_OK));
+                        break;
+                    }
                 }
-                else
-                {
-                    e = API_EARGS;
-                    delete[] c;
-                    break;
-                }
+
+                delete[] c;
             }
 
             e = API_EARGS;
@@ -9527,7 +9532,14 @@ void MegaApiImpl::sendPendingRequests()
 			unsigned len = (strlen(link)-(ptr-link))*3/4+4;
 			byte *c = new byte[len];
             len = Base64::atob(ptr,c,len);
-			client->querysignuplink(c,len);
+            if (len)
+            {
+                client->querysignuplink(c,len);
+            }
+            else
+            {
+                e = API_EARGS;
+            }
 			delete[] c;
 			break;
 		}

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6767,7 +6767,7 @@ error MegaClient::openfilelink(const char* link, int op)
                 return API_OK;
             }
         }
-        else    // no key provided, check only the existence of the node
+        else if (*ptr == '\0')    // no key provided, check only the existence of the node
         {
             if (op)
             {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6767,6 +6767,14 @@ error MegaClient::openfilelink(const char* link, int op)
                 return API_OK;
             }
         }
+        else    // no key provided, check only the existence of the node
+        {
+            if (op)
+            {
+                reqs.add(new CommandGetPH(this, ph, NULL, op));
+                return API_OK;
+            }
+        }
     }
 
     return API_EARGS;

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -231,9 +231,9 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         {
             link.assign(request->getLink());
         }
-#endif
         responseReceived = true;
         break;
+#endif
 
     }
 }


### PR DESCRIPTION
List of public links independent from list of outgoing shares:
- New `TreeProcessor` to find public links.
- New interface to get only public links.
- Changes to `getOutShares()` to exclude public links (actually, changes in `OutShareProcessor`).
- Changes to `getOutShare(node)` to exclude public links.

Additionally, `MegaApi::querySignupLink()` supports #newsignup links.

Also, allow to check the existence of nodes related to a public link without key.