### PR TITLE
Ensure that the upload token is received after the completion of uploads

### DIFF
--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -78,7 +78,7 @@ struct MEGA_API Transfer : public FileFingerprint
     handletransfer_map::iterator faputcompletion_it;
     
     // upload result
-    byte ultoken[NewNode::UPLOADTOKENLEN + 1];
+    byte *ultoken;
 
     // backlink to base
     MegaClient* client;

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -332,8 +332,15 @@ void Transfer::failed(error e, dstime timeleft)
         }
     }
 
-    if (defer && !(e == API_EOVERQUOTA && !timeleft))
+    if (type == PUT)
     {
+        chunkmacs.clear();
+        progresscompleted = 0;
+        pos = 0;
+    }
+
+    if (defer && !(e == API_EOVERQUOTA && !timeleft))
+    {        
         failcount++;
         delete slot;
 

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -271,8 +271,6 @@ void TransferSlot::doio(MegaClient* client)
                             }
 
                             LOG_debug << "Invalid upload token: " << reqs[i]->in;
-                            transfer->progresscompleted -= reqs[i]->size;
-                            transfer->chunkmacs[reqs[i]->pos].finished = false;
 
                             // fail with returned error
                             return transfer->failed((error)atoi(reqs[i]->in.c_str()));
@@ -309,7 +307,6 @@ void TransferSlot::doio(MegaClient* client)
                                 {
                                     LOG_warn << "MAC verification failed";
                                     transfer->chunkmacs.clear();
-                                    transfer->progresscompleted -= reqs[i]->size;
                                     return transfer->failed(API_EKEY);
                                 }
                             }

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -266,6 +266,7 @@ void TransferSlot::doio(MegaClient* client)
                                 else
                                 {
                                     delete [] transfer->ultoken;
+                                    transfer->ultoken = NULL;
                                 }
                             }
 


### PR DESCRIPTION
If it isn't received, the upload fails and a notification is sent
The changes include compatibility with transfer resumption