### PR TITLE
Fix the generation of thumbnails for jpg files with QT5

### DIFF
--- a/include/mega/gfx/qt.h
+++ b/include/mega/gfx/qt.h
@@ -48,6 +48,7 @@ class MEGA_API GfxProcQT : public GfxProc
     };
 
     QImageReader *image;
+    QString imagePath;
     int orientation;
 
     bool readbitmap(FileAccess*, string*, int);

--- a/src/gfx/qt.cpp
+++ b/src/gfx/qt.cpp
@@ -349,11 +349,11 @@ bool GfxProcQT::readbitmap(FileAccess*, string* localname, int)
 {
 #ifdef _WIN32
     localname->append("", 1);
-    QString imagePath = QString::fromWCharArray((wchar_t *)localname->c_str());
+    imagePath = QString::fromWCharArray((wchar_t *)localname->c_str());
     if(imagePath.startsWith(QString::fromUtf8("\\\\?\\")))
         imagePath = imagePath.mid(4);
 #else
-    QString imagePath = QString::fromUtf8(localname->c_str());
+    imagePath = QString::fromUtf8(localname->c_str());
 #endif
 
     image = readbitmapQT(w, h, orientation, imagePath);
@@ -362,14 +362,25 @@ bool GfxProcQT::readbitmap(FileAccess*, string* localname, int)
     localname->resize(localname->size()-1);
 #endif
 
-    return (image!=NULL);
+    return (image != NULL);
 }
 
 bool GfxProcQT::resizebitmap(int rw, int rh, string* jpegout)
 {
+    if (!image)
+    {
+        image = readbitmapQT(w, h, orientation, imagePath);
+        if (!image)
+        {
+            return false;
+        }
+    }
+
     QImage result = resizebitmapQT(image, orientation, w, h, rw, rh);
     if(result.isNull()) return false;
     jpegout->clear();
+    delete image;
+    image = NULL;
 
     //Remove transparency
     QImage finalImage(result.size(), QImage::Format_RGB32);
@@ -465,7 +476,12 @@ QImage GfxProcQT::resizebitmapQT(QImageReader *image, int orientation, int w, in
     }
 
     QImage result = image->read();
-    if(result.isNull()) return result;
+    if (result.isNull())
+    {
+        LOG_err << "Error reading image: " << image->errorString().toStdString();
+        return result;
+    }
+
     image->device()->seek(0);
 
     QTransform transform;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -9061,10 +9061,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                             // files have the same size and the same mtime (or the
                             // same fingerprint, if available): no action needed
                             if (!ll->checked)
-                            {
-                                // Restoration of missing attributes temporarily disabled
-                                // on synced folders
-                                /*
+                            {                                
                                 if (gfx && gfx->isgfx(&ll->localname))
                                 {
                                     int missingattr = 0;
@@ -9089,12 +9086,11 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                                             LOG_debug << "Restoring missing attributes: " << ll->name;
                                             string localpath;
                                             ll->getlocalpath(&localpath);
-                                            SymmCipher*symmcipher = ll->node->nodecipher();
+                                            SymmCipher *symmcipher = ll->node->nodecipher();
                                             gfx->gendimensionsputfa(NULL, &localpath, ll->node->nodehandle, symmcipher, missingattr);
                                         }
                                     }
                                 }
-                                */
 
                                 ll->checked = true;
                             }


### PR DESCRIPTION
It seems that the same QImageReader can't read twice the same JPG image so it's needed to create a new one.

The restoration of file attributes has been enabled again.