### PR TITLE
Ability to remove users from `megacli`

### DIFF
--- a/bindings/ios/MEGARequest.h
+++ b/bindings/ios/MEGARequest.h
@@ -44,7 +44,6 @@ typedef NS_ENUM (NSInteger, MEGARequestType) {
     MEGARequestTypeGetAttrUser,
     MEGARequestTypeSetAttrUser,
     MEGARequestTypeRetryPendingConnections,
-    MEGARequestTypeAddContact,
     MEGARequestTypeRemoveContact,
     MEGARequestTypeCreateAccount,
     MEGARequestTypeConfirmAccount,
@@ -215,7 +214,6 @@ typedef NS_ENUM (NSInteger, MEGANodeAccessLevel) {
  * - [MEGASdk fastCreateAccountWithEmail:password:name] - Returns the name of the user
  * - [MEGASdk shareNode:withUser:level:] - Returns the handle of the folder to share
  * - [MEGASdk getAvatarUser:destinationFilePath:] - Returns the email of the user to get the avatar
- * - [MEGASdk addContactWithEmail:] - Returns the email of the contact
  * - [MEGASdk removeContactWithEmail:] - Returns the email of the contact
  * - [MEGASdk getUserData] - Returns the name of the user
  *

--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -1827,35 +1827,6 @@ typedef NS_ENUM(NSInteger, HTTPServer) {
 - (void)changePassword:(NSString *)oldPassword newPassword:(NSString *)newPassword;
 
 /**
- * @brief Add a new contact to the MEGA account.
- *
- * The associated request type with this request is MEGARequestTypeAddContact.
- * Valid data in the MEGARequest object received on callbacks:
- * - [MEGARequest email] - Returns the email of the contact
- *
- * @param email Email of the new contact.
- * @param delegate Delegate to track this request.
- *
- * @deprecated: This way to add contacts will be removed in future updates. Please use 
- * [MEGASdk inviteContactWithEmail:message:action:].
- */
-- (void)addContactWithEmail:(NSString *)email delegate:(id<MEGARequestDelegate>)delegate;
-
-/**
- * @brief Add a new contact to the MEGA account.
- *
- * The associated request type with this request is MEGARequestTypeAddContact.
- * Valid data in the MEGARequest object received on callbacks:
- * - [MEGARequest email] - Returns the email of the contact
- *
- * @param email Email of the new contact.
- *
- * @deprecated: This way to add contacts will be removed in future updates. Please use
- * [MEGASdk inviteContactWithEmail:message:action:].
- */
-- (void)addContactWithEmail:(NSString *)email;
-
-/**
  * @brief Invite another person to be your MEGA contact
  *
  * The user doesn't need to be registered on MEGA. If the email isn't associated with
@@ -1940,25 +1911,25 @@ typedef NS_ENUM(NSInteger, HTTPServer) {
 - (void)replyContactRequest:(MEGAContactRequest *)request action:(MEGAReplyAction)action;
 
 /**
- * @brief Remove a contact to the MEGA account.
+ * @brief Remove a contact from the MEGA account.
  *
  * The associated request type with this request is MEGARequestTypeRemoveContact.
  * Valid data in the MEGARequest object received on callbacks:
  * - [MEGARequest email] - Returns the email of the contact
  *
- * @param user User of the new contact.
+ * @param user User of the contact to be removed.
  * @param delegate Delegate to track this request.
  */
 - (void)removeContactUser:(MEGAUser *)user delegate:(id<MEGARequestDelegate>)delegate;
 
 /**
- * @brief Add a new contact to the MEGA account.
+ * @brief Remove a contact from the MEGA account.
  *
- * The associated request type with this request is MEGARequestTypeAddContact.
+ * The associated request type with this request is MEGARequestTypeRemoveContact.
  * Valid data in the MEGARequest object received on callbacks:
  * - [MEGARequest email] - Returns the email of the contact
  *
- * @param user User of the new contact.
+ * @param user User of the contact to be removed.
  */
 - (void)removeContactUser:(MEGAUser *)user;
 

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -689,14 +689,6 @@ static DelegateMEGALogerListener *externalLogger = new DelegateMEGALogerListener
     self.megaApi->changePassword((oldPassword != nil) ? [oldPassword UTF8String] : NULL, (newPassword != nil) ? [newPassword UTF8String] : NULL);
 }
 
-- (void)addContactWithEmail:(NSString *)email delegate:(id<MEGARequestDelegate>)delegate {
-    self.megaApi->addContact((email != nil) ? [email UTF8String] : NULL, [self createDelegateMEGARequestListener:delegate singleListener:YES]);
-}
-
-- (void)addContactWithEmail:(NSString *)email {
-    self.megaApi->addContact((email != nil) ? [email UTF8String] : NULL);
-}
-
 - (void)inviteContactWithEmail:(NSString *)email message:(NSString *)message action:(MEGAInviteAction)action delegate:(id<MEGARequestDelegate>)delegate {
     self.megaApi->inviteContact((email != nil) ? [email UTF8String] : NULL, (message != nil) ? [message UTF8String] : NULL, (int)action, [self createDelegateMEGARequestListener:delegate singleListener:YES]);
 }

--- a/bindings/java/nz/mega/sdk/MegaApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaApiJava.java
@@ -2596,36 +2596,6 @@ public class MegaApiJava {
     }
 
     /**
-     * Add a new contact to the MEGA account.
-     * <p>
-     * The associated request type with this request is MegaRequest.TYPE_ADD_CONTACT
-     * Valid data in the MegaRequest object received on callbacks: <br>
-     * - MegaRequest.getEmail() - Returns the email of the contact.
-     * 
-     * @param email
-     *            Email of the new contact.
-     * @param listener
-     *            MegaRequestListener to track this request.
-     * @deprecated This method of adding contacts will be removed in future updates.
-     * Please use MegaApiJava.inviteContact().
-     */
-    @Deprecated public void addContact(String email, MegaRequestListenerInterface listener) {
-        megaApi.addContact(email, createDelegateRequestListener(listener));
-    }
-
-    /**
-     * Add a new contact to the MEGA account.
-     * 
-     * @param email
-     *            Email of the new contact.
-     * @deprecated This method of adding contacts will be removed in future updates.
-     * Please use MegaApiJava.inviteContact().
-     */
-    @Deprecated public void addContact(String email) {
-        megaApi.addContact(email);
-    }
-
-    /**
      * Invite another person to be your MEGA contact.
      * <p>
      * The user does not need to be registered with MEGA. If the email is not associated with

--- a/bindings/php/megaapi.php
+++ b/bindings/php/megaapi.php
@@ -771,9 +771,9 @@ class MegaApiPHP extends MegaApi
 		$this->megaApi->changePassword($oldPassword, $newPassword, $this->createDelegateRequestListener($listener));
 	}
 
-	function addContact($email, $listener = null) 
+	function inviteContact($user, $message, $action, $listener = null) 
 	{
-		$this->megaApi->addContact($email, $this->createDelegateRequestListener($listener));
+		$this->megaApi->inviteContact($user, $message, $action, $this->createDelegateRequestListener($listener));
 	}
 
 	function removeContact($user, $listener = null) 

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -1568,25 +1568,6 @@ void MegaSDK::changePassword(String^ oldPassword, String^ newPassword)
 		(newPassword != nullptr) ? utf8newPassword.c_str() : NULL);
 }
 
-void MegaSDK::addContact(String^ email, MRequestListenerInterface^ listener)
-{
-    std::string utf8email;
-    if (email != nullptr)
-        MegaApi::utf16ToUtf8(email->Data(), email->Length(), &utf8email);
-
-    megaApi->addContact((email != nullptr) ? utf8email.c_str() : NULL,
-        createDelegateMRequestListener(listener));
-}
-
-void MegaSDK::addContact(String^ email)
-{
-    std::string utf8email;
-    if (email != nullptr)
-        MegaApi::utf16ToUtf8(email->Data(), email->Length(), &utf8email);
-
-    megaApi->addContact((email != nullptr) ? utf8email.c_str() : NULL);
-}
-
 void MegaSDK::inviteContact(String^ email, String^ message, MContactRequestInviteActionType action, MRequestListenerInterface^ listener)
 {
     std::string utf8email;

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -277,8 +277,6 @@ namespace mega
 
         void changePassword(String^ oldPassword, String^ newPassword, MRequestListenerInterface^ listener);
         void changePassword(String^ oldPassword, String^ newPassword);
-        void addContact(String^ email, MRequestListenerInterface^ listener);
-        void addContact(String^ email);
         void inviteContact(String^ email, String^ message, MContactRequestInviteActionType action, MRequestListenerInterface^ listener);
         void inviteContact(String^ email, String^ message, MContactRequestInviteActionType action);
         void replyContactRequest(MContactRequest^ request, MContactRequestReplyActionType action, MRequestListenerInterface^ listener);

--- a/doc/source/api_usage.rst
+++ b/doc/source/api_usage.rst
@@ -407,14 +407,13 @@ User Contact Management
 Users maintain a *contact list* of peers they know.
 
 :Method: 
-    ``error addcontact(const char* user)``
+    ``inviteContact(const char *email,
+		const char *message,
+		int action,
+		MegaRequestListener *listener = NULL)``
+    :``email``:  User by e-mail address
 
-    :``user``: User by e-mail address or handle. If the user has an
-        existing MEGA account, he or she will appear in the local
-        contact list immediately. Otherwise, an e-mail invitation will
-        be sent.
-
-Receiving a folder share from a user implicitly adds him or her to the
+Receiving a folder share from a user implicitly invites him or her to the
 recipient's contact list.
 
 

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -840,7 +840,7 @@ void DemoApp::putfa_result(handle, fatype, error e)
     }
 }
 
-void DemoApp::invite_result(error e)
+void DemoApp::removecontact_result(error e)
 {
     if (e)
     {
@@ -1752,7 +1752,7 @@ static void process_line(char* l)
                 cout << "      invite dstemail [origemail|del|rmd]" << endl;
                 cout << "      ipc handle a|d|i" << endl;
                 cout << "      showpcr" << endl;
-                cout << "      users" << endl;
+                cout << "      users [email del]" << endl;
                 cout << "      getua attrname [email]" << endl;
                 cout << "      putua attrname [del|set string|load file]" << endl;
                 cout << "      putbps [limit|auto|none]" << endl;
@@ -2641,49 +2641,60 @@ static void process_line(char* l)
                     }
                     else if (words[0] == "users")
                     {
-                        for (user_map::iterator it = client->users.begin(); it != client->users.end(); it++)
+                        if (words.size() == 1)
                         {
-                            if (it->second.email.size())
+                            for (user_map::iterator it = client->users.begin(); it != client->users.end(); it++)
                             {
-                                cout << "\t" << it->second.email;
+                                if (it->second.email.size())
+                                {
+                                    cout << "\t" << it->second.email;
 
-                                if (it->second.userhandle == client->me)
-                                {
-                                    cout << ", session user";
-                                }
-                                else if (it->second.show == VISIBLE)
-                                {
-                                    cout << ", visible";
-                                }
-                                else if (it->second.show == HIDDEN)
-                                {
-                                    cout << ", hidden";
-                                }
-                                else if (it->second.show == INACTIVE)
-                                {
-                                    cout << ", inactive";
-                                }
-                                else if (it->second.show == BLOCKED)
-                                {
-                                    cout << ", blocked";
-                                }
-                                else
-                                {
-                                    cout << ", unknown visibility (" << it->second.show << ")";
-                                }
+                                    if (it->second.userhandle == client->me)
+                                    {
+                                        cout << ", session user";
+                                    }
+                                    else if (it->second.show == VISIBLE)
+                                    {
+                                        cout << ", visible";
+                                    }
+                                    else if (it->second.show == HIDDEN)
+                                    {
+                                        cout << ", hidden";
+                                    }
+                                    else if (it->second.show == INACTIVE)
+                                    {
+                                        cout << ", inactive";
+                                    }
+                                    else if (it->second.show == BLOCKED)
+                                    {
+                                        cout << ", blocked";
+                                    }
+                                    else
+                                    {
+                                        cout << ", unknown visibility (" << it->second.show << ")";
+                                    }
 
-                                if (it->second.sharing.size())
-                                {
-                                    cout << ", sharing " << it->second.sharing.size() << " folder(s)";
-                                }
+                                    if (it->second.sharing.size())
+                                    {
+                                        cout << ", sharing " << it->second.sharing.size() << " folder(s)";
+                                    }
 
-                                if (it->second.pubk.isvalid())
-                                {
-                                    cout << ", public key cached";
-                                }
+                                    if (it->second.pubk.isvalid())
+                                    {
+                                        cout << ", public key cached";
+                                    }
 
-                                cout << endl;
+                                    cout << endl;
+                                }
                             }
+                        }
+                        else if (words.size() == 3 && words[2] == "del")
+                        {
+                            client->removecontact(words[1].c_str(), HIDDEN);
+                        }
+                        else
+                        {
+                            cout << "      users [email del]" << endl;
                         }
 
                         return;

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -136,7 +136,7 @@ struct DemoApp : public MegaApp
 
     void putfa_result(handle, fatype, error);
 
-    void invite_result(error);
+    void removecontact_result(error);
     void putua_result(error);
     void getua_result(error);
     void getua_result(byte*, unsigned);

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -181,13 +181,13 @@ public:
     CommandSetKeyPair(MegaClient*, const byte*, unsigned, const byte*, unsigned);
 };
 
-// invite contact/set visibility
-class MEGA_API CommandUserRequest : public Command
+// set visibility
+class MEGA_API CommandRemoveContact : public Command
 {
 public:
     void procresult();
 
-    CommandUserRequest(MegaClient*, const char*, visibility_t);
+    CommandRemoveContact(MegaClient*, const char*, visibility_t);
 };
 
 // set user attributes

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -137,7 +137,7 @@ struct MEGA_API MegaApp
     virtual void sendevent_result(error) { }
 
     // user invites/attributes
-    virtual void invite_result(error) { }
+    virtual void removecontact_result(error) { }
     virtual void putua_result(error) { }
     virtual void getua_result(error) { }
     virtual void getua_result(byte*, unsigned) { }

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -212,7 +212,7 @@ public:
     void getua(User* u, const char* an = NULL);
 
     // add new contact (by e-mail address)
-    error invite(const char*, visibility_t = VISIBLE);
+    error removecontact(const char*, visibility_t = HIDDEN);
 
     // add/remove/update outgoing share
     void setshare(Node*, const char*, accesslevel_t, const char* = NULL);

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1600,7 +1600,7 @@ class MegaRequest
             TYPE_GET_PUBLIC_NODE, TYPE_GET_ATTR_FILE,
             TYPE_SET_ATTR_FILE, TYPE_GET_ATTR_USER,
             TYPE_SET_ATTR_USER, TYPE_RETRY_PENDING_CONNECTIONS,
-            TYPE_ADD_CONTACT, TYPE_REMOVE_CONTACT, TYPE_CREATE_ACCOUNT,
+            TYPE_REMOVE_CONTACT, TYPE_CREATE_ACCOUNT,
             TYPE_CONFIRM_ACCOUNT,
             TYPE_QUERY_SIGNUP_LINK, TYPE_ADD_SYNC, TYPE_REMOVE_SYNC,
             TYPE_REMOVE_SYNCS, TYPE_PAUSE_TRANSFERS,
@@ -5250,14 +5250,7 @@ class MegaApi
         /**
          * @brief Add a new contact to the MEGA account
          *
-         * The associated request type with this request is MegaRequest::TYPE_ADD_CONTACT
-         * Valid data in the MegaRequest object received on callbacks:
-         * - MegaRequest::getEmail - Returns the email of the contact
-         *
-         * @param email Email of the new contact
-         * @param listener MegaRequestListener to track this request
-         *
-         * @deprecated: This way to add contacts will be removed in future updates. Please use MegaApi::inviteContact.
+         * @obsolete: This way to add contacts is obsolete. Please use MegaApi::inviteContact.
          */
         void addContact(const char* email, MegaRequestListener* listener = NULL);
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1812,7 +1812,6 @@ class MegaRequest
          * - MegaApi::sendFileToUser - Returns the email of the user that receives the node
          * - MegaApi::share - Returns the email that receives the shared folder
          * - MegaApi::getUserAvatar - Returns the email of the user to get the avatar
-         * - MegaApi::addContact - Returns the email of the contact
          * - MegaApi::removeContact - Returns the email of the contact
          * - MegaApi::getUserData - Returns the email of the contact
          * - MegaApi::inviteContact - Returns the email of the contact
@@ -5246,13 +5245,6 @@ class MegaApi
          * @param listener MegaRequestListener to track this request
          */
         void changePassword(const char *oldPassword, const char *newPassword, MegaRequestListener *listener = NULL);
-
-        /**
-         * @brief Add a new contact to the MEGA account
-         *
-         * @obsolete: This way to add contacts is obsolete. Please use MegaApi::inviteContact.
-         */
-        void addContact(const char* email, MegaRequestListener* listener = NULL);
 
         /**
          * @brief Invite another person to be your MEGA contact

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1222,7 +1222,6 @@ class MegaApiImpl : public MegaApp
         char *exportMasterKey();
 
         void changePassword(const char *oldPassword, const char *newPassword, MegaRequestListener *listener = NULL);
-        void addContact(const char* email, MegaRequestListener* listener = NULL);
         void inviteContact(const char* email, const char* message, int action, MegaRequestListener* listener = NULL);
         void replyContactRequest(MegaContactRequest *request, int action, MegaRequestListener* listener = NULL);
         void respondContactRequest();
@@ -1627,7 +1626,7 @@ protected:
         virtual void checkfile_result(handle h, error e, byte* filekey, m_off_t size, m_time_t ts, m_time_t tm, string* filename, string* fingerprint, string* fileattrstring);
 
         // user invites/attributes
-        virtual void invite_result(error);
+        virtual void removecontact_result(error);
         virtual void putua_result(error);
         virtual void getua_result(error);
         virtual void getua_result(byte*, unsigned);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1948,16 +1948,16 @@ void CommandPurchaseCheckout::procresult()
     }
 }
 
-CommandUserRequest::CommandUserRequest(MegaClient* client, const char* m, visibility_t show)
+CommandRemoveContact::CommandRemoveContact(MegaClient* client, const char* m, visibility_t show)
 {
-    cmd("ur");
+    cmd("ur2");
     arg("u", m);
     arg("l", (int)show);
 
     tag = client->reqtag;
 }
 
-void CommandUserRequest::procresult()
+void CommandRemoveContact::procresult()
 {
     error e;
 
@@ -1971,7 +1971,7 @@ void CommandUserRequest::procresult()
         e = API_OK;
     }
 
-    client->app->invite_result(e);
+    client->app->removecontact_result(e);
 }
 
 CommandPutUA::CommandPutUA(MegaClient* client, const char *an, const byte* av, unsigned avl)

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1525,11 +1525,6 @@ bool MegaApi::usingHttpsOnly()
     return pImpl->usingHttpsOnly();
 }
 
-void MegaApi::addContact(const char* email, MegaRequestListener* listener)
-{
-    pImpl->addContact(email, listener);
-}
-
 void MegaApi::inviteContact(const char *email, const char *message, int action, MegaRequestListener *listener)
 {
     pImpl->inviteContact(email, message, action, listener);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6315,15 +6315,15 @@ void MegaClient::getpaymentmethods()
     reqs.add(new CommandGetPaymentMethods(this));
 }
 
-// add new contact (by e-mail address)
-error MegaClient::invite(const char* email, visibility_t show)
+// delete or block an existing contact
+error MegaClient::removecontact(const char* email, visibility_t show)
 {
-    if (!strchr(email, '@'))
+    if (!strchr(email, '@') || (show != HIDDEN && show != BLOCKED))
     {
         return API_EARGS;
     }
 
-    reqs.add(new CommandUserRequest(this, email, show));
+    reqs.add(new CommandRemoveContact(this, email, show));
 
     return API_OK;
 }


### PR DESCRIPTION
Additionally, this pull-requests:

- Updates the API request to remove/block contacts: `ur` --> `ur2`
- Removes the obsolete method to add contacts without invitation.