### PR TITLE
Android cross compile autotools fix

### DIFF
--- a/contrib/build_android.sh
+++ b/contrib/build_android.sh
@@ -77,4 +77,4 @@ export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib -L${TOOLCHAIN_LIB}"
 
 opts="--host=arm-linux-androideabi --with-sysroot=$SYSROOT "
 
-./contrib/build_sdk.sh -n -y -r -f -x "$opts"
+./contrib/build_sdk.sh -q -n -y -r -f -x "$opts"

--- a/contrib/build_android32.sh
+++ b/contrib/build_android32.sh
@@ -77,4 +77,4 @@ export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib -L${TOOLCHAIN_LIB}"
 
 opts="--host=arm-linux-androideabi --with-sysroot=$SYSROOT "
 
-./contrib/build_sdk.sh -n -y -r -f -x "$opts"
+./contrib/build_sdk.sh -q -n -y -r -f -x "$opts"

--- a/include/mega.h
+++ b/include/mega.h
@@ -77,7 +77,4 @@
 #include "mega/gfx/freeimage.h"
 #include "mega/gfx/GfxProcCG.h"
 
-#include <cctype>
-#include <locale>
-
 #endif

--- a/include/mega.h
+++ b/include/mega.h
@@ -77,4 +77,7 @@
 #include "mega/gfx/freeimage.h"
 #include "mega/gfx/GfxProcCG.h"
 
+#include <cctype>
+#include <locale>
+
 #endif

--- a/include/mega/posix/megasys.h
+++ b/include/mega/posix/megasys.h
@@ -50,7 +50,7 @@
     #include <stddef.h>
 #endif
 
-#include <stdio.h>
+#include <ctype.h>
 
 #ifdef HAVE_STDLIB_H
     #include <stdlib.h>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -226,7 +226,7 @@ bool HashSignature::check(AsymmCipher* pubk, const byte* sig, unsigned len)
     if (size < h.size())
     {
         // left-pad with 0
-        s.insert(0, h.size() - size, 0);
+        s.insert((size_t)0, h.size() - size, 0);
         s.resize(h.size());
     }
 
@@ -314,8 +314,8 @@ bool PayCrypter::rsaEncryptKeys(const string *cleartext, const byte *pubkdata, i
 
     //Complete the result (2-byte header + RSA result)
     int reslen = result->size();
-    result->insert(0, 1, (byte)(reslen >> 8));
-    result->insert(1, 1, (byte)(reslen));
+    result->insert((size_t)0, 1, (byte)(reslen >> 8));
+    result->insert((size_t)1, 1, (byte)(reslen));
     return true;
 }
 
@@ -443,7 +443,7 @@ string * TLVstore::tlvRecordsToContainer()
 
 string TLVstore::get(string type)
 {
-    return tlv.at(type);
+    return tlv[type];
 }
 
 const TLV_map * TLVstore::getMap() const


### PR DESCRIPTION
This PR is not sufficient: cryptopp v 5.6.2 has a failure that prevents compilation. It is corrected in 5.6.3. Nevertheless, this PR doesn't changes cryptopp to v5.6.3 because:
1) 5.6.3 not fully tested in other compilations/executions.
2) 5.6.3 has a problem that prevents autotools headers cheking when cross-compiling for android (https://github.com/weidai11/cryptopp/issues/222). This has been corrected in cryptopp's github repo (https://github.com/weidai11/cryptopp/commit/1e1762041738e695d52aa89c356853373b804030). It will not be released in a long while, in the meantime it could be tricked with: ``export CXXFLAGS="$CXXFLAGS -DCRYPTOPP_UNCAUGHT_EXCEPTION_AVAILABLE"``