### PR TITLE
Fix ephemereal user

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5598,7 +5598,12 @@ bool MegaClient::readusers(JSON* j)
             bool notify = !u;
             if (u || (u = finduser(uh, 1)))
             {
-                mapuser(uh, m);
+                string email;
+                Node::copystring(&email, m);
+                if (email != "none")    // ephemereal session
+                {
+                    mapuser(uh, m);
+                }
 
                 if (v != VISIBILITY_UNKNOWN)
                 {


### PR DESCRIPTION
`megacli` creates an ephemereal account as the first step to create a
full account.

Now, the API returns `"m":"none"` for the email of the ephereal user. It
makes the SDK to store the email and identify the account as confirmed,
instead of ephemereal, blocking the signup process from the SDK (in
`megacli`).