### PR TITLE
Fix ownerkey

### DIFF
--- a/include/mega/share.h
+++ b/include/mega/share.h
@@ -56,12 +56,12 @@ struct MEGA_API NewShare
 
     handle pending;
     bool upgrade_pending_to_full;
-    bool have_key, have_auth;
+    bool have_key, have_auth, remove_key;
 
     byte key[SymmCipher::BLOCKSIZE];
     byte auth[SymmCipher::BLOCKSIZE];
 
-    NewShare(handle, int, handle, accesslevel_t, m_time_t, const byte*, const byte* = NULL, handle = UNDEF, bool = false);
+    NewShare(handle, int, handle, accesslevel_t, m_time_t, const byte*, const byte* = NULL, handle = UNDEF, bool = false, bool = false);
 };
 } // namespace
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -146,7 +146,7 @@ void MegaClient::mergenewshare(NewShare *s, bool notify)
 
     if ((n = nodebyhandle(s->h)))
     {
-        if (!n->sharekey && s->have_key)
+        if (s->have_key && (!n->sharekey || memcmp(s->key, n->sharekey->key, SymmCipher::KEYLENGTH)))
         {
             // setting an outbound sharekey requires node authentication
             // unless coming from a trusted source (the local cache)
@@ -175,6 +175,14 @@ void MegaClient::mergenewshare(NewShare *s, bool notify)
 
             if (auth)
             {
+                if (n->sharekey)
+                {
+                    int creqtag = reqtag;
+                    reqtag = 0;
+                    sendevent(99424,"Replacing share key");
+                    reqtag = creqtag;
+                    delete n->sharekey;
+                }
                 n->sharekey = new SymmCipher(s->key);
                 skreceived = true;
             }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -220,7 +220,7 @@ void MegaClient::mergenewshare(NewShare *s, bool notify)
                 }
 
                 // Erase sharekey if no outgoing shares (incl pending) exist
-                if (!n->outshares && !n->pendingshares && s->remove_key)
+                if (s->remove_key && !n->outshares && !n->pendingshares)
                 {
                     rewriteforeignkeys(n);
 

--- a/src/share.cpp
+++ b/src/share.cpp
@@ -81,7 +81,7 @@ void Share::update(accesslevel_t a, m_time_t t, PendingContactRequest* pending)
 
 // coutgoing: < 0 - don't authenticate, > 0 - authenticate using handle auth
 NewShare::NewShare(handle ch, int coutgoing, handle cpeer, accesslevel_t caccess,
-                   m_time_t cts, const byte* ckey, const byte* cauth, handle cpending,bool cupgrade_pending_to_full)
+                   m_time_t cts, const byte* ckey, const byte* cauth, handle cpending,bool cupgrade_pending_to_full, bool okremoved)
 {
     h = ch;
     outgoing = coutgoing;
@@ -90,6 +90,7 @@ NewShare::NewShare(handle ch, int coutgoing, handle cpeer, accesslevel_t caccess
     ts = cts;
     pending = cpending;
     upgrade_pending_to_full = cupgrade_pending_to_full;
+    remove_key = okremoved;
 
     if (ckey)
     {


### PR DESCRIPTION
When a share is removed, in order for the participants to not lose cryptographic access to the not-know-yet nodes, the API retains the share secret. It created problems in the past when creating a public folder link (already deployed a hotfix).
When the share is removed by the owner and there's no more participants, the share secret should be effectively removed. This branch aims to forget the share secret only in those cases.