### PR TITLE
included -pthread when linking with -lrt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -819,8 +819,8 @@ if test "x$WIN32" = "xno" ; then
     SAVE_LDFLAGS="-lrt $SAVE_LDFLAGS"
     LDFLAGS="-lrt $LDFLAGS"
     if test "$HAVE_PTHREAD" = "yes"; then
-        SAVE_LDFLAGS="-lpthread $SAVE_LDFLAGS"
-        LDFLAGS="-lpthread $LDFLAGS"
+        SAVE_LDFLAGS="-pthread $SAVE_LDFLAGS"
+        LDFLAGS="-pthread $LDFLAGS"
     fi    
 #    LIBRT_CXXFLAGS="-lrt "
 #    LIBRT_CPPFLAGS="-lrt "

--- a/configure.ac
+++ b/configure.ac
@@ -232,7 +232,6 @@ else
 fi
 if test "$HAVE_PTHREAD" = "yes"; then
     AC_DEFINE(USE_PTHREAD, 1, [Defined if pthreads are available])
-    LDFLAGS="-lpthread $LDFLAGS"
 fi
 AM_CONDITIONAL([HAVE_PTHREAD], [test "${HAVE_PTHREAD}" = "yes"])
 
@@ -819,6 +818,10 @@ if test "x$WIN32" = "xno" ; then
     AC_CHECK_LIB([rt], [aio_write], [
     SAVE_LDFLAGS="-lrt $SAVE_LDFLAGS"
     LDFLAGS="-lrt $LDFLAGS"
+    if test "$HAVE_PTHREAD" = "yes"; then
+        SAVE_LDFLAGS="-lpthread $SAVE_LDFLAGS"
+        LDFLAGS="-lpthread $LDFLAGS"
+    fi    
 #    LIBRT_CXXFLAGS="-lrt "
 #    LIBRT_CPPFLAGS="-lrt "
 #    LIBRT_LDFLAGS="-lrt "

--- a/configure.ac
+++ b/configure.ac
@@ -232,6 +232,7 @@ else
 fi
 if test "$HAVE_PTHREAD" = "yes"; then
     AC_DEFINE(USE_PTHREAD, 1, [Defined if pthreads are available])
+    LDFLAGS="-lpthread $LDFLAGS"
 fi
 AM_CONDITIONAL([HAVE_PTHREAD], [test "${HAVE_PTHREAD}" = "yes"])
 
@@ -1562,7 +1563,7 @@ AC_MSG_NOTICE([Configured to build Mega SDK:
   Install prefix:   $prefix
   Compiler:         $CXX
   CXXFLAGS:         $CXXFLAGS
-  LDFLAGS:         $LDFLAGS
+  LDFLAGS:          $LDFLAGS
   gcc hardening:    $enable_gcc_hardening
   debug:            $enable_debug
   static:           $enable_static


### PR DESCRIPTION
fixes static compilation that misses pthread symbols in systems' librt.a