### PR TITLE
Accept `ESID` as logout result

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -237,6 +237,9 @@ public:
     // free all state information
     void locallogout();
 
+    // remove caches
+    void removecaches();
+
     // SDK version
     const char* version();
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -5321,6 +5321,11 @@ class MegaApi
          *
          * The associated request type with this request is MegaRequest::TYPE_LOGOUT
          *
+         * Under certain circumstances, this request might return the error code
+         * MegaError::API_ESID. It should not be taken as an error, since the reason
+         * is that the logout action has been notified before the reception of the
+         * logout response itself.
+         *
          * @param listener MegaRequestListener to track this request
          */
         void logout(MegaRequestListener *listener = NULL);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1163,20 +1163,7 @@ void CommandLogout::procresult()
     MegaApp *app = client->app;
     if(!e)
     {
-        if (client->sctable)
-        {
-            client->sctable->remove();
-        }
-
-#ifdef ENABLE_SYNC
-        for (sync_list::iterator it = client->syncs.begin(); it != client->syncs.end(); it++)
-        {
-            if((*it)->statecachetable)
-            {
-                (*it)->statecachetable->remove();
-            }
-        }
-#endif
+        client->removecaches();
         client->locallogout();
     }
     app->logout_result(e);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1161,7 +1161,7 @@ void CommandLogout::procresult()
 {
     error e = (error)client->json.getint();
     MegaApp *app = client->app;
-    if(!e || e == API_ESID)
+    if(!e)
     {
         if (client->sctable)
         {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1161,7 +1161,7 @@ void CommandLogout::procresult()
 {
     error e = (error)client->json.getint();
     MegaApp *app = client->app;
-    if(!e)
+    if(!e || e == API_ESID)
     {
         if (client->sctable)
         {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1181,7 +1181,6 @@ void CommandLogout::procresult()
     if(!e)
     {
         client->removecaches();
-        client->disabletransferresumption();
         client->locallogout();
     }
     app->logout_result(e);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7295,6 +7295,15 @@ void MegaApiImpl::request_error(error e)
         request->setText(client->sslfakeissuer.c_str());
     }
 
+    if (e == API_ESID)
+    {
+        if (client->sctable)
+        {
+            client->sctable->remove();
+        }
+        client->locallogout();
+    }
+
     requestQueue.push(request);
     waiter->notify();
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7301,6 +7301,16 @@ void MegaApiImpl::request_error(error e)
         {
             client->sctable->remove();
         }
+
+#ifdef ENABLE_SYNC
+        for (sync_list::iterator it = client->syncs.begin(); it != client->syncs.end(); it++)
+        {
+            if ((*it)->statecachetable)
+            {
+                (*it)->statecachetable->remove();
+            }
+        }
+#endif
         client->locallogout();
     }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -5393,7 +5393,7 @@ MegaNodeList *MegaApiImpl::search(const char *searchString)
     Node *node;
 
     // rootnodes
-    for (int i = 0; i < (sizeof client->rootnodes / sizeof *client->rootnodes); i++)
+    for (unsigned int i = 0; i < (sizeof client->rootnodes / sizeof *client->rootnodes); i++)
     {
         node = client->nodebyhandle(client->rootnodes[i]);
 
@@ -7336,7 +7336,7 @@ void MegaApiImpl::logout_result(error e)
     MegaRequestPrivate* request = requestMap.at(client->restag);
     if(!request || (request->getType() != MegaRequest::TYPE_LOGOUT)) return;
 
-    if(!e)
+    if(!e || e == API_ESID)
     {
         requestMap.erase(request->getTag());
 
@@ -8545,8 +8545,6 @@ int naturalsorting_compare (const char *i, const char *j)
         }
         else    // we are comparing numbers on both strings
         {
-            char char_i, char_j;
-
             u_int64_t number_i = 0;
             unsigned int i_overflow_count = 0;
             while (*i && isDigit(i))

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7297,20 +7297,7 @@ void MegaApiImpl::request_error(error e)
 
     if (e == API_ESID)
     {
-        if (client->sctable)
-        {
-            client->sctable->remove();
-        }
-
-#ifdef ENABLE_SYNC
-        for (sync_list::iterator it = client->syncs.begin(); it != client->syncs.end(); it++)
-        {
-            if ((*it)->statecachetable)
-            {
-                (*it)->statecachetable->remove();
-            }
-        }
-#endif
+        client->removecaches();
         client->locallogout();
     }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7867,7 +7867,6 @@ void MegaApiImpl::request_error(error e)
     if (e == API_ESID)
     {
         client->removecaches();
-        client->disabletransferresumption();
         client->locallogout();
     }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2477,7 +2477,6 @@ void MegaClient::logout()
     if (loggedin() != FULLACCOUNT)
     {
         removecaches();
-        disabletransferresumption();
         locallogout();
 
         restag = reqtag;
@@ -2577,6 +2576,8 @@ void MegaClient::removecaches()
         }
     }
 #endif
+
+    disabletransferresumption();
 }
 
 const char *MegaClient::version()

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2369,20 +2369,7 @@ void MegaClient::logout()
 {
     if (loggedin() != FULLACCOUNT)
     {
-        if (sctable)
-        {
-            sctable->remove();
-        }
-
-#ifdef ENABLE_SYNC
-        for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
-        {
-            if ((*it)->statecachetable)
-            {
-                (*it)->statecachetable->remove();
-            }
-        }
-#endif
+        removecaches();
         locallogout();
 
         restag = reqtag;
@@ -2461,6 +2448,24 @@ void MegaClient::locallogout()
 
 #ifdef ENABLE_SYNC
     syncadding = 0;
+#endif
+}
+
+void MegaClient::removecaches()
+{
+    if (sctable)
+    {
+        sctable->remove();
+    }
+
+#ifdef ENABLE_SYNC
+    for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
+    {
+        if((*it)->statecachetable)
+        {
+            (*it)->statecachetable->remove();
+        }
+    }
 #endif
 }
 

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -407,6 +407,9 @@ void SdkTest::logout(int timeout)
         EXPECT_TRUE(logoutReceived) << "Logout failed after " << timeout  << " seconds";
     }
 
+    // if the connection was closed before the response of the request was received, the result is ESID
+    if (lastError == MegaError::API_ESID) lastError = MegaError::API_OK;
+
     EXPECT_EQ(MegaError::API_OK, lastError) << "Logout failed (error: " << lastError << ")";
 }
 


### PR DESCRIPTION
Also removes 2 warnings: unused variables and comparission between
signed and unsigned variables.