### PR TITLE
Add initialization to mutex constructor

### DIFF
--- a/contrib/QtCreator/megacli.files
+++ b/contrib/QtCreator/megacli.files
@@ -139,3 +139,5 @@
 ../../tests/sdktests.cpp
 ../../tests/sdk_test.h
 ../../tests/crypto_test.cpp
+../../src/thread/libuvthread.cpp
+../../include/mega/thread/libuvthread.h

--- a/include/mega/thread/cppthread.h
+++ b/include/mega/thread/cppthread.h
@@ -51,6 +51,7 @@ class CppMutex : public Mutex
 {
 public:
     CppMutex();
+    CppMutex(bool recursive);
     virtual void init(bool recursive);
     virtual void lock();
     virtual void unlock();

--- a/include/mega/thread/libuvthread.h
+++ b/include/mega/thread/libuvthread.h
@@ -50,6 +50,7 @@ class LibUVMutex : public Mutex
 {
 public:
     LibUVMutex();
+    LibUVMutex(bool recursive);
     virtual void init(bool recursive);
     virtual void lock();
     virtual void unlock();

--- a/include/mega/thread/posixthread.h
+++ b/include/mega/thread/posixthread.h
@@ -47,6 +47,7 @@ class PosixMutex : public Mutex
 {
 public:
     PosixMutex();
+    PosixMutex(bool recursive);
     virtual void init(bool recursive);
     virtual void lock();
     virtual void unlock();

--- a/include/mega/thread/qtthread.h
+++ b/include/mega/thread/qtthread.h
@@ -51,6 +51,7 @@ class QtMutex : public Mutex
 {
 public:
     QtMutex();
+    QtMutex(bool recursive);
     virtual void init(bool recursive);
     virtual void lock();
     virtual void unlock();

--- a/include/mega/thread/win32thread.h
+++ b/include/mega/thread/win32thread.h
@@ -49,6 +49,7 @@ class Win32Mutex : public Mutex
 {
 public:
     Win32Mutex();
+    Win32Mutex(bool recursive);
     virtual void init(bool recursive);
     virtual void lock();
     virtual void unlock();

--- a/src/thread/cppthread.cpp
+++ b/src/thread/cppthread.cpp
@@ -57,6 +57,14 @@ CppMutex::CppMutex()
     rmutex = NULL;
 }
 
+CppMutex::CppMutex(bool recursive)
+{
+    mutex = NULL;
+    rmutex = NULL;
+
+    init(recursive);
+}
+
 void CppMutex::init(bool recursive = true)
 {
     if (mutex || rmutex)

--- a/src/thread/libuvthread.cpp
+++ b/src/thread/libuvthread.cpp
@@ -64,6 +64,14 @@ LibUVMutex::LibUVMutex()
     count = NULL;
 }
 
+LibUVMutex::LibUVMutex(bool recursive)
+{
+    mutex = NULL;
+    count = NULL;
+
+    init(recursive);
+}
+
 void LibUVMutex::init(bool recursive)
 {
     mutex = new uv_mutex_t;

--- a/src/thread/posixthread.cpp
+++ b/src/thread/posixthread.cpp
@@ -53,6 +53,14 @@ PosixMutex::PosixMutex()
     attr = NULL;
 }
 
+PosixMutex::PosixMutex(bool recursive)
+{
+    mutex = NULL;
+    attr = NULL;
+
+    init(recursive);
+}
+
 void PosixMutex::init(bool recursive)
 {
     if (recursive)

--- a/src/thread/qtthread.cpp
+++ b/src/thread/qtthread.cpp
@@ -62,6 +62,14 @@ QtMutex::QtMutex()
     mutex = NULL;
 }
 
+QtMutex::QtMutex(bool recursive)
+{
+    mutex = NULL;
+
+    init(recursive);
+}
+
+
 void QtMutex::init(bool recursive)
 {
     if(recursive)

--- a/src/thread/win32thread.cpp
+++ b/src/thread/win32thread.cpp
@@ -60,6 +60,13 @@ Win32Mutex::Win32Mutex()
     InitializeCriticalSection(&mutex);
 }
 
+Win32Mutex::Win32Mutex(bool recursive)
+{
+    InitializeCriticalSection(&mutex);
+
+    init(recursive);        // just for correctness
+}
+
 void Win32Mutex::init(bool recursive)
 {
 


### PR DESCRIPTION
These changes are required for the branch `fix-gcm` of the chat project. Wait for merging until the MR!14 is merged.