### PR TITLE
Fix a bug introduced by latest changes

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -16482,12 +16482,12 @@ MegaTextChatPrivate::MegaTextChatPrivate(const MegaTextChat *chat)
 {
     this->id = chat->getHandle();
     this->priv = chat->getOwnPrivilege();
-    this->url = chat->getUrl();
+    this->url = chat->getUrl() ? chat->getUrl() : "";
     this->shard = chat->getShard();
     this->peers = chat->getPeerList() ? chat->getPeerList()->copy() : NULL;
     this->group = chat->isGroup();
     this->ou = chat->getOriginatingUser();
-    this->title = chat->getTitle();
+    this->title = chat->getTitle() ? chat->getTitle() : "";
 }
 
 MegaTextChatPrivate::MegaTextChatPrivate(handle id, int priv, string url, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title)


### PR DESCRIPTION
Since now the returned value of MegaTextChat::getTitle/getUrl() can be
NULL, this checkup is mandatory.