### PR TITLE
Better management of integrity checks

### DIFF
--- a/include/mega/http.h
+++ b/include/mega/http.h
@@ -263,6 +263,9 @@ struct MEGA_API HttpReqXfer : public HttpReq
 // file chunk upload
 struct MEGA_API HttpReqUL : public HttpReqXfer
 {
+    // size (in bytes) of the CRC of uploaded chunks
+    static const int CRCSIZE;
+
     bool prepare(FileAccess*, const char*, SymmCipher*, chunkmac_map*, uint64_t, m_off_t, m_off_t);
 
     m_off_t transferred(MegaClient*);

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -98,6 +98,18 @@ struct MEGA_API Transfer : public FileFingerprint
     // previous wrong fingerprint
     FileFingerprint badfp;
 
+    // flag to know if prevmetamac is valid
+    bool prevmetamacvalid;
+
+    // previous wrong metamac
+    int64_t prevmetamac;
+
+    // flag to know if currentmetamac is valid
+    bool currentmetamacvalid;
+
+    // current wrong metamac
+    int64_t currentmetamac;
+
     // transfer state
     bool finished;
 

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -99,13 +99,13 @@ struct MEGA_API Transfer : public FileFingerprint
     FileFingerprint badfp;
 
     // flag to know if prevmetamac is valid
-    bool prevmetamacvalid;
+    bool hasprevmetamac;
 
     // previous wrong metamac
     int64_t prevmetamac;
 
     // flag to know if currentmetamac is valid
-    bool currentmetamacvalid;
+    bool hascurrentmetamac;
 
     // current wrong metamac
     int64_t currentmetamac;

--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -55,6 +55,9 @@ struct MEGA_API TransferSlot
     // number of consecutive errors
     unsigned errorcount;
 
+    // last error
+    error lasterror;
+
     // file attribute string
     string fileattrstring;
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -323,13 +323,13 @@ bool File::failed(error e)
 {
     if (e == API_EKEY)
     {
-        if (!transfer->currentmetamacvalid)
+        if (!transfer->hascurrentmetamac)
         {
             // several integrity check errors uploading chunks
             return transfer->failcount < 1;
         }
 
-        if (transfer->prevmetamacvalid && transfer->prevmetamac == transfer->currentmetamac)
+        if (transfer->hasprevmetamac && transfer->prevmetamac == transfer->currentmetamac)
         {
             // integrity check failed after download, two times with the same value
             return false;
@@ -337,8 +337,8 @@ bool File::failed(error e)
 
         // integrity check failed once, try again
         transfer->prevmetamac = transfer->currentmetamac;
-        transfer->prevmetamacvalid = true;
-        return true;
+        transfer->hasprevmetamac = true;
+        return transfer->failcount < 16;
     }
 
     return (e != API_EBLOCKED && e != API_ENOENT && e != API_EINTERNAL && transfer->failcount < 16)

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -321,8 +321,28 @@ void File::terminated()
 // failuresup to 16 times, except I/O errors (6 times)
 bool File::failed(error e)
 {
-    return (e != API_EKEY && e != API_EBLOCKED && e != API_ENOENT && e != API_EINTERNAL && transfer->failcount < 16) &&
-            !((e == API_EREAD || e == API_EWRITE) && transfer->failcount > 6);
+    if (e == API_EKEY)
+    {
+        if (!transfer->currentmetamacvalid)
+        {
+            // several integrity check errors uploading chunks
+            return transfer->failcount < 1;
+        }
+
+        if (transfer->prevmetamacvalid && transfer->prevmetamac == transfer->currentmetamac)
+        {
+            // integrity check failed after download, two times with the same value
+            return false;
+        }
+
+        // integrity check failed once, try again
+        transfer->prevmetamac = transfer->currentmetamac;
+        transfer->prevmetamacvalid = true;
+        return true;
+    }
+
+    return (e != API_EBLOCKED && e != API_ENOENT && e != API_EINTERNAL && transfer->failcount < 16)
+            && !((e == API_EREAD || e == API_EWRITE) && transfer->failcount > 6);
 }
 
 void File::displayname(string* dname)
@@ -435,17 +455,19 @@ void SyncFileGet::prepare()
 
 bool SyncFileGet::failed(error e)
 {
+    bool retry = File::failed(e);
+
     if (n->parent && n->parent->localnode)
     {
         n->parent->localnode->treestate(TREESTATE_PENDING);
 
-        if (e == API_EBLOCKED)
+        if (!retry && (e == API_EBLOCKED || e == API_EKEY))
         {
             n->parent->client->movetosyncdebris(n, n->parent->localnode->sync->inshare);
         }
     }
 
-    return File::failed(e);
+    return retry;
 }
 
 void SyncFileGet::progress()

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -913,6 +913,7 @@ void MegaClient::exec()
         {
             if ((*it)->failure)
             {
+                (*it)->lasterror = API_EFAILED;
                 (*it)->errorcount++;
                 (*it)->failure = false;
                 (*it)->lastdata = Waiter::ds;

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -41,6 +41,8 @@ Transfer::Transfer(MegaClient* cclient, direction_t ctype)
     tag = 0;
     slot = NULL;
     progresscompleted = 0;
+    prevmetamacvalid = false;
+    currentmetamacvalid = false;
     finished = false;
     lastaccesstime = 0;
     ultoken = NULL;
@@ -369,9 +371,10 @@ void Transfer::failed(error e, dstime timeleft)
 
     for (file_list::iterator it = files.begin(); it != files.end(); it++)
     {
-        if ((*it)->failed(e) && !defer)
+        if ((*it)->failed(e))
         {
             defer = true;
+            break;
         }
     }
 

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -41,8 +41,8 @@ Transfer::Transfer(MegaClient* cclient, direction_t ctype)
     tag = 0;
     slot = NULL;
     progresscompleted = 0;
-    prevmetamacvalid = false;
-    currentmetamacvalid = false;
+    hasprevmetamac = false;
+    hascurrentmetamac = false;
     finished = false;
     lastaccesstime = 0;
     ultoken = NULL;

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -338,7 +338,7 @@ void TransferSlot::doio(MegaClient* client)
                                 if (transfer->progresscompleted)
                                 {
                                     transfer->currentmetamac = macsmac(&transfer->chunkmacs);
-                                    transfer->currentmetamacvalid = true;
+                                    transfer->hascurrentmetamac = true;
                                 }
 
                                 // verify meta MAC

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -38,6 +38,7 @@ TransferSlot::TransferSlot(Transfer* ctransfer)
 
     lastdata = Waiter::ds;
     errorcount = 0;
+    lasterror = API_OK;
 
     failure = false;
     retrying = false;
@@ -217,7 +218,7 @@ void TransferSlot::doio(MegaClient* client)
 
     if (errorcount > 4)
     {
-        return transfer->failed(API_EFAILED);
+        return transfer->failed(lasterror);
     }
 
     for (int i = connections; i--; )
@@ -233,17 +234,12 @@ void TransferSlot::doio(MegaClient* client)
                 case REQ_SUCCESS:
                     lastdata = Waiter::ds;
                     transfer->lastaccesstime = time(NULL);
-                    transfer->progresscompleted += reqs[i]->size;
 
                     LOG_debug << "Chunk finished OK (" << transfer->type << ") Pos: " << transfer->pos
-                              << " Completed: " << transfer->progresscompleted << " of " << transfer->size;
+                              << " Completed: " << (transfer->progresscompleted + reqs[i]->size) << " of " << transfer->size;
 
                     if (transfer->type == PUT)
                     {
-                        errorcount = 0;
-                        transfer->failcount = 0;
-                        transfer->chunkmacs[reqs[i]->pos].finished = true;
-
                         // completed put transfers are signalled through the
                         // return of the upload token
                         if (reqs[i]->in.size())
@@ -271,6 +267,10 @@ void TransferSlot::doio(MegaClient* client)
 
                                 if (tokenOK)
                                 {
+                                    errorcount = 0;
+                                    transfer->failcount = 0;
+                                    transfer->chunkmacs[reqs[i]->pos].finished = true;
+                                    transfer->progresscompleted += reqs[i]->size;
                                     memcpy(transfer->filekey, transfer->key.key, sizeof transfer->key.key);
                                     ((int64_t*)transfer->filekey)[2] = transfer->ctriv;
                                     ((int64_t*)transfer->filekey)[3] = macsmac(&transfer->chunkmacs);
@@ -295,11 +295,23 @@ void TransferSlot::doio(MegaClient* client)
                                 }
                             }
 
-                            LOG_debug << "Invalid upload token: " << reqs[i]->in;
+                            LOG_debug << "Error uploading chunk: " << reqs[i]->in;
+                            error e = (error)atoi(reqs[i]->in.c_str());
+                            if (e == API_EKEY)
+                            {
+                                LOG_warn << "Integrity check failed";
+                                lasterror = e;
+                                errorcount++;
+                                reqs[i]->status = REQ_PREPARED;
+                                break;
+                            }
 
                             // fail with returned error
-                            return transfer->failed((error)atoi(reqs[i]->in.c_str()));
+                            return transfer->failed(e);
                         }
+
+                        transfer->chunkmacs[reqs[i]->pos].finished = true;
+                        transfer->progresscompleted += reqs[i]->size;
 
                         if (transfer->progresscompleted == transfer->size)
                         {
@@ -310,21 +322,31 @@ void TransferSlot::doio(MegaClient* client)
 
                             return transfer->failed(API_EINTERNAL);
                         }
+
+                        errorcount = 0;
+                        transfer->failcount = 0;
                     }
                     else
                     {
                         if (reqs[i]->size == reqs[i]->bufpos)
                         {
-                            errorcount = 0;
-                            transfer->failcount = 0;
-
                             reqs[i]->finalize(fa, &transfer->key, &transfer->chunkmacs, transfer->ctriv, 0, -1);
+                            transfer->progresscompleted += reqs[i]->size;
 
                             if (transfer->progresscompleted == transfer->size)
                             {
-                                // verify meta MAC
-                                if (!transfer->progresscompleted || (macsmac(&transfer->chunkmacs) == transfer->metamac))
+                                if (transfer->progresscompleted)
                                 {
+                                    transfer->currentmetamac = macsmac(&transfer->chunkmacs);
+                                    transfer->currentmetamacvalid = true;
+                                }
+
+                                // verify meta MAC
+                                if (!transfer->progresscompleted
+                                        || (transfer->currentmetamac == transfer->metamac))
+                                {
+                                    errorcount = 0;
+                                    transfer->failcount = 0;
                                     client->transfercacheadd(transfer);
 
                                     if (transfer->progresscompleted != progressreported)
@@ -339,16 +361,18 @@ void TransferSlot::doio(MegaClient* client)
                                 }
                                 else
                                 {
-                                    LOG_warn << "MAC verification failed";
+                                    LOG_warn << "MAC verification failed";                                    
                                     transfer->chunkmacs.clear();
                                     return transfer->failed(API_EKEY);
                                 }
                             }
+                            errorcount = 0;
+                            transfer->failcount = 0;
                         }
                         else
                         {
                             LOG_warn << "Invalid chunk size: " << reqs[i]->size << " - " << reqs[i]->bufpos;
-                            transfer->progresscompleted -= reqs[i]->size;
+                            lasterror = API_EREAD;
                             errorcount++;
                             reqs[i]->status = REQ_PREPARED;
                             break;


### PR DESCRIPTION
- CRC for uploads
- Provide the last error in transfers to apps
- Retry the upload of chunks that fails due to the CRC
- Repeat wrong downloads to check if the file is really corrupt
- Move corrupt files to SyncDebris
- Reorganized the management of the variables "progresscompleted", "errorcount" and "failcount"