### PR TITLE
Remove shares

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -242,7 +242,8 @@ public:
 class MEGA_API CommandMoveNode : public Command
 {
     handle h;
-    handle pp;
+    handle pp;  // previous parent
+    handle np;  // new parent
     bool syncop;
     syncdel_t syncdel;
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1833,6 +1833,19 @@ void CommandSetPendingContact::procresult()
             {
                 pcr->changed.deleted = true;
                 client->notifypcr(pcr);
+
+                // remove pending shares related to the deleted PCR
+                Node *n;
+                for (node_map::iterator it = client->nodes.begin(); it != client->nodes.end(); it++)
+                {
+                    n = it->second;
+                    if (n->pendingshares && n->pendingshares->find(pcr->id) != n->pendingshares->end())
+                    {
+                        client->newshares.push_back(
+                                    new NewShare(n->nodehandle, 1, n->owner, ACCESS_UNKNOWN,
+                                                 0, NULL, NULL, pcr->id, false));
+                    }
+                }
             }
         }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1175,6 +1175,8 @@ void CommandMoveNode::procresult()
                                                         0, NULL, NULL, UNDEF, false));
                     }
                 }
+
+                client->mergenewshares(1);
             }
         }
 
@@ -1846,6 +1848,8 @@ void CommandSetPendingContact::procresult()
                                                  0, NULL, NULL, pcr->id, false));
                     }
                 }
+
+                client->mergenewshares(1);
             }
         }
 


### PR DESCRIPTION
 - Remove shares and pending shares when a node is moved into Rubbish (ignoring AP due to the `i` element requires to apply changes upon response of the movement request)
- Remove pending shares when a PCR is deleted (ignoring AP du to the `i` element requires to apply changes upon response of the deletion request)

Note: this PR will be complete once API fix the AP sent out when a pending share is moved into Rubbish, since currently it's sending the AP to remove a share, not a pending share (`s` vs. `s2` including the ID of the PCR)