### PR TITLE
Ability to set binary user attribute in megacli

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -3017,6 +3017,14 @@ static void process_line(char* l)
 
                                     return;
                                 }
+                                else if (words[2] == "set64")
+                                {
+                                    byte value[words[3].size() * 3 / 4 + 3];
+                                    int valuelen = Base64::atob(words[3].data(), value, sizeof(value));
+                                    client->putua(attrtype, value, valuelen);
+
+                                    return;
+                                }
                                 else if (words[2] == "load")
                                 {
                                     string data, localpath;


### PR DESCRIPTION
Some new user attributes store binary data, so the `putua <attrname> set <attrvalue>` doesn't work because it expects plain ASCII strings.
This commit adds `putua <attrname> set64 <attrvalue64>`, which converts the value from base64 to binary before putting the new user attr value.