### PR TITLE
Add support of .dylib files for Mac OS X

### DIFF
--- a/bindings/megaapi.i
+++ b/bindings/megaapi.i
@@ -24,8 +24,16 @@
                     try {
                         System.load(System.getProperty("user.dir") + "/libs/mega.dll");
                     } catch (UnsatisfiedLinkError e4) {
-                        System.err.println("Native code library failed to load. \n" + e1 + "\n" + e2 + "\n" + e3 + "\n" + e4);
-                        System.exit(1);
+                        try {
+                            System.load(System.getProperty("user.dir") + "/libmega.dylib");
+                        } catch (UnsatisfiedLinkError e5) {
+                            try {
+                                System.load(System.getProperty("user.dir") + "/libs/libmegajava.dylib");
+                            } catch (UnsatisfiedLinkError e6) {
+                                System.err.println("Native code library failed to load. \n" + e1 + "\n" + e2 + "\n" + e3 + "\n" + e4 + "\n" + e5 + "\n" + e6);
+                                System.exit(1);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Dear developers,
I found that this sdk was not support Mac OS X because of .dylib files. So I add few codes for fix issuse.