### PR TITLE
Update chats at `Command::procresult()`

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -3496,7 +3496,7 @@ static void process_line(char* l)
                                 return;
                             }
 
-                            client->inviteToChat(chatid, u->uid.c_str(), priv);
+                            client->inviteToChat(chatid, u->userhandle, priv);
                             return;
                         }
                         else
@@ -3527,7 +3527,7 @@ static void process_line(char* l)
                                     return;
                                 }
 
-                                client->removeFromChat(chatid, u->uid.c_str());
+                                client->removeFromChat(chatid, u->userhandle);
                                 return;
                             }
                             else

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -3515,7 +3515,7 @@ static void process_line(char* l)
 
                             if (words.size() == 2)
                             {
-                                client->removeFromChat(chatid);
+                                client->removeFromChat(chatid, client->me);
                             }
                             else if (words.size() == 3)
                             {

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -737,7 +737,7 @@ class MEGA_API CommandChatInvite : public Command
     handle chatid;
     handle uh;
     privilege_t priv;
-    const char *title;
+    string title;
 
 public:
     void procresult();
@@ -808,7 +808,7 @@ public:
 class MEGA_API CommandChatSetTitle : public Command
 {
     handle chatid;
-    const char *title;
+    string title;
 
 public:
     void procresult();

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -724,7 +724,6 @@ public:
 #ifdef ENABLE_CHAT
 class MEGA_API CommandChatCreate : public Command
 {
-    MegaClient *client;
     userpriv_vector *chatPeers;
 
 public:
@@ -735,7 +734,10 @@ public:
 
 class MEGA_API CommandChatInvite : public Command
 {
-    MegaClient *client;
+    handle chatid;
+    handle uh;
+    privilege_t priv;
+    const char *title;
 
 public:
     void procresult();
@@ -745,7 +747,9 @@ public:
 
 class MEGA_API CommandChatRemove : public Command
 {
-    MegaClient *client;
+    handle chatid;
+    handle uh;
+
 public:
     void procresult();
 
@@ -754,7 +758,7 @@ public:
 
 class MEGA_API CommandChatURL : public Command
 {
-    MegaClient *client;
+    handle chatid;
 
 public:
     void procresult();
@@ -764,7 +768,6 @@ public:
 
 class MEGA_API CommandChatGrantAccess : public Command
 {
-    MegaClient *client;
 
 public:
     void procresult();
@@ -774,7 +777,6 @@ public:
 
 class MEGA_API CommandChatRemoveAccess : public Command
 {
-    MegaClient *client;
 
 public:
     void procresult();
@@ -784,7 +786,9 @@ public:
 
 class MEGA_API CommandChatUpdatePermissions : public Command
 {
-    MegaClient *client;
+    handle chatid;
+    handle uh;
+    privilege_t priv;
 
 public:
     void procresult();
@@ -794,7 +798,6 @@ public:
 
 class MEGA_API CommandChatTruncate : public Command
 {
-    MegaClient *client;
 
 public:
     void procresult();
@@ -804,7 +807,8 @@ public:
 
 class MEGA_API CommandChatSetTitle : public Command
 {
-    MegaClient *client;
+    handle chatid;
+    const char *title;
 
 public:
     void procresult();
@@ -814,7 +818,6 @@ public:
 
 class MEGA_API CommandChatPresenceURL : public Command
 {
-    MegaClient *client;
 
 public:
     void procresult();
@@ -824,8 +827,6 @@ public:
 
 class MEGA_API CommandRegisterPushNotification : public Command
 {
-    MegaClient *client;
-
 public:
     void procresult();
 

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -793,7 +793,7 @@ class MEGA_API CommandChatUpdatePermissions : public Command
 public:
     void procresult();
 
-    CommandChatUpdatePermissions(MegaClient*, handle, const char *, privilege_t);
+    CommandChatUpdatePermissions(MegaClient*, handle, handle, privilege_t);
 };
 
 class MEGA_API CommandChatTruncate : public Command

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -742,7 +742,7 @@ class MEGA_API CommandChatInvite : public Command
 public:
     void procresult();
 
-    CommandChatInvite(MegaClient*, handle, const char *, privilege_t, const char *);
+    CommandChatInvite(MegaClient*, handle, handle uh, privilege_t, const char *);
 };
 
 class MEGA_API CommandChatRemove : public Command
@@ -753,7 +753,7 @@ class MEGA_API CommandChatRemove : public Command
 public:
     void procresult();
 
-    CommandChatRemove(MegaClient*, handle, const char * = NULL);
+    CommandChatRemove(MegaClient*, handle, handle uh);
 };
 
 class MEGA_API CommandChatURL : public Command

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -465,10 +465,10 @@ public:
     void createChat(bool group, const userpriv_vector *userpriv);
 
     // invite a user to a chat
-    void inviteToChat(handle chatid, const char *uid, int priv, const char *title = NULL);
+    void inviteToChat(handle chatid, handle uh, int priv, const char *title = NULL);
 
     // remove a user from a chat
-    void removeFromChat(handle chatid, const char *uid = NULL);
+    void removeFromChat(handle chatid, handle uh);
 
     // get the URL of a chat
     void getUrlChat(handle chatid);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -483,7 +483,7 @@ public:
     void removeAccessInChat(handle chatid, handle h, const char *uid);
 
     // update permissions of a peer in a chat
-    void updateChatPermissions(handle chatid, const char *uid, int priv);
+    void updateChatPermissions(handle chatid, handle uh, int priv);
 
     // truncate chat from message id
     void truncateChat(handle chatid, handle messageid);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4530,13 +4530,17 @@ void CommandChatCreate::procresult()
     }
 }
 
-CommandChatInvite::CommandChatInvite(MegaClient *client, handle chatid, const char *uid, privilege_t priv, const char* title)
+CommandChatInvite::CommandChatInvite(MegaClient *client, handle chatid, handle uh, privilege_t priv, const char* title)
 {
     this->client = client;
     this->chatid = chatid;
-    Base64::atob(uid, (byte*)&this->uh, sizeof this->uh);
+    this->uh = uh;
     this->priv = priv;
     this->title = title ? string(title) : "";
+
+    char uid[12];
+    Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
+    uid[11] = 0;
 
     cmd("mci");
 
@@ -4591,18 +4595,22 @@ void CommandChatInvite::procresult()
     }
 }
 
-CommandChatRemove::CommandChatRemove(MegaClient *client, handle chatid, const char *uid)
+CommandChatRemove::CommandChatRemove(MegaClient *client, handle chatid, handle uh)
 {
     this->client = client;
     this->chatid = chatid;
-    Base64::atob(uid, (byte*)&this->uh, sizeof this->uh);
+    this->uh = uh;
 
     cmd("mcr");
 
     arg("id", (byte*)&chatid, MegaClient::CHATHANDLE);
 
-    if (uid)
+    if (uh != client->me)
     {
+        char uid[12];
+        Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
+        uid[11] = 0;
+
         arg("u", uid);
     }
     arg("v", 1);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4536,7 +4536,7 @@ CommandChatInvite::CommandChatInvite(MegaClient *client, handle chatid, const ch
     this->chatid = chatid;
     Base64::atob(uid, (byte*)&this->uh, sizeof this->uh);
     this->priv = priv;
-    this->title = title;
+    this->title = title ? string(title) : "";
 
     cmd("mci");
 
@@ -4576,9 +4576,9 @@ void CommandChatInvite::procresult()
 
             chat->userpriv->push_back(userpriv_pair(uh, priv));
 
-            if (title)  // only if title was set for this chatroom, update it
+            if (!title.empty())  // only if title was set for this chatroom, update it
             {
-                chat->title.assign(title);
+                chat->title = title;
             }
         }
 
@@ -4850,7 +4850,7 @@ CommandChatSetTitle::CommandChatSetTitle(MegaClient *client, handle chatid, cons
 {
     this->client = client;
     this->chatid = chatid;
-    this->title = title;
+    this->title = title ? string(title) : "";
 
     cmd("mcst");
     arg("v", 1);
@@ -4876,14 +4876,7 @@ void CommandChatSetTitle::procresult()
                 return;
             }
 
-            if (title)
-            {
-                client->chats[chatid]->title.assign(title);
-            }
-            else
-            {
-                client->chats[chatid]->title = "";
-            }
+            client->chats[chatid]->title = title;
         }
 
         client->app->chatsettitle_result(e);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4765,12 +4765,16 @@ void CommandChatRemoveAccess::procresult()
     }
 }
 
-CommandChatUpdatePermissions::CommandChatUpdatePermissions(MegaClient *client, handle chatid, const char *uid, privilege_t priv)
+CommandChatUpdatePermissions::CommandChatUpdatePermissions(MegaClient *client, handle chatid, handle uh, privilege_t priv)
 {
     this->client = client;
     this->chatid = chatid;
-    Base64::atob(uid, (byte*)&this->uh, sizeof this->uh);
+    this->uh = uh;
     this->priv = priv;
+
+    char uid[12];
+    Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
+    uid[11] = 0;
 
     cmd("mcup");
     arg("v", 1);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -13953,11 +13953,7 @@ void MegaApiImpl::sendPendingRequests()
                 break;
             }
 
-            char uid[12];
-            Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
-            uid[11] = 0;
-
-            client->inviteToChat(chatid, uid, access, title);
+            client->inviteToChat(chatid, uh, access, title);
             break;
         }
         case MegaRequest::TYPE_CHAT_REMOVE:
@@ -13974,15 +13970,12 @@ void MegaApiImpl::sendPendingRequests()
             // user is optional. If not provided, command apply to own user
             if (uh != INVALID_HANDLE)
             {
-                char uid[12];
-                Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
-                uid[11] = 0;
-
-                client->removeFromChat(chatid, uid);
+                client->removeFromChat(chatid, uh);
             }
             else
             {
-                client->removeFromChat(chatid);
+                request->setParentHandle(client->me);
+                client->removeFromChat(chatid, client->me);
             }
             break;
         }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14033,11 +14033,7 @@ void MegaApiImpl::sendPendingRequests()
                 break;
             }
 
-            char uid[12];
-            Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
-            uid[11] = 0;
-
-            client->updateChatPermissions(chatid, uid, access);
+            client->updateChatPermissions(chatid, uh, access);
             break;
         }
         case MegaRequest::TYPE_CHAT_TRUNCATE:

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -10843,9 +10843,9 @@ void MegaClient::removeAccessInChat(handle chatid, handle h, const char *uid)
     reqs.add(new CommandChatRemoveAccess(this, chatid, h, uid));
 }
 
-void MegaClient::updateChatPermissions(handle chatid, const char *uid, int priv)
+void MegaClient::updateChatPermissions(handle chatid, handle uh, int priv)
 {
-    reqs.add(new CommandChatUpdatePermissions(this, chatid, uid, (privilege_t) priv));
+    reqs.add(new CommandChatUpdatePermissions(this, chatid, uh, (privilege_t) priv));
 }
 
 void MegaClient::truncateChat(handle chatid, handle messageid)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -10761,14 +10761,14 @@ void MegaClient::createChat(bool group, const userpriv_vector *userpriv)
     reqs.add(new CommandChatCreate(this, group, userpriv));
 }
 
-void MegaClient::inviteToChat(handle chatid, const char *uid, int priv, const char *title)
+void MegaClient::inviteToChat(handle chatid, handle uh, int priv, const char *title)
 {
-    reqs.add(new CommandChatInvite(this, chatid, uid, (privilege_t) priv, title));
+    reqs.add(new CommandChatInvite(this, chatid, uh, (privilege_t) priv, title));
 }
 
-void MegaClient::removeFromChat(handle chatid, const char *uid)
+void MegaClient::removeFromChat(handle chatid, handle uh)
 {
-    reqs.add(new CommandChatRemove(this, chatid, uid));
+    reqs.add(new CommandChatRemove(this, chatid, uh));
 }
 
 void MegaClient::getUrlChat(handle chatid)


### PR DESCRIPTION
The response to chat-related API commands didn't update the state of
chatrooms that now is maintained by the SDK. This commit aims to solve
this issue.