### PR TITLE
Fix folder plink

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -881,16 +881,6 @@ class MegaNode
          */
         virtual std::string* getPublicAuth();
 
-        /**
-         * @brief Return the share key of this noe
-         *
-         * The MegaNode object retains the ownership of the returned pointer. It will be valid until the deletion
-         * of the MegaNode object.
-         *
-         * @return The key used to share this node.
-         */
-        virtual std::string *getSharekey();
-
 #ifdef ENABLE_SYNC
         /**
          * @brief Returns true if this node was deleted from the MEGA account by the

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -883,6 +883,16 @@ class MegaNode
          */
         virtual std::string* getPublicAuth();
 
+        /**
+         * @brief Return the share key of this noe
+         *
+         * The MegaNode object retains the ownership of the returned pointer. It will be valid until the deletion
+         * of the MegaNode object.
+         *
+         * @return The key used to share this node.
+         */
+        virtual std::string *getSharekey();
+
 #ifdef ENABLE_SYNC
         /**
          * @brief Returns true if this node was deleted from the MEGA account by the

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -286,6 +286,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
             bool foreign : 1;
         };
         PublicLink *plink;
+        std::string sharekey;   // for plinks of folders
 
 #ifdef ENABLE_SYNC
         bool syncdeleted;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -248,7 +248,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
         virtual bool isShared();
         virtual bool isOutShare();
         virtual bool isInShare();
-        virtual std::string* getSharekey();
+        std::string* getSharekey();
 
 
 #ifdef ENABLE_SYNC

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -248,6 +248,8 @@ class MegaNodePrivate : public MegaNode, public Cachable
         virtual bool isShared();
         virtual bool isOutShare();
         virtual bool isInShare();
+        virtual std::string* getSharekey();
+
 
 #ifdef ENABLE_SYNC
         virtual bool isSyncDeleted();

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -288,7 +288,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
             bool foreign : 1;
         };
         PublicLink *plink;
-        std::string sharekey;   // for plinks of folders
+        std::string *sharekey;   // for plinks of folders
 
 #ifdef ENABLE_SYNC
         bool syncdeleted;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -382,6 +382,11 @@ string *MegaNode::getPublicAuth()
     return NULL;
 }
 
+string *MegaNode::getSharekey()
+{
+    return NULL;
+}
+
 #ifdef ENABLE_SYNC
 bool MegaNode::isSyncDeleted()
 {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -382,11 +382,6 @@ string *MegaNode::getPublicAuth()
     return NULL;
 }
 
-string *MegaNode::getSharekey()
-{
-    return NULL;
-}
-
 #ifdef ENABLE_SYNC
 bool MegaNode::isSyncDeleted()
 {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -599,6 +599,11 @@ char *MegaNodePrivate::getBase64Key()
         key = new char[FOLDERNODEKEYLENGTH*4/3+3];
         memcpy(key, sharekey.data(), FOLDERNODEKEYLENGTH*4/3+3);
     }
+    else
+    {
+        key = new char;
+        key[0] = 0;
+    }
 
     return key;
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -962,6 +962,7 @@ MegaNodePrivate::~MegaNodePrivate()
     delete [] fingerprint;
     delete customAttrs;
     delete plink;
+    delete sharekey;
 }
 
 MegaUserPrivate::MegaUserPrivate(User *user) : MegaUser()

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -138,6 +138,11 @@ MegaNodePrivate::MegaNodePrivate(MegaNode *node)
     if (node->isExported())
     {
         this->plink = new PublicLink(node->getPublicHandle(), node->getExpirationTime(), node->isTakenDown());
+
+        if (type == FOLDERNODE)
+        {
+            this->sharekey = *node->getSharekey();
+        }
     }
     else
     {
@@ -285,6 +290,11 @@ MegaNodePrivate::MegaNodePrivate(Node *node)
 
         this->sharekey.assign(key, sizeof key);
     }
+}
+
+string* MegaNodePrivate::getSharekey()
+{
+    return &sharekey;
 }
 
 MegaNode *MegaNodePrivate::copy()

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -141,7 +141,8 @@ MegaNodePrivate::MegaNodePrivate(MegaNode *node)
 
         if (type == FOLDERNODE)
         {
-            this->sharekey = *node->getSharekey();
+            MegaNodePrivate *n = dynamic_cast<MegaNodePrivate *>(node);
+            this->sharekey = n ? *n->getSharekey() : "";
         }
     }
     else

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -587,6 +587,7 @@ string *MegaNodePrivate::getNodeKey()
 char *MegaNodePrivate::getBase64Key()
 {
     char *key = NULL;
+    size_t fnklen_ascii = FOLDERNODEKEYLENGTH * 4 / 3 + 3;
 
     // the key
     if (type == FILENODE && nodekey.size() >= FILENODEKEYLENGTH)
@@ -594,14 +595,14 @@ char *MegaNodePrivate::getBase64Key()
         key = new char[FILENODEKEYLENGTH*4/3+3];
         Base64::btoa((const byte*)nodekey.data(),FILENODEKEYLENGTH, key);
     }
-    else if (type == FOLDERNODE)
+    else if (type == FOLDERNODE && sharekey.size() >= fnklen_ascii)
     {
-        key = new char[FOLDERNODEKEYLENGTH*4/3+3];
-        memcpy(key, sharekey.data(), FOLDERNODEKEYLENGTH*4/3+3);
+        key = new char[fnklen_ascii];
+        memcpy(key, sharekey.data(), fnklen_ascii);
     }
     else
     {
-        key = new char;
+        key = new char[1];
         key[0] = 0;
     }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -140,7 +140,9 @@ MegaNodePrivate::MegaNodePrivate(MegaNode *node)
         this->plink = new PublicLink(node->getPublicHandle(), node->getExpirationTime(), node->isTakenDown());
     }
     else
+    {
         this->plink = NULL;
+    }
 
     if (node->hasCustomAttrs())
     {
@@ -276,6 +278,13 @@ MegaNodePrivate::MegaNodePrivate(Node *node)
     this->outShares = (node->outshares) ? (node->outshares->size() > 1 || node->outshares->begin()->second->user) : false;
     this->inShare = (node->inshare != NULL) && !node->parent;
     this->plink = node->plink ? new PublicLink(node->plink) : NULL;
+    if (plink && type == FOLDERNODE && node->sharekey)
+    {
+        char key[FOLDERNODEKEYLENGTH*4/3+3];
+        Base64::btoa(node->sharekey->key, FOLDERNODEKEYLENGTH, key);
+
+        this->sharekey.assign(key, sizeof key);
+    }
 }
 
 MegaNode *MegaNodePrivate::copy()
@@ -574,6 +583,11 @@ char *MegaNodePrivate::getBase64Key()
     {
         key = new char[FILENODEKEYLENGTH*4/3+3];
         Base64::btoa((const byte*)nodekey.data(),FILENODEKEYLENGTH, key);
+    }
+    else if (type == FOLDERNODE)
+    {
+        key = new char[FOLDERNODEKEYLENGTH*4/3+3];
+        memcpy(key, sharekey.data(), FOLDERNODEKEYLENGTH*4/3+3);
     }
 
     return key;
@@ -8811,12 +8825,19 @@ void MegaApiImpl::exportnode_result(handle h, handle ph)
         // the key
         if (n->type == FILENODE)
         {
-            if(n->nodekey.size()>=FILENODEKEYLENGTH)
+            if(n->nodekey.size() >= FILENODEKEYLENGTH)
+            {
                 Base64::btoa((const byte*)n->nodekey.data(),FILENODEKEYLENGTH,key);
+            }
             else
+            {
                 key[0]=0;
+            }
         }
-        else if (n->sharekey) Base64::btoa(n->sharekey->key,FOLDERNODEKEYLENGTH,key);
+        else if (n->sharekey)
+        {
+            Base64::btoa(n->sharekey->key,FOLDERNODEKEYLENGTH,key);
+        }
         else
         {
             fireOnRequestFinish(request, MegaError(MegaError::API_EKEY));

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1292,10 +1292,11 @@ TEST_F(SdkTest, SdkTestContacts)
  * - Revoke the access to the share
  * - Share a folder with a non registered email
  * - Check the correctness of the pending outgoing share
- * - Create a public link
- * - Import a public link
- * - Get a node from public link
+ * - Create a file public link
+ * - Import a file public link
+ * - Get a node from a file public link
  * - Remove a public link
+ * - Create a folder public link
  */
 TEST_F(SdkTest, SdkTestShares)
 {
@@ -1501,7 +1502,7 @@ TEST_F(SdkTest, SdkTestShares)
     delete n;
 
 
-    // --- Create a public link ---
+    // --- Create a file public link ---
 
     MegaNode *nfile1 = megaApi[0]->getNodeByHandle(hfile1);
 
@@ -1528,7 +1529,7 @@ TEST_F(SdkTest, SdkTestShares)
     ASSERT_FALSE(nfile1->isExpired()) << "Public link is expired, it mustn't";
 
 
-    // --- Import a public link ---
+    // --- Import a file public link ---
 
     ASSERT_NO_FATAL_FAILURE( importPublicLink(link, rootnode) );
 
@@ -1538,7 +1539,7 @@ TEST_F(SdkTest, SdkTestShares)
     ASSERT_EQ(rootnode->getHandle(), nimported->getParentHandle()) << "Imported file in wrong path";
 
 
-    // --- Get node from public link ---
+    // --- Get node from file public link ---
 
     ASSERT_NO_FATAL_FAILURE( getPublicNode(link) );
 
@@ -1554,6 +1555,35 @@ TEST_F(SdkTest, SdkTestShares)
     ASSERT_FALSE(nfile1->isPublic()) << "Public link removal failed (still public)";
 
     delete nimported;
+
+
+    // --- Create a folder public link ---
+
+    MegaNode *nfolder1 = megaApi[0]->getNodeByHandle(hfolder1);
+
+    ASSERT_NO_FATAL_FAILURE( createPublicLink(nfolder1) );
+    // The created link is stored in this->link at onRequestFinish()
+
+    delete nfolder1;
+
+    // Get a fresh snapshot of the node and check it's actually exported
+    nfolder1 = megaApi[0]->getNodeByHandle(hfolder1);
+    ASSERT_TRUE(nfolder1->isExported()) << "Node is not exported, must be exported";
+    ASSERT_FALSE(nfolder1->isTakenDown()) << "Public link is taken down, it mustn't";
+
+    delete nfolder1;
+
+    oldLink = link;
+    link = "";
+    nfolder1 = megaApi[0]->getNodeByHandle(hfolder1);
+    ASSERT_STREQ(oldLink.c_str(), nfolder1->getPublicLink()) << "Wrong public link from MegaNode";
+
+    // Regenerate the same link should not trigger a new request
+    ASSERT_NO_FATAL_FAILURE( createPublicLink(nfolder1) );
+    ASSERT_STREQ(oldLink.c_str(), link.c_str()) << "Wrong public link after link update";
+
+    delete nfolder1;
+
 }
 
 #ifdef ENABLE_CHAT


### PR DESCRIPTION
`MegaNode::getPublicLink()` needs work for folder public links. Currently, only the key for file public links is available. This branch adds the key for folders too.

Furthermore, it protects `getBase64key()` to not return NULL, but empty string.