### PR TITLE
Patch for user visibility status

### DIFF
--- a/bindings/megaapi.i
+++ b/bindings/megaapi.i
@@ -166,6 +166,7 @@
 %newobject mega::MegaApi::dumpXMPPSession;
 %newobject mega::MegaApi::getMyEmail;
 %newobject mega::MegaApi::getMyUserHandle;
+%newobject mega::MegaApi::getMyUser;
 %newobject mega::MegaApi::getMyXMPPJid;
 %newobject mega::MegaApi::exportMasterKey;
 %newobject mega::MegaApi::getTransfers;

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2655,6 +2655,14 @@ static void process_line(char* l)
                                 {
                                     cout << ", hidden";
                                 }
+                                else if (it->second.show == INACTIVE)
+                                {
+                                    cout << ", inactive";
+                                }
+                                else if (it->second.show == BLOCKED)
+                                {
+                                    cout << ", blocked";
+                                }
                                 else if (it->second.show == ME)
                                 {
                                     cout << ", session user";

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2647,7 +2647,11 @@ static void process_line(char* l)
                             {
                                 cout << "\t" << it->second.email;
 
-                                if (it->second.show == VISIBLE)
+                                if (it->second.userhandle == client->me)
+                                {
+                                    cout << ", session user";
+                                }
+                                else if (it->second.show == VISIBLE)
                                 {
                                     cout << ", visible";
                                 }
@@ -2662,10 +2666,6 @@ static void process_line(char* l)
                                 else if (it->second.show == BLOCKED)
                                 {
                                     cout << ", blocked";
-                                }
-                                else if (it->second.show == ME)
-                                {
-                                    cout << ", session user";
                                 }
                                 else
                                 {

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -219,7 +219,7 @@ typedef vector<struct Node*> node_vector;
 // contact visibility:
 // HIDDEN - not shown
 // VISIBLE - shown
-typedef enum { VISIBILITY_UNKNOWN = -1, HIDDEN = 0, VISIBLE, ME } visibility_t;
+typedef enum { VISIBILITY_UNKNOWN = -1, HIDDEN = 0, VISIBLE = 1, INACTIVE = 2, BLOCKED = 3, ME } visibility_t;
 
 typedef enum { PUTNODES_APP, PUTNODES_SYNC, PUTNODES_SYNCDEBRIS } putsource_t;
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -219,7 +219,7 @@ typedef vector<struct Node*> node_vector;
 // contact visibility:
 // HIDDEN - not shown
 // VISIBLE - shown
-typedef enum { VISIBILITY_UNKNOWN = -1, HIDDEN = 0, VISIBLE = 1, INACTIVE = 2, BLOCKED = 3, ME } visibility_t;
+typedef enum { VISIBILITY_UNKNOWN = -1, HIDDEN = 0, VISIBLE = 1, INACTIVE = 2, BLOCKED = 3 } visibility_t;
 
 typedef enum { PUTNODES_APP, PUTNODES_SYNC, PUTNODES_SYNCDEBRIS } putsource_t;
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -900,8 +900,10 @@ class MegaUser
 	public:
 		enum {
 			VISIBILITY_UNKNOWN = -1,
-			VISIBILITY_HIDDEN = 0,
-			VISIBILITY_VISIBLE,
+            VISIBILITY_HIDDEN = 0,
+            VISIBILITY_VISIBLE = 1,
+            VISIBILITY_INACTIVE = 2,
+            VISIBILITY_BLOCKED = 3,
 			VISIBILITY_ME
 		};
 
@@ -953,7 +955,13 @@ class MegaUser
          * - VISIBILITY_VISIBLE = 1
          * The contact is currently visible
          *
-         * - VISIBILITY_ME = 2
+         * - VISIBILITY_INACTIVE = 2
+         * The contact is currently inactive
+         *
+         * - VISIBILITY_BLOCKED = 3
+         * The contact is currently blocked
+         *
+         * - VISIBILITY_ME = 4
          * The contact is the owner of the account being used by the SDK
          *
          * @return Current visibility of the contact
@@ -4291,6 +4299,18 @@ class MegaApi
          * @return User handle of the account
          */
         char* getMyUserHandle();
+
+        /**
+         * @brief Get the MegaUser of the currently open account
+         *
+         * If the MegaApi object isn't logged in,
+         * this function returns NULL
+         *
+         * You take the ownership of the returned value
+         *
+         * @return MegaUser of the currently open account, otherwise NULL
+         */
+        MegaUser* getMyUser();
 
         /**
          * @brief Returns the XMPP JID of the currently open account

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -903,8 +903,7 @@ class MegaUser
             VISIBILITY_HIDDEN = 0,
             VISIBILITY_VISIBLE = 1,
             VISIBILITY_INACTIVE = 2,
-            VISIBILITY_BLOCKED = 3,
-			VISIBILITY_ME
+            VISIBILITY_BLOCKED = 3
 		};
 
 		virtual ~MegaUser();
@@ -961,9 +960,7 @@ class MegaUser
          * - VISIBILITY_BLOCKED = 3
          * The contact is currently blocked
          *
-         * - VISIBILITY_ME = 4
-         * The contact is the owner of the account being used by the SDK
-         *
+         * @note The visibility of your own user is undefined and shouldn't be used.
          * @return Current visibility of the contact
          */
         virtual int getVisibility();
@@ -4303,11 +4300,11 @@ class MegaApi
         /**
          * @brief Get the MegaUser of the currently open account
          *
-         * If the MegaApi object isn't logged in,
-         * this function returns NULL
+         * If the MegaApi object isn't logged in, this function returns NULL.
          *
          * You take the ownership of the returned value
          *
+         * @note The visibility of your own user is unhdefined and shouldn't be used.
          * @return MegaUser of the currently open account, otherwise NULL
          */
         MegaUser* getMyUser();

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1129,6 +1129,7 @@ class MegaApiImpl : public MegaApp
         int isLoggedIn();
         char* getMyEmail();
         char* getMyUserHandle();
+        MegaUser *getMyUser();
         char* getMyXMPPJid();
         static void setLogLevel(int logLevel);
         static void setLoggerClass(MegaLogger *megaLogger);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1075,6 +1075,11 @@ char *MegaApi::getMyUserHandle()
     return pImpl->getMyUserHandle();
 }
 
+MegaUser *MegaApi::getMyUser()
+{
+    return pImpl->getMyUser();
+}
+
 char *MegaApi::getMyXMPPJid()
 {
     return pImpl->getMyXMPPJid();

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4909,8 +4909,9 @@ MegaUser* MegaApiImpl::getContact(const char* email)
     sdkMutex.lock();
 	MegaUser *user = MegaUserPrivate::fromUser(client->finduser(email, 0));
 
-    if (user->getHandle() == client->me)
+    if (user && user->getHandle() == client->me)
     {
+        delete user;
         user = NULL;    // it's not a contact
     }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -2603,6 +2603,14 @@ char *MegaApiImpl::getMyUserHandle()
     return result;
 }
 
+MegaUser *MegaApiImpl::getMyUser()
+{
+    sdkMutex.lock();
+    MegaUser *user = MegaUserPrivate::fromUser(client->finduser(client->me));
+    sdkMutex.unlock();
+    return user;
+}
+
 char *MegaApiImpl::getMyXMPPJid()
 {
     sdkMutex.lock();
@@ -4881,6 +4889,10 @@ MegaUserList* MegaApiImpl::getContacts()
 	for (user_map::iterator it = client->users.begin() ; it != client->users.end() ; it++ )
 	{
 		User *u = &(it->second);
+        if (u->userhandle == client->me)
+        {
+            continue;
+        }
         vector<User *>::iterator i = std::lower_bound(vUsers.begin(), vUsers.end(), u, MegaApiImpl::userComparatorDefaultASC);
 		vUsers.insert(i, u);
 	}
@@ -4896,6 +4908,12 @@ MegaUser* MegaApiImpl::getContact(const char* email)
 {
     sdkMutex.lock();
 	MegaUser *user = MegaUserPrivate::fromUser(client->finduser(email, 0));
+
+    if (user->getHandle() == client->me)
+    {
+        user = NULL;    // it's not a contact
+    }
+
     sdkMutex.unlock();
 	return user;
 }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5491,35 +5491,16 @@ bool MegaClient::readusers(JSON* j)
             warn("Unknown contact user e-mail address");
         }
 
+        // FIXME: the API sends '2' for your own user AND for inactive users
+        // Until it's changed in the API, the SDK will amend the visibility status
+        if (v == INACTIVE && uh == me)
+        {
+            v = ME;
+        }
+
         if (!warnlevel())
         {
-            User* u;
-
-            if (v == ME)
-            {
-                if (me != UNDEF && uh != me)
-                {
-                    char mehandle[sizeof me * 4 / 3 + 4];
-                    char uhhandle[sizeof uh * 4 / 3 + 4];
-
-                    Base64::btoa((const byte *)&me, sizeof me, mehandle);
-                    Base64::btoa((const byte *)&uh, sizeof uh, uhhandle);
-
-                    char report[256];
-                    sprintf(report, "Own user handle mismatch: %s - %s (%d)", mehandle, uhhandle, fetchingnodes);
-
-                    int creqtag = reqtag;
-                    reqtag = 0;
-                    sendevent(99403, report);
-                    reqtag = creqtag;
-                }
-                else
-                {
-                    me = uh;
-                }
-            }
-
-            u = finduser(uh, 0);
+            User* u = finduser(uh, 0);
             bool notify = !u;
             if (u || (u = finduser(uh, 1)))
             {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5491,13 +5491,6 @@ bool MegaClient::readusers(JSON* j)
             warn("Unknown contact user e-mail address");
         }
 
-        // FIXME: the API sends '2' for your own user AND for inactive users
-        // Until it's changed in the API, the SDK will amend the visibility status
-        if (v == INACTIVE && uh == me)
-        {
-            v = ME;
-        }
-
         if (!warnlevel())
         {
             User* u = finduser(uh, 0);

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -116,12 +116,14 @@ User* User::unserialize(MegaClient* client, string* d)
         return NULL;
     }
 
-    if (v == ME)
-    {
-        client->me = uh;
-    }
-
     client->mapuser(uh, m.c_str());
+
+    // FIXME: the API sends '2' for your own user AND for inactive users
+    // Until it's changed in the API, the SDK will amend the visibility status
+    if (v == INACTIVE && uh == client->me)
+    {
+        v = ME;
+    }
     u->set(v, ts);
 
     if ((ptr < end) && !(ptr = u->attrs.unserialize(ptr)))

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -117,13 +117,6 @@ User* User::unserialize(MegaClient* client, string* d)
     }
 
     client->mapuser(uh, m.c_str());
-
-    // FIXME: the API sends '2' for your own user AND for inactive users
-    // Until it's changed in the API, the SDK will amend the visibility status
-    if (v == INACTIVE && uh == client->me)
-    {
-        v = ME;
-    }
     u->set(v, ts);
 
     if ((ptr < end) && !(ptr = u->attrs.unserialize(ptr)))


### PR DESCRIPTION
- Added new visibilities: `INACTIVE` and `BLOCKED`.
- Moved `ME` from 2 to 4
- The handle of the logged in user is exclusively set to the value
returned by the login command.
- During fetchnodes, if a `c=2` is received for a user, but the handle
is the same than the logged in user, the visibility status is set to
`ME` instead of `INACTIVE`.
- Now, `MegaApi::getContacts()` and `getContact()` exclude the own user
from the list (it's not a contact).
- A new interface for `MegaUser* MegaApi::getMyUser()`.