### PR TITLE
Adaptative chunk sizes for downloads

### DIFF
--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -46,6 +46,13 @@ struct MEGA_API TransferSlot
     // max time without progress callbacks
     static const dstime PROGRESSTIMEOUT = 10;
 
+    // max time without progress callbacks
+#if defined(__ANDROID__) || defined(USE_IOS) || defined(WINDOWS_PHONE)
+    static const m_off_t MAX_DOWNLOAD_CHUNK_SIZE = 2097152;
+#else
+    static const m_off_t MAX_DOWNLOAD_CHUNK_SIZE = 16777216;
+#endif
+
     m_off_t progressreported;
 
     m_time_t lastprogressreport;

--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -48,9 +48,9 @@ struct MEGA_API TransferSlot
 
     // max time without progress callbacks
 #if defined(__ANDROID__) || defined(USE_IOS) || defined(WINDOWS_PHONE)
-    static const m_off_t MAX_DOWNLOAD_CHUNK_SIZE = 2097152;
+    static const m_off_t MAX_DOWNLOAD_REQ_SIZE = 2097152;
 #else
-    static const m_off_t MAX_DOWNLOAD_CHUNK_SIZE = 16777216;
+    static const m_off_t MAX_DOWNLOAD_REQ_SIZE = 16777216;
 #endif
 
     m_off_t progressreported;

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -39,7 +39,7 @@ struct MEGA_API ChunkedHash
     static const int SEGSIZE = 131072;
 
     static m_off_t chunkfloor(m_off_t);
-    static m_off_t chunkceil(m_off_t);
+    static m_off_t chunkceil(m_off_t, m_off_t limit = 0);
 };
 
 /**

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -586,15 +586,15 @@ void HttpReqDL::finalize(FileAccess* fa, SymmCipher* key, chunkmac_map* macs,
         }
     }
 
-    byte *bufstart = buf + skip;
-    m_off_t buflen = bufpos - skip - prune;
-    m_off_t bufpos = dlpos + skip;
+    byte *chunkstart = buf + skip;
+    m_off_t chunklen = bufpos - skip - prune;
+    m_off_t chunkpos = dlpos + skip;
 
-    ChunkMAC &chunkmac = (*macs)[ChunkedHash::chunkfloor(bufpos)];
-    key->ctr_crypt(bufstart, buflen, bufpos, ctriv, chunkmac.mac, 0,
+    ChunkMAC &chunkmac = (*macs)[ChunkedHash::chunkfloor(chunkpos)];
+    key->ctr_crypt(chunkstart, chunklen, chunkpos, ctriv, chunkmac.mac, 0,
             !chunkmac.finished && !chunkmac.offset);
 
-    fa->fwrite(bufstart, buflen, bufpos);
+    fa->fwrite(chunkstart, chunklen, chunkpos);
 
     chunkmac.finished = true;
     chunkmac.offset = 0;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2493,11 +2493,7 @@ bool MegaClient::dispatch(direction_t d)
                     for (chunkmac_map::iterator it = nexttransfer->chunkmacs.begin();
                          it != nexttransfer->chunkmacs.end(); it++)
                     {
-                        m_off_t chunkceil = ChunkedHash::chunkceil(it->first);
-                        if (chunkceil > nexttransfer->size)
-                        {
-                            chunkceil = nexttransfer->size;
-                        }
+                        m_off_t chunkceil = ChunkedHash::chunkceil(it->first, nexttransfer->size);
 
                         if (nexttransfer->pos == it->first && it->second.finished)
                         {

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -320,11 +320,7 @@ Transfer *Transfer::unserialize(MegaClient *client, string *d, transfer_map* tra
 
     for (chunkmac_map::iterator it = t->chunkmacs.begin(); it != t->chunkmacs.end(); it++)
     {
-        m_off_t chunkceil = ChunkedHash::chunkceil(it->first);
-        if (chunkceil > t->size)
-        {
-            chunkceil = t->size;
-        }
+        m_off_t chunkceil = ChunkedHash::chunkceil(it->first, t->size);
 
         if (t->pos == it->first && it->second.finished)
         {

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -71,6 +71,7 @@ TransferSlot::~TransferSlot()
             && transfer->progresscompleted != transfer->size)
     {
         m_off_t p = 0;
+        bool cachetransfer = false;
         for (int i = 0; i < connections; i++)
         {
             if (fa && reqs[i] && reqs[i]->status == REQ_INFLIGHT
@@ -79,18 +80,43 @@ TransferSlot::~TransferSlot()
             {
                 m_off_t bufpos = reqs[i]->bufpos & -SymmCipher::BLOCKSIZE;
                 m_off_t dlpos = ((HttpReqDL *)reqs[i])->dlpos;
-                ChunkMAC &chunk = transfer->chunkmacs[reqs[i]->pos];
 
-                p += bufpos;
-                transfer->key.ctr_crypt(reqs[i]->buf, bufpos, dlpos, transfer->ctriv,
-                            chunk.mac, false, !chunk.finished && !chunk.offset);
+                byte *bufstart = reqs[i]->buf;
+                m_off_t buflen = bufpos;
+                m_off_t startpos = dlpos;
+                m_off_t endpos = ChunkedHash::chunkceil(startpos, transfer->size);
+                m_off_t finalpos = startpos + buflen;
 
-                fa->fwrite((const byte*)reqs[i]->buf, bufpos, dlpos);
-                chunk.offset += (unsigned int)bufpos;
+                while (endpos <= finalpos)
+                {
+                    m_off_t chunksize = endpos - startpos;
+                    reqs[i]->finalize(fa, &transfer->key, &transfer->chunkmacs, transfer->ctriv, startpos, endpos);
+                    transfer->progresscompleted += chunksize;
+                    LOG_debug << "Caching finished chunk: " << startpos << " - " << endpos << "   Size: " << chunksize;
+
+                    startpos = endpos;
+                    endpos = ChunkedHash::chunkceil(startpos, transfer->size);
+
+                    bufstart += chunksize;
+                    buflen -= chunksize;
+                    cachetransfer = true;
+                }
+
+                if (buflen >= SymmCipher::BLOCKSIZE)
+                {
+                    ChunkMAC &chunk = transfer->chunkmacs[ChunkedHash::chunkfloor(startpos)];
+                    transfer->key.ctr_crypt(bufstart, buflen, startpos, transfer->ctriv,
+                                chunk.mac, false, !chunk.finished && !chunk.offset);
+
+                    fa->fwrite((const byte*)bufstart, buflen, startpos);
+                    chunk.offset += (unsigned int)buflen;
+                    cachetransfer = true;
+                    p += buflen;
+                }
             }
         }
 
-        if (p)
+        if (cachetransfer)
         {
             transfer->client->transfercacheadd(transfer);
             LOG_debug << "Completed: " << (transfer->progresscompleted + p)
@@ -190,6 +216,25 @@ void TransferSlot::doio(MegaClient* client)
     {
         if (transfer->type == GET || transfer->ultoken)
         {
+            if (fa && transfer->type == GET)
+            {
+                LOG_debug << "Verifying cached download";
+                transfer->currentmetamac = macsmac(&transfer->chunkmacs);
+                transfer->hascurrentmetamac = true;
+
+                // verify meta MAC
+                if (transfer->currentmetamac == transfer->metamac)
+                {
+                    return transfer->complete();
+                }
+                else
+                {
+                    LOG_warn << "MAC verification failed for cached download";
+                    transfer->chunkmacs.clear();
+                    return transfer->failed(API_EKEY);
+                }
+            }
+
             // this is a pending completion, retry every 200 ms by default
             retrybt.backoff(2);
             retrying = true;
@@ -331,8 +376,17 @@ void TransferSlot::doio(MegaClient* client)
                     {
                         if (reqs[i]->size == reqs[i]->bufpos)
                         {
-                            reqs[i]->finalize(fa, &transfer->key, &transfer->chunkmacs, transfer->ctriv, 0, -1);
-                            transfer->progresscompleted += reqs[i]->size;
+                            m_off_t startpos = ((HttpReqDL *)reqs[i])->dlpos;
+                            m_off_t finalpos = startpos + reqs[i]->bufpos;
+                            while (startpos < finalpos)
+                            {
+                                m_off_t endpos = ChunkedHash::chunkceil(startpos, transfer->size);
+                                m_off_t chunksize = endpos - startpos;
+                                reqs[i]->finalize(fa, &transfer->key, &transfer->chunkmacs, transfer->ctriv, startpos, endpos);
+                                transfer->progresscompleted += chunksize;
+                                LOG_debug << "Finished chunk: " << startpos << " - " << endpos << "   Size: " << chunksize;
+                                startpos = endpos;
+                            }
 
                             if (transfer->progresscompleted == transfer->size)
                             {
@@ -453,13 +507,7 @@ void TransferSlot::doio(MegaClient* client)
         {
             if (!reqs[i] || (reqs[i]->status == REQ_READY))
             {
-                m_off_t npos = ChunkedHash::chunkceil(transfer->nextpos());
-
-                if (npos > transfer->size)
-                {
-                    npos = transfer->size;
-                }
-
+                m_off_t npos = ChunkedHash::chunkceil(transfer->nextpos(), transfer->size);
                 if (!transfer->size)
                 {
                     transfer->pos = 0;
@@ -467,6 +515,43 @@ void TransferSlot::doio(MegaClient* client)
 
                 if ((npos > transfer->pos) || !transfer->size)
                 {
+                    if (transfer->type == GET && transfer->size && transfer->pos >= 3670016)
+                    {
+                        m_off_t maxChunkSize = (transfer->size - transfer->progresscompleted) / connections / 2;
+                        if (maxChunkSize > MAX_DOWNLOAD_CHUNK_SIZE)
+                        {
+                            maxChunkSize = MAX_DOWNLOAD_CHUNK_SIZE;
+                        }
+
+                        if (maxChunkSize > 0x100000)
+                        {
+                            m_off_t val = 0x100000;
+                            while (val <= maxChunkSize)
+                            {
+                                val <<= 1;
+                            }
+                            maxChunkSize = val >> 1;
+                            maxChunkSize -= 0x100000;
+                        }
+                        else
+                        {
+                            maxChunkSize = 0;
+                        }
+
+                        chunkmac_map::iterator it = transfer->chunkmacs.find(npos);
+                        m_off_t chunkSize = npos - transfer->pos;
+                        while (npos < transfer->size
+                               && chunkSize <= maxChunkSize
+                               && (it == transfer->chunkmacs.end()
+                                   || (!it->second.finished && !it->second.offset)))
+                        {
+                            npos = ChunkedHash::chunkceil(npos, transfer->size);
+                            chunkSize = npos - transfer->pos;
+                            it = transfer->chunkmacs.find(npos);
+                        }
+                        LOG_debug << "Downloading chunk of size " << chunkSize;
+                    }
+
                     if (!reqs[i])
                     {
                         reqs[i] = transfer->type == PUT ? (HttpReqXfer*)new HttpReqUL() : (HttpReqXfer*)new HttpReqDL();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -162,7 +162,7 @@ m_off_t ChunkedHash::chunkfloor(m_off_t p)
 }
 
 // end of chunk (== start of next chunk)
-m_off_t ChunkedHash::chunkceil(m_off_t p)
+m_off_t ChunkedHash::chunkceil(m_off_t p, m_off_t limit)
 {
     m_off_t cp, np;
 
@@ -174,13 +174,14 @@ m_off_t ChunkedHash::chunkceil(m_off_t p)
 
         if ((p >= cp) && (p < np))
         {
-            return np;
+            return (!limit || np < limit) ? np : limit;
         }
 
         cp = np;
     }
 
-    return ((p - cp) & - (8 * SEGSIZE)) + cp + 8 * SEGSIZE;
+    np = ((p - cp) & - (8 * SEGSIZE)) + cp + 8 * SEGSIZE;
+    return (!limit || np < limit) ? np : limit;
 }
 
 


### PR DESCRIPTION
- Chunk sizes depending on the file position, number of connections and remaining data
- Different max chunk sizes for mobile and desktop apps
- Extra parameter for chunkceil to ease its usage
- Compatibility with transfer resumption (backwards compatibility too)
- Verify transfers that were cached with all data already transferred