### PR TITLE
Set visibility upon response of CommandRemoveContact()

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -184,6 +184,9 @@ public:
 // set visibility
 class MEGA_API CommandRemoveContact : public Command
 {
+    string email;
+    visibility_t v;
+
 public:
     void procresult();
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2178,6 +2178,9 @@ void CommandPurchaseCheckout::procresult()
 
 CommandRemoveContact::CommandRemoveContact(MegaClient* client, const char* m, visibility_t show)
 {
+    this->email = m ? m : "";
+    this->v = show;
+
     cmd("ur2");
     arg("u", m);
     arg("l", (int)show);
@@ -2197,6 +2200,12 @@ void CommandRemoveContact::procresult()
     {
         client->json.storeobject();
         e = API_OK;
+
+        User *u = client->finduser(email.c_str());
+        if (u)
+        {
+            u->show = v;
+        }
     }
 
     client->app->removecontact_result(e);

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1185,11 +1185,9 @@ TEST_F(SdkTest, SdkTestContacts)
 
     string firstname = "My firstname";
 
-    userUpdated[0] = userUpdated[1] = false;
+    userUpdated[1] = false;
     ASSERT_NO_FATAL_FAILURE( setUserAttribute(MegaApi::USER_ATTR_FIRSTNAME, firstname));
     ASSERT_TRUE( waitForResponse(&userUpdated[1]) )   // at the target side (auxiliar account)
-            << "User attribute update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&userUpdated[0]) )   // at the target side (main account)
             << "User attribute update not received after " << maxTimeout << " seconds";
 
 
@@ -1207,11 +1205,9 @@ TEST_F(SdkTest, SdkTestContacts)
 
     // --- Load avatar ---
 
-    userUpdated[0] = userUpdated[1] = false;
+    userUpdated[1] = false;
     ASSERT_NO_FATAL_FAILURE( setUserAttribute(MegaApi::USER_ATTR_AVATAR, AVATARSRC));
     ASSERT_TRUE( waitForResponse(&userUpdated[1]) )   // at the target side (auxiliar account)
-            << "User attribute update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&userUpdated[0]) )   // at the target side (main account)
             << "User attribute update not received after " << maxTimeout << " seconds";
 
 
@@ -1236,11 +1232,9 @@ TEST_F(SdkTest, SdkTestContacts)
 
     // --- Delete avatar ---
 
-    userUpdated[0] = userUpdated[1] = false;
+    userUpdated[1] = false;
     ASSERT_NO_FATAL_FAILURE( setUserAttribute(MegaApi::USER_ATTR_AVATAR, ""));
     ASSERT_TRUE( waitForResponse(&userUpdated[1]) )   // at the target side (auxiliar account)
-            << "User attribute update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&userUpdated[0]) )   // at the target side (main account)
             << "User attribute update not received after " << maxTimeout << " seconds";
 
 


### PR DESCRIPTION
Otherwise, apps retrieving the list of contacts right after the request
finishes may not see the change, since it currently relies on the AP
reception.