### PR TITLE
Case-sensitive fopen for reading on Windows

### DIFF
--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -190,7 +190,7 @@ bool WinFileAccess::fopen(string* name, bool read, bool write)
     else
     {
         HANDLE  h = FindFirstFileExW((LPCWSTR)name->data(), FindExInfoStandard, &fad,
-                             FindExSearchNameMatch, NULL, FIND_FIRST_EX_CASE_SENSITIVE);
+                             FindExSearchNameMatch, NULL, 0);
 
         if (h == INVALID_HANDLE_VALUE)
         {

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -225,7 +225,9 @@ bool WinFileAccess::fopen(string* name, bool read, bool write)
             }
 
             if (memcmp(filename, fad.cFileName, filenamesize < sizeof(fad.cFileName) ? filenamesize : sizeof(fad.cFileName))
-                    && (filenamesize > sizeof(fad.cAlternateFileName) || memcmp(filename, fad.cAlternateFileName, filenamesize)))
+                    && (filenamesize > sizeof(fad.cAlternateFileName) || memcmp(filename, fad.cAlternateFileName, filenamesize))
+                    && !((filenamesize == 4 && !memcmp(filename, L".", 4))
+                         || (filenamesize == 6 && !memcmp(filename, L"..", 6))))
             {
                 LOG_warn << "fopen failed due to invalid case";
                 retry = false;

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -207,13 +207,13 @@ bool WinFileAccess::fopen(string* name, bool read, bool write)
         do {
             filename -= sizeof(wchar_t);
             filenamesize += sizeof(wchar_t);
-        } while(filename >= name->data() && memcmp(L"\\", filename, sizeof(wchar_t)));
+        } while (filename >= name->data() && memcmp(L"\\", filename, sizeof(wchar_t)));
 
         if (filename >= name->data() && filenamesize > sizeof(wchar_t))
         {
             filename += sizeof(wchar_t);
-            if (memcmp(filename, fad.cFileName, filenamesize < MAX_PATH ? filenamesize : MAX_PATH)
-                    && memcmp(filename, fad.cAlternateFileName, filenamesize < 14 ? filenamesize : 14))
+            if (memcmp(filename, fad.cFileName, filenamesize < sizeof(fad.cFileName) ? filenamesize : sizeof(fad.cFileName))
+                    && (filenamesize > sizeof(fad.cAlternateFileName) || memcmp(filename, fad.cAlternateFileName, filenamesize)))
             {
                 LOG_warn << "fopen failed due to invalid case";
                 retry = false;

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -200,27 +200,39 @@ bool WinFileAccess::fopen(string* name, bool read, bool write)
             name->resize(name->size() - added - 1);
             return false;
         }
-        FindClose(h);
 
         const char *filename = name->data() + name->size() - 1;
         int filenamesize = 0;
         do {
             filename -= sizeof(wchar_t);
             filenamesize += sizeof(wchar_t);
-        } while(filename >= name->data() && memcmp(L"\\", filename, sizeof(wchar_t)));
+        } while (filename >= name->data() && memcmp(L"\\", filename, sizeof(wchar_t)));
 
         if (filename >= name->data() && filenamesize > sizeof(wchar_t))
         {
             filename += sizeof(wchar_t);
-            if (memcmp(filename, fad.cFileName, filenamesize < MAX_PATH ? filenamesize : MAX_PATH)
-                    && memcmp(filename, fad.cAlternateFileName, filenamesize < 14 ? filenamesize : 14))
+            bool found = false;
+
+            do
+            {
+                if (!memcmp(filename, fad.cFileName, filenamesize < MAX_PATH ? filenamesize : MAX_PATH)
+                        || !memcmp(filename, fad.cAlternateFileName, filenamesize < 14 ? filenamesize : 14))
+                {
+                    found = true;
+                    break;
+                }
+            } while (FindNextFileW(h, &fad));
+
+            if (!found)
             {
                 LOG_warn << "fopen failed due to invalid case";
                 retry = false;
                 name->resize(name->size() - added - 1);
+                FindClose(h);
                 return false;
             }
         }
+        FindClose(h);
 
         // ignore symlinks - they would otherwise be treated as moves
         // also, ignore some other obscure filesystem object categories
@@ -252,13 +264,18 @@ bool WinFileAccess::fopen(string* name, bool read, bool write)
                         read ? OPEN_EXISTING : OPEN_ALWAYS,
                         &ex);
 #else
+    DWORD flags = (type == FOLDERNODE) ? FILE_FLAG_BACKUP_SEMANTICS : 0;
+    if (read)
+    {
+        flags |= FILE_FLAG_POSIX_SEMANTICS;
+    }
+
     hFile = CreateFileW((LPCWSTR)name->data(),
                         read ? GENERIC_READ : GENERIC_WRITE,
                         FILE_SHARE_WRITE | FILE_SHARE_READ,
                         NULL,
                         read ? OPEN_EXISTING : OPEN_ALWAYS,
-                        (type == FOLDERNODE) ? FILE_FLAG_BACKUP_SEMANTICS : 0,
-                        NULL);
+                        flags, NULL);
 #endif
 
     name->resize(name->size() - added - 1);


### PR DESCRIPTION
WIth this pull request, fopen refuses to open a file for reading if the name of the local file doesn't exactly match (including case) the provided name.

This prevents a sync bug that detects local renames that really don't exist when there are queued filesystem notifications for a file that has been renamed changing only the case of letters.

Due to this problem, action packets informing about these renames can lead the SDK to send new commands modifying the same node. That can cause a storm of API commands if several SDK instances are syncing the same folder at once.