### PR TITLE
Allow no-URL in `mcf` from gettree response

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7186,8 +7186,7 @@ void MegaClient::procmcf(JSON *j)
                     break;
 
                 case EOO:
-                    if (chatid != UNDEF && priv != PRIV_UNKNOWN && !url.empty()
-                            && shard != -1)
+                    if (chatid != UNDEF && priv != PRIV_UNKNOWN && shard != -1)
                     {
                         TextChat *chat = new TextChat();
                         chat->id = chatid;


### PR DESCRIPTION
API won't return the `url` anymore as part of the `mcf` element in the
fetchnodes response.