### PR TITLE
Allow to remove existing cache

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -466,9 +466,6 @@ private:
 
     // a TransferSlot chunk failed
     bool chunkfailed;
-
-    // open/create state cache database table
-    void opensctable();
     
     // fetch state serialize from local cache
     bool fetchsc(DbTable*);
@@ -582,6 +579,9 @@ public:
 
     // record type indicator for sctable
     enum { CACHEDSCSN, CACHEDNODE, CACHEDUSER, CACHEDLOCALNODE, CACHEDPCR, CACHEDTRANSFER, CACHEDFILE } sctablerectype;
+
+    // open/create state cache database table
+    void opensctable();
 
     // initialize/update state cache referenced sctable
     void initsc();

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6301,6 +6301,14 @@ class MegaApi
         void localLogout(MegaRequestListener *listener = NULL);
 
         /**
+         * @brief Removes the corresponding cache of a session
+         *
+         * @param sid Session key previously dumped with MegaApi::dumpSession
+         * @return True if the DB was removed, false if cache not found.
+         */
+        bool removeCache(const char *sid);
+
+        /**
          * @brief Submit feedback about the app
          *
          * The associated request type with this request is MegaRequest::TYPE_SUBMIT_FEEDBACK

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6301,12 +6301,9 @@ class MegaApi
         void localLogout(MegaRequestListener *listener = NULL);
 
         /**
-         * @brief Removes the corresponding cache of a session
-         *
-         * @param sid Session key previously dumped with MegaApi::dumpSession
-         * @return True if the DB was removed, false if cache not found.
+         * @brief Invalidate the existing cache and create a fresh one
          */
-        bool removeCache(const char *sid);
+        void invalidateCache();
 
         /**
          * @brief Submit feedback about the app

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1394,6 +1394,7 @@ class MegaApiImpl : public MegaApp
         void removeContact(MegaUser *user, MegaRequestListener* listener=NULL);
         void logout(MegaRequestListener *listener = NULL);
         void localLogout(MegaRequestListener *listener = NULL);
+        bool removeDB(const char *sid);
         void submitFeedback(int rating, const char *comment, MegaRequestListener *listener = NULL);
         void reportEvent(const char *details = NULL, MegaRequestListener *listener = NULL);
         void sendEvent(int eventType, const char* message, MegaRequestListener *listener = NULL);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1394,7 +1394,7 @@ class MegaApiImpl : public MegaApp
         void removeContact(MegaUser *user, MegaRequestListener* listener=NULL);
         void logout(MegaRequestListener *listener = NULL);
         void localLogout(MegaRequestListener *listener = NULL);
-        bool removeDB(const char *sid);
+        void invalidateCache();
         void submitFeedback(int rating, const char *comment, MegaRequestListener *listener = NULL);
         void reportEvent(const char *details = NULL, MegaRequestListener *listener = NULL);
         void sendEvent(int eventType, const char* message, MegaRequestListener *listener = NULL);
@@ -1687,6 +1687,7 @@ protected:
         MegaDbAccess *dbAccess;
         GfxProc *gfxAccess;
         string basePath;
+        bool nocache;
 
 #ifdef HAVE_LIBUV
         MegaHTTPServer *httpServer;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1777,9 +1777,9 @@ void MegaApi::localLogout(MegaRequestListener *listener)
     pImpl->localLogout(listener);
 }
 
-bool MegaApi::removeCache(const char *sid)
+void MegaApi::invalidateCache()
 {
-    return pImpl->removeDB(sid);
+    pImpl->invalidateCache();
 }
 
 void MegaApi::submitFeedback(int rating, const char *comment, MegaRequestListener* listener)

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1777,6 +1777,11 @@ void MegaApi::localLogout(MegaRequestListener *listener)
     pImpl->localLogout(listener);
 }
 
+bool MegaApi::removeCache(const char *sid)
+{
+    return pImpl->removeDB(sid);
+}
+
 void MegaApi::submitFeedback(int rating, const char *comment, MegaRequestListener* listener)
 {
     pImpl->submitFeedback(rating, comment, listener);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4685,22 +4685,6 @@ void MegaApiImpl::disableExport(MegaNode *node, MegaRequestListener *listener)
 
 void MegaApiImpl::fetchNodes(MegaRequestListener *listener)
 {
-    if (nocache)
-    {
-        client->opensctable();
-
-        if (client->sctable)
-        {
-            client->sctable->remove();
-            delete client->sctable;
-            client->sctable = NULL;
-
-            client->cachedscsn = UNDEF;
-        }
-
-        nocache = false;
-    }
-
 	MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_FETCH_NODES, listener);
 	requestQueue.push(request);
     waiter->notify();
@@ -12193,6 +12177,22 @@ void MegaApiImpl::sendPendingRequests()
 		}
 		case MegaRequest::TYPE_FETCH_NODES:
 		{
+            if (nocache)
+            {
+                client->opensctable();
+
+                if (client->sctable)
+                {
+                    client->sctable->remove();
+                    delete client->sctable;
+                    client->sctable = NULL;
+
+                    client->cachedscsn = UNDEF;
+                }
+
+                nocache = false;
+            }
+
 			client->fetchnodes();
 			break;
 		}

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4907,6 +4907,33 @@ void MegaApiImpl::localLogout(MegaRequestListener *listener)
     waiter->notify();
 }
 
+bool MegaApiImpl::removeDB(const char *sid)
+{
+    bool ret = false;
+    if (sid)
+    {
+        sdkMutex.lock();
+
+        string currentsid = client->sid;
+        client->sid = sid;
+
+        client->opensctable();
+        if (client->sctable)
+        {
+            client->sctable->remove();
+            delete client->sctable;
+            client->sctable = NULL;
+            ret = true;
+        }
+
+        client->sid = currentsid;
+
+        sdkMutex.unlock();
+    }
+
+    return ret;
+}
+
 void MegaApiImpl::submitFeedback(int rating, const char *comment, MegaRequestListener *listener)
 {
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_SUBMIT_FEEDBACK, listener);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4694,6 +4694,8 @@ void MegaApiImpl::fetchNodes(MegaRequestListener *listener)
             client->sctable->remove();
             delete client->sctable;
             client->sctable = NULL;
+
+            client->cachedscsn = UNDEF;
         }
 
         nocache = false;


### PR DESCRIPTION
Specially useful to regenerate karere's cache when there's an existing
SDK's cache, without the need of creating a new session.