### PR TITLE
Fix compilation of `megacli`

### DIFF
--- a/bindings/qt/sdk.pri
+++ b/bindings/qt/sdk.pri
@@ -33,6 +33,7 @@ SOURCES += src/attrmap.cpp \
     src/proxy.cpp \
     src/pendingcontactrequest.cpp \
     src/crypto/cryptopp.cpp  \
+    src/crypto/sodium.cpp  \
     src/db/sqlite.cpp  \
     src/gfx/qt.cpp \
     src/gfx/external.cpp \
@@ -127,6 +128,7 @@ HEADERS  += include/mega.h \
             include/mega/proxy.h \
             include/mega/pendingcontactrequest.h \
             include/mega/crypto/cryptopp.h  \
+            include/mega/crypto/sodium.h  \
             include/mega/db/sqlite.h  \
             include/mega/gfx/qt.h \
             include/mega/gfx/external.h \

--- a/bindings/qt/sdk.pri
+++ b/bindings/qt/sdk.pri
@@ -134,13 +134,16 @@ HEADERS  += include/mega.h \
             include/mega/thread/qtthread.h \
             include/megaapi.h \
             include/megaapi_impl.h \
-            bindings/qt/QTMegaRequestListener.h \
+            include/mega/mega_utf8proc.h
+
+CONFIG(USE_MEGAAPI) {
+    HEADERS += bindings/qt/QTMegaRequestListener.h \
             bindings/qt/QTMegaTransferListener.h \
             bindings/qt//QTMegaGlobalListener.h \
             bindings/qt/QTMegaSyncListener.h \
             bindings/qt/QTMegaListener.h \
-            bindings/qt/QTMegaEvent.h \
-            include/mega/mega_utf8proc.h
+            bindings/qt/QTMegaEvent.h
+}
 
 win32 {
     HEADERS  += include/mega/win32/megasys.h  \

--- a/contrib/QtCreator/MEGACli/MEGACli.pro
+++ b/contrib/QtCreator/MEGACli/MEGACli.pro
@@ -27,4 +27,5 @@ else {
 }
 
 SOURCES += ../../../examples/megacli.cpp
+HEADERS += ../../../examples/megacli.h
 include(../../../bindings/qt/sdk.pri)


### PR DESCRIPTION
Including the headers for QT bindings in a pure SDK project throws undefined references.