### PR TITLE
Set a non-repeating timer for cURL on Windows

### DIFF
--- a/include/mega/posix/meganet.h
+++ b/include/mega/posix/meganet.h
@@ -114,6 +114,7 @@ protected:
     bool curlipv6;
     bool reset;
     bool statechange;
+    bool dnsok;
     string dnsservers;
     curl_slist* contenttypejson;
     curl_slist* contenttypebinary;

--- a/include/mega/posix/meganet.h
+++ b/include/mega/posix/meganet.h
@@ -124,7 +124,7 @@ protected:
     void addcurlevents(WinWaiter *waiter);
     std::vector<SockInfo> aressockets;
     std::map<int, SockInfo> curlsockets;
-    m_time_t curltimeoutms;
+    m_time_t curltimeoutreset;
     m_time_t arestimeoutds;
 #endif
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -9072,7 +9072,7 @@ bool isDigit(const char *c)
 // returns 0 if i==j, +1 if i goes first, -1 if j goes first.
 int naturalsorting_compare (const char *i, const char *j)
 {
-    static u_int64_t maxNumber = (ULONG_MAX - 57) / 10; // 57 --> ASCII code for '9'
+    static uint64_t maxNumber = (ULONG_MAX - 57) / 10; // 57 --> ASCII code for '9'
 
     bool stringMode = true;
 
@@ -9114,9 +9114,7 @@ int naturalsorting_compare (const char *i, const char *j)
         }
         else    // we are comparing numbers on both strings
         {
-            char char_i, char_j;
-
-            u_int64_t number_i = 0;
+            uint64_t number_i = 0;
             unsigned int i_overflow_count = 0;
             while (*i && isDigit(i))
             {
@@ -9131,7 +9129,7 @@ int naturalsorting_compare (const char *i, const char *j)
                 }
             }
 
-            u_int64_t number_j = 0;
+            uint64_t number_j = 0;
             unsigned int j_overflow_count = 0;
             while (*j && isDigit(j))
             {
@@ -9162,12 +9160,12 @@ int naturalsorting_compare (const char *i, const char *j)
         }
     }
 
-    if(*j)
+    if (*j)
     {
         return -1;
     }
 
-    if(*i)
+    if (*i)
     {
         return 1;
     }

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -60,6 +60,7 @@ CurlHttpIO::CurlHttpIO()
     curlipv6 = data->features & CURL_VERSION_IPV6;
     LOG_debug << "IPv6 enabled: " << curlipv6;
 
+    dnsok = false;
     reset = false;
     statechange = false;
 
@@ -1192,7 +1193,7 @@ void CurlHttpIO::post(HttpReq* req, const char* data, unsigned len)
             LOG_info << "Using custom DNS servers: " << dnsservers;
             ares_set_servers_csv(ares, dnsservers.c_str());
         }
-        else if (!dnscache.size())
+        else if (!dnsok)
         {
             getMEGADNSservers(&dnsservers, false);
             ares_set_servers_csv(ares, dnsservers.c_str());
@@ -1492,6 +1493,7 @@ bool CurlHttpIO::doio()
 
                 if (req->status == REQ_SUCCESS)
                 {
+                    dnsok = true;
                     lastdata = Waiter::ds;
                 }
                 else


### PR DESCRIPTION
The value returned by cURL was being used to set a repeating timer on Windows.
According to the documentation of cURL, that is wrong.
With this fix, the CPU usage will be reduced.