### PR TITLE
Skip restoration of file attributes

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -90,9 +90,12 @@ void HttpReqCommandPutFA::procresult()
                         (n->attrs.map.find('f') == n->attrs.map.end() || n->attrs.map['f'] != me64) )
                 {
                     LOG_debug << "Restoration of file attributes is not allowed for current user (" << me64 << ").";
-
                     n->attrs.map['f'] = me64;
+
+                    int creqtag = client->reqtag;
+                    client->reqtag = 0;
                     client->setattr(n);
+                    client->reqtag = creqtag;
                 }
             }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -78,6 +78,22 @@ void HttpReqCommandPutFA::procresult()
         }
         else
         {
+            if (e == API_EACCESS)
+            {
+                // create a custom attribute indicating thumbnail can't be restored from this account
+                Node *n = client->nodebyhandle(th);
+                if (n && n->attrs.map.find('f') == n->attrs.map.end() && client->checkaccess(n, FULL))
+                {
+                    char buf[12];
+                    Base64::btoa((const byte*)&client->me, MegaClient::USERHANDLE, buf);
+
+                    LOG_debug << "Restoration of file attributes is not allowed for current user (" << buf << ").";
+
+                    n->attrs.map['f'] = buf;
+                    client->setattr(n);
+                }
+            }
+
             status = REQ_SUCCESS;
             return client->app->putfa_result(th, type, e);
         }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -82,14 +82,16 @@ void HttpReqCommandPutFA::procresult()
             {
                 // create a custom attribute indicating thumbnail can't be restored from this account
                 Node *n = client->nodebyhandle(th);
-                if (n && n->attrs.map.find('f') == n->attrs.map.end() && client->checkaccess(n, FULL))
+
+                char me64[12];
+                Base64::btoa((const byte*)&client->me, MegaClient::USERHANDLE, me64);
+
+                if (n && client->checkaccess(n, FULL) &&
+                        (n->attrs.map.find('f') == n->attrs.map.end() || n->attrs.map['f'] != me64) )
                 {
-                    char buf[12];
-                    Base64::btoa((const byte*)&client->me, MegaClient::USERHANDLE, buf);
+                    LOG_debug << "Restoration of file attributes is not allowed for current user (" << me64 << ").";
 
-                    LOG_debug << "Restoration of file attributes is not allowed for current user (" << buf << ").";
-
-                    n->attrs.map['f'] = buf;
+                    n->attrs.map['f'] = me64;
                     client->setattr(n);
                 }
             }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -8565,11 +8565,16 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
 
                                     if (missingattr && checkaccess(ll->node, OWNER))
                                     {
-                                        LOG_debug << "Restoring missing attributes: " << ll->name;
-                                        string localpath;
-                                        ll->getlocalpath(&localpath);
-                                        SymmCipher*symmcipher = ll->node->nodecipher();
-                                        gfx->gendimensionsputfa(NULL, &localpath, ll->node->nodehandle, symmcipher, missingattr);
+                                        char me64[12];
+                                        Base64::btoa((const byte*)&me, MegaClient::USERHANDLE, me64);
+                                        if (ll->node->attrs.map.find('f') == ll->node->attrs.map.end() || ll->node->attrs.map['f'] != me64)
+                                        {
+                                            LOG_debug << "Restoring missing attributes: " << ll->name;
+                                            string localpath;
+                                            ll->getlocalpath(&localpath);
+                                            SymmCipher*symmcipher = ll->node->nodecipher();
+                                            gfx->gendimensionsputfa(NULL, &localpath, ll->node->nodehandle, symmcipher, missingattr);
+                                        }
                                     }
                                 }
                                 */

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -427,6 +427,7 @@ void Transfer::complete()
         int missingattr = 0;
         char me64[12];
         Base64::btoa((const byte*)&client->me, MegaClient::USERHANDLE, me64);
+        set<handle> nodes;
 
         if (!transient_error)
         {
@@ -435,8 +436,12 @@ void Transfer::complete()
             {
                 if ((*it)->hprivate && !(*it)->hforeign && (n = client->nodebyhandle((*it)->h)))
                 {
-                    if (client->gfx && client->gfx->isgfx(&(*it)->localname))
+                    if (client->gfx && client->gfx->isgfx(&(*it)->localname) &&
+                            nodes.find(n->nodehandle) == nodes.end() &&    // this node hasn't been processed yet
+                            client->checkaccess(n, FULL))
                     {
+                        nodes.insert(n->nodehandle);
+
                         // check for missing imagery
                         if (!n->hasfileattribute(GfxProc::THUMBNAIL120X120)) missingattr |= 1 << GfxProc::THUMBNAIL120X120;
                         if (!n->hasfileattribute(GfxProc::PREVIEW1000x1000)) missingattr |= 1 << GfxProc::PREVIEW1000x1000;

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -437,7 +437,7 @@ void Transfer::complete()
                 {
                     if (client->gfx && client->gfx->isgfx(&(*it)->localname) &&
                             nodes.find(n->nodehandle) == nodes.end() &&    // this node hasn't been processed yet
-                            client->checkaccess(n, FULL))
+                            client->checkaccess(n, OWNER))
                     {
                         int missingattr = 0;
                         nodes.insert(n->nodehandle);

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -424,7 +424,6 @@ void Transfer::complete()
 #endif
         delete fa;
 
-        int missingattr = 0;
         char me64[12];
         Base64::btoa((const byte*)&client->me, MegaClient::USERHANDLE, me64);
         set<handle> nodes;
@@ -440,6 +439,7 @@ void Transfer::complete()
                             nodes.find(n->nodehandle) == nodes.end() &&    // this node hasn't been processed yet
                             client->checkaccess(n, FULL))
                     {
+                        int missingattr = 0;
                         nodes.insert(n->nodehandle);
 
                         // check for missing imagery


### PR DESCRIPTION
When a node was copied/imported from another account, the new owner
cannot upload file attributes (only the former uploader of the file is
allowed to).

To avoid recurrent tries of restoration, the node is tagged with a
custom attribute, 'f', containing the own userhandle. In the future,
when missing attributes are detected, before attempting to restore them,
this attribute is checked.