### PR TITLE
Chain share + link instead of send the in parallel

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -234,6 +234,7 @@ public:
 
     // export node link or remove existing exported link for this node
     error exportnode(Node*, int, m_time_t);
+    void getpubliclink(Node* n, int del, m_time_t ets); // auxiliar method to add req
 
     // add/delete sync
     error addsync(string*, const char*, string*, Node*, fsfp_t = 0, int = 0);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8390,9 +8390,22 @@ void MegaApiImpl::share_result(error e)
     if(!request || ((request->getType() != MegaRequest::TYPE_EXPORT) &&
                     (request->getType() != MegaRequest::TYPE_SHARE))) return;
 
-    //exportnode_result will be called to end the request.
-	if(request->getType() == MegaRequest::TYPE_EXPORT)
+    // exportnode_result will be called to end the request.
+    if(!e && request->getType() == MegaRequest::TYPE_EXPORT)
+    {
+        Node* node = client->nodebyhandle(request->getNodeHandle());
+        if(!node)
+        {
+            fireOnRequestFinish(request, API_EARGS);
+            return;
+        }
+
+        if (request->getAccess())
+        {
+            client->getpubliclink(node, !request->getAccess(), request->getNumber());
+        }
 		return;
+    }
 
     fireOnRequestFinish(request, megaError);
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8391,19 +8391,22 @@ void MegaApiImpl::share_result(error e)
                     (request->getType() != MegaRequest::TYPE_SHARE))) return;
 
     // exportnode_result will be called to end the request.
-    if(!e && request->getType() == MegaRequest::TYPE_EXPORT)
+    if (!e && request->getType() == MegaRequest::TYPE_EXPORT)
     {
         Node* node = client->nodebyhandle(request->getNodeHandle());
-        if(!node)
+        if (!node)
         {
-            fireOnRequestFinish(request, API_EARGS);
+            fireOnRequestFinish(request, API_ENOENT);
             return;
         }
 
-        if (request->getAccess())
+        if (!request->getAccess())
         {
-            client->getpubliclink(node, !request->getAccess(), request->getNumber());
+            fireOnRequestFinish(request, API_EINTERNAL);
+            return;
         }
+
+        client->getpubliclink(node, false, request->getNumber());
 		return;
     }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7328,7 +7328,7 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
     switch (n->type)
     {
     case FILENODE:
-        reqs.add(new CommandSetPH(this, n, del, ets));
+        getpubliclink(n, del, ets);
         break;
 
     case FOLDERNODE:
@@ -7336,14 +7336,14 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
         {
             // deletion of outgoing share also deletes the link automatically
             // need to first remove the link and then the share
-            reqs.add(new CommandSetPH(this, n, del, ets));
+            getpubliclink(n, del, ets);
             setshare(n, NULL, ACCESS_UNKNOWN);
         }
         else
         {
             // exporting folder - need to create share first
             setshare(n, NULL, RDONLY);
-            reqs.add(new CommandSetPH(this, n, del, ets));
+            // getpubliclink() is called as _result() of the share
         }
 
         break;
@@ -7353,6 +7353,11 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
     }
 
     return API_OK;
+}
+
+void MegaClient::getpubliclink(Node* n, int del, m_time_t ets)
+{
+    reqs.add(new CommandSetPH(this, n, del, ets));
 }
 
 // open exported file link


### PR DESCRIPTION
This helps to solve the issue of the server keeping the sharekey of
deleted shares, which makes the initial share request to return the old
sharekey and the folder link creation to fail. This way, the share is
retried first with the old sharekey and later, the link creation works.