### PR TITLE
Update cache and notify chats

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -672,7 +672,6 @@ void DemoApp::printChatInformation(TextChat *chat)
     cout << "Chat ID: " << hstr << endl;
     cout << "\tOwn privilege level: " << getPrivilegeString(chat->priv) << endl;
     cout << "\tChat shard: " << chat->shard << endl;
-    cout << "\tURL: " << chat->url << endl;
     if (chat->group)
     {
         cout << "\tGroup chat: yes" << endl;

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -696,6 +696,14 @@ void DemoApp::printChatInformation(TextChat *chat)
     {
         cout << " no peers (only you as participant)" << endl;
     }
+    if (chat->tag)
+    {
+        cout << "\tIs own change: yes" << endl;
+    }
+    else
+    {
+        cout << "\tIs own change: no" << endl;
+    }
     if (!chat->title.empty())
     {
         char *tstr = new char[chat->title.size() * 4 / 3 + 4];

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -758,8 +758,6 @@ public:
 
 class MEGA_API CommandChatURL : public Command
 {
-    handle chatid;
-
 public:
     void procresult();
 
@@ -798,6 +796,7 @@ public:
 
 class MEGA_API CommandChatTruncate : public Command
 {
+    handle chatid;
 
 public:
     void procresult();

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -432,11 +432,17 @@ struct TextChat : public Cachable
     string title;   // byte array
     handle ou;
 
+    int tag;    // source tag, to identify own changes
+
     TextChat();
     ~TextChat();
 
     bool serialize(string *d);
     static TextChat* unserialize(class MegaClient *client, string *d);
+
+    void setTag(int tag);
+    int getTag();
+    void resetTag();
 };
 typedef vector<TextChat*> textchat_vector;
 typedef map<handle, TextChat*> textchat_map;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -426,7 +426,6 @@ struct TextChat : public Cachable
 {
     handle id;
     privilege_t priv;
-    string url;
     int shard;
     userpriv_vector *userpriv;
     bool group;

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1380,23 +1380,6 @@ public:
     virtual int getOwnPrivilege() const;
 
     /**
-     * @brief Returns your URL to connect to chatd for this chat
-     *
-     * The MegaTextChat retains the ownership of the returned string. It will
-     * be only valid until the MegaTextChat is deleted.
-     *
-     * @return The URL of the chatd server, or NULL if not available.
-     */
-    virtual const char *getUrl() const;
-
-    /**
-     * @brief setUrl Establish the URL to connect to chatd for this chat
-     *
-     * @param url The new URL for the MegaTextChat
-     */
-    virtual void setUrl(const char *url);
-
-    /**
      * @brief getShard Returns the chat shard
      * @return
      */

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1421,6 +1421,18 @@ public:
      */
     virtual const char *getTitle() const;
 
+    /**
+     * @brief Indicates if the chat is changed by yourself or by another client.
+     *
+     * This value is only useful for chats notified by MegaListener::onChatsUpdate or
+     * MegaGlobalListener::onChatsUpdate that can notify about chat modifications.
+     *
+     * @return 0 if the change is external. >0 if the change is the result of an
+     * explicit request, -1 if the change is the result of an implicit request
+     * made by the SDK internally.
+     */
+    virtual int isOwnChange() const;
+
 };
 
 /**

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -958,15 +958,13 @@ class MegaTextChatPrivate : public MegaTextChat
 {
 public:
     MegaTextChatPrivate(const MegaTextChat *);
-    MegaTextChatPrivate(handle id, int priv, string url, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title);
+    MegaTextChatPrivate(handle id, int priv, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title);
 
     virtual ~MegaTextChatPrivate();
     virtual MegaTextChat *copy() const;
 
     virtual MegaHandle getHandle() const;
     virtual int getOwnPrivilege() const;
-    virtual const char *getUrl() const;
-    virtual void setUrl(const char *);
     virtual int getShard() const;
     virtual const MegaTextChatPeerList *getPeerList() const;
     virtual bool isGroup() const;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -958,7 +958,7 @@ class MegaTextChatPrivate : public MegaTextChat
 {
 public:
     MegaTextChatPrivate(const MegaTextChat *);
-    MegaTextChatPrivate(handle id, int priv, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title);
+    MegaTextChatPrivate(handle id, int priv, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title, int tag);
 
     virtual ~MegaTextChatPrivate();
     virtual MegaTextChat *copy() const;
@@ -971,6 +971,8 @@ public:
     virtual MegaHandle getOriginatingUser() const;
     virtual const char *getTitle() const;
 
+    virtual int isOwnChange() const;
+
 private:
     handle id;
     int priv;
@@ -980,6 +982,7 @@ private:
     bool group;
     handle ou;
     string title;
+    int tag;
 };
 
 class MegaTextChatListPrivate : public MegaTextChatList

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4467,7 +4467,6 @@ void CommandChatCreate::procresult()
     }
     else
     {
-        string url;
         handle chatid = UNDEF;
         int shard = -1;
         bool group = false;
@@ -4476,10 +4475,6 @@ void CommandChatCreate::procresult()
         {
             switch (client->json.getnameid())
             {
-                case MAKENAMEID3('u','r','l'):
-                    client->json.storeobject(&url);
-                    break;
-
                 case MAKENAMEID2('i','d'):
                     chatid = client->json.gethandle(MegaClient::CHATHANDLE);
                     break;
@@ -4493,7 +4488,7 @@ void CommandChatCreate::procresult()
                     break;
 
                 case EOO:
-                    if (chatid != UNDEF && !url.empty() && shard != -1)
+                    if (chatid != UNDEF && shard != -1)
                     {
                         if (client->chats.find(chatid) == client->chats.end())
                         {
@@ -4503,7 +4498,6 @@ void CommandChatCreate::procresult()
                         TextChat *chat = client->chats[chatid];
                         chat->id = chatid;
                         chat->priv = PRIV_MODERATOR;
-                        chat->url = url;
                         chat->shard = shard;
                         delete chat->userpriv;  // discard any existing `userpriv`
                         chat->userpriv = this->chatPeers;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4814,6 +4814,7 @@ void CommandChatUpdatePermissions::procresult()
                 return;
             }
 
+            bool found = false;
             userpriv_vector::iterator upvit;
             for (upvit = chat->userpriv->begin(); upvit != chat->userpriv->end(); upvit++)
             {
@@ -4821,8 +4822,16 @@ void CommandChatUpdatePermissions::procresult()
                 {
                     chat->userpriv->erase(upvit);
                     chat->userpriv->push_back(userpriv_pair(uh, priv));
+                    found = true;
                     break;
                 }
+            }
+
+            if (!found)
+            {
+                // the update succeed, but that peer is not included in the chatroom
+                client->app->chatupdatepermissions_result(API_EINTERNAL);
+                return;
             }
         }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4806,31 +4806,38 @@ void CommandChatUpdatePermissions::procresult()
             }
 
             TextChat *chat = client->chats[chatid];
-            if (!chat->userpriv)
+            if (uh != client->me)
             {
-                // the update succeed, but that peer is not included in the chatroom
-                client->app->chatupdatepermissions_result(API_EINTERNAL);
-                return;
-            }
-
-            bool found = false;
-            userpriv_vector::iterator upvit;
-            for (upvit = chat->userpriv->begin(); upvit != chat->userpriv->end(); upvit++)
-            {
-                if (upvit->first == uh)
+                if (!chat->userpriv)
                 {
-                    chat->userpriv->erase(upvit);
-                    chat->userpriv->push_back(userpriv_pair(uh, priv));
-                    found = true;
-                    break;
+                    // the update succeed, but that peer is not included in the chatroom
+                    client->app->chatupdatepermissions_result(API_EINTERNAL);
+                    return;
+                }
+
+                bool found = false;
+                userpriv_vector::iterator upvit;
+                for (upvit = chat->userpriv->begin(); upvit != chat->userpriv->end(); upvit++)
+                {
+                    if (upvit->first == uh)
+                    {
+                        chat->userpriv->erase(upvit);
+                        chat->userpriv->push_back(userpriv_pair(uh, priv));
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    // the update succeed, but that peer is not included in the chatroom
+                    client->app->chatupdatepermissions_result(API_EINTERNAL);
+                    return;
                 }
             }
-
-            if (!found)
+            else
             {
-                // the update succeed, but that peer is not included in the chatroom
-                client->app->chatupdatepermissions_result(API_EINTERNAL);
-                return;
+                chat->priv = priv;
             }
 
             chat->setTag(tag ? tag : -1);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4700,15 +4700,6 @@ void CommandChatURL::procresult()
         }
         else
         {
-            if (client->chats.find(chatid) == client->chats.end())
-            {
-                // the invitation succeed for a non-existing chatroom
-                client->app->chaturl_result(NULL, API_EINTERNAL);
-                return;
-            }
-
-            client->chats[chatid]->url = url;
-
             client->app->chaturl_result(&url, API_OK);
         }
     }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4503,6 +4503,7 @@ void CommandChatCreate::procresult()
                         chat->userpriv = this->chatPeers;
                         chat->group = group;
 
+                        chat->setTag(tag ? tag : -1);
                         client->notifychat(chat);
 
                         client->app->chatcreate_result(chat, API_OK);
@@ -4580,6 +4581,8 @@ void CommandChatInvite::procresult()
             {
                 chat->title = title;
             }
+
+            chat->setTag(tag ? tag : -1);
             client->notifychat(chat);
         }
 
@@ -4658,6 +4661,7 @@ void CommandChatRemove::procresult()
                 }
             }
 
+            chat->setTag(tag ? tag : -1);
             client->notifychat(chat);
         }
 
@@ -4822,6 +4826,8 @@ void CommandChatUpdatePermissions::procresult()
                 client->app->chatupdatepermissions_result(API_EINTERNAL);
                 return;
             }
+
+            chat->setTag(tag ? tag : -1);
             client->notifychat(chat);
         }
 
@@ -4865,6 +4871,7 @@ void CommandChatTruncate::procresult()
             }
 
             TextChat *chat = client->chats[chatid];
+            chat->setTag(tag ? tag : -1);
             client->notifychat(chat);
         }
 
@@ -4910,6 +4917,7 @@ void CommandChatSetTitle::procresult()
             TextChat *chat = client->chats[chatid];
             chat->title = title;
 
+            chat->setTag(tag ? tag : -1);
             client->notifychat(chat);
         }
 

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -4141,6 +4141,11 @@ const char * MegaTextChat::getTitle() const
     return NULL;
 }
 
+int MegaTextChat::isOwnChange() const
+{
+    return 0;
+}
+
 MegaTextChatList::~MegaTextChatList()
 {
 

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -4116,16 +4116,6 @@ int MegaTextChat::getOwnPrivilege() const
     return PRIV_UNKNOWN;
 }
 
-const char *MegaTextChat::getUrl() const
-{
-    return NULL;
-}
-
-void MegaTextChat::setUrl(const char *)
-{
-
-}
-
 int MegaTextChat::getShard() const
 {
     return -1;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17236,9 +17236,10 @@ MegaTextChatPrivate::MegaTextChatPrivate(const MegaTextChat *chat)
     this->group = chat->isGroup();
     this->ou = chat->getOriginatingUser();
     this->title = chat->getTitle() ? chat->getTitle() : "";
+    this->tag = chat->isOwnChange();
 }
 
-MegaTextChatPrivate::MegaTextChatPrivate(handle id, int priv, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title)
+MegaTextChatPrivate::MegaTextChatPrivate(handle id, int priv, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title, int tag)
 {
     this->id = id;
     this->priv = priv;
@@ -17247,6 +17248,7 @@ MegaTextChatPrivate::MegaTextChatPrivate(handle id, int priv, int shard, const M
     this->group = group;
     this->ou = ou;
     this->title = title;
+    this->tag = tag;
 }
 
 MegaTextChat *MegaTextChatPrivate::copy() const
@@ -17292,6 +17294,11 @@ MegaHandle MegaTextChatPrivate::getOriginatingUser() const
 const char *MegaTextChatPrivate::getTitle() const
 {
     return !title.empty() ? title.c_str() : NULL;
+}
+
+int MegaTextChatPrivate::isOwnChange() const
+{
+    return tag;
 }
 
 MegaTextChatListPrivate::~MegaTextChatListPrivate()
@@ -17356,7 +17363,7 @@ MegaTextChatListPrivate::MegaTextChatListPrivate(textchat_map *list)
     {
         chat = it->second;
         chatPeers = chat->userpriv ? new MegaTextChatPeerListPrivate(chat->userpriv) : NULL;
-        megaChat = new MegaTextChatPrivate(chat->id, chat->priv, chat->shard, chatPeers, chat->group, chat->ou, chat->title);
+        megaChat = new MegaTextChatPrivate(chat->id, chat->priv, chat->shard, chatPeers, chat->group, chat->ou, chat->title, chat->tag);
 
         this->list.push_back(megaChat);
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17231,7 +17231,6 @@ MegaTextChatPrivate::MegaTextChatPrivate(const MegaTextChat *chat)
 {
     this->id = chat->getHandle();
     this->priv = chat->getOwnPrivilege();
-    this->url = chat->getUrl() ? chat->getUrl() : "";
     this->shard = chat->getShard();
     this->peers = chat->getPeerList() ? chat->getPeerList()->copy() : NULL;
     this->group = chat->isGroup();
@@ -17239,11 +17238,10 @@ MegaTextChatPrivate::MegaTextChatPrivate(const MegaTextChat *chat)
     this->title = chat->getTitle() ? chat->getTitle() : "";
 }
 
-MegaTextChatPrivate::MegaTextChatPrivate(handle id, int priv, string url, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title)
+MegaTextChatPrivate::MegaTextChatPrivate(handle id, int priv, int shard, const MegaTextChatPeerList *peers, bool group, handle ou, string title)
 {
     this->id = id;
     this->priv = priv;
-    this->url = url;
     this->shard = shard;
     this->peers = peers ? peers->copy() : NULL;
     this->group = group;
@@ -17269,23 +17267,6 @@ MegaHandle MegaTextChatPrivate::getHandle() const
 int MegaTextChatPrivate::getOwnPrivilege() const
 {
     return priv;
-}
-
-const char *MegaTextChatPrivate::getUrl() const
-{
-    return !url.empty() ? url.c_str() : NULL;
-}
-
-void MegaTextChatPrivate::setUrl(const char *url)
-{
-    if (url)
-    {
-        this->url.assign(url);
-    }
-    else
-    {
-        this->url.clear();
-    }
 }
 
 int MegaTextChatPrivate::getShard() const
@@ -17375,7 +17356,7 @@ MegaTextChatListPrivate::MegaTextChatListPrivate(textchat_map *list)
     {
         chat = it->second;
         chatPeers = chat->userpriv ? new MegaTextChatPeerListPrivate(chat->userpriv) : NULL;
-        megaChat = new MegaTextChatPrivate(chat->id, chat->priv, chat->url, chat->shard, chatPeers, chat->group, chat->ou, chat->title);
+        megaChat = new MegaTextChatPrivate(chat->id, chat->priv, chat->shard, chatPeers, chat->group, chat->ou, chat->title);
 
         this->list.push_back(megaChat);
     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5011,7 +5011,9 @@ void MegaClient::notifypurge(void)
 
         for (textchat_map::iterator it = chatnotify.begin(); it != chatnotify.end(); it++)
         {
-            it->second->notified = false;
+            TextChat *chat = it->second;
+
+            chat->notified = false;
         }
 
         chatnotify.clear();

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4851,6 +4851,7 @@ void MegaClient::sc_chatupdate()
                     delete chat->userpriv;  // discard any existing `userpriv`
                     chat->userpriv = userpriv;
 
+                    chat->setTag(0);    // external change
                     notifychat(chat);
                 }
 
@@ -5014,6 +5015,7 @@ void MegaClient::notifypurge(void)
             TextChat *chat = it->second;
 
             chat->notified = false;
+            chat->resetTag();
         }
 
         chatnotify.clear();

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4811,7 +4811,6 @@ void MegaClient::sc_chatupdate()
                     chat->shard = shard;
                     chat->group = group;
                     chat->priv = PRIV_UNKNOWN;
-                    chat->url = ""; // not received in action packets
                     chat->ou = ou;
                     chat->title = title;
 
@@ -7553,7 +7552,6 @@ void MegaClient::procmcf(JSON *j)
         {
             handle chatid = UNDEF;
             privilege_t priv = PRIV_UNKNOWN;
-            string url;
             int shard = -1;
             userpriv_vector *userpriv = NULL;
             bool group = false;
@@ -7570,10 +7568,6 @@ void MegaClient::procmcf(JSON *j)
 
                 case 'p':
                     priv = (privilege_t) j->getint();
-                    break;
-
-                case MAKENAMEID3('u','r','l'):
-                    j->storeobject(&url);
                     break;
 
                 case MAKENAMEID2('c','s'):
@@ -7603,7 +7597,6 @@ void MegaClient::procmcf(JSON *j)
                         TextChat *chat = chats[chatid];
                         chat->id = chatid;
                         chat->priv = priv;
-                        chat->url = url;
                         chat->shard = shard;
                         chat->group = group;
                         chat->title = title;

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -159,7 +159,7 @@ User* User::unserialize(MegaClient* client, string* d)
 
     client->mapuser(uh, m.c_str());
     u->set(v, ts);
-    u->setTag(-1);
+    u->resetTag();
 
     if (attrVersion == '\0')
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -47,16 +47,10 @@ TextChat::~TextChat()
 
 bool TextChat::serialize(string *d)
 {
-    unsigned char l;
     unsigned short ll;
 
     d->append((char*)&id, sizeof id);
     d->append((char*)&priv, sizeof priv);
-
-    l = (unsigned char)url.size();
-    d->append((char*)&l, sizeof l);
-    d->append(url.c_str(), l);
-
     d->append((char*)&shard, sizeof shard);
 
     ll = userpriv ? userpriv->size() : 0;
@@ -94,14 +88,12 @@ TextChat* TextChat::unserialize(class MegaClient *client, string *d)
 {
     handle id;
     privilege_t priv;
-    string url;
     int shard;
     userpriv_vector *userpriv = NULL;
     bool group;
     string title;   // byte array
     handle ou;
 
-    unsigned char l;
     unsigned short ll;
     const char* ptr = d->data();
     const char* end = ptr + d->size();
@@ -116,17 +108,6 @@ TextChat* TextChat::unserialize(class MegaClient *client, string *d)
 
     priv = MemAccess::get<privilege_t>(ptr);
     ptr += sizeof priv;
-
-    l = *ptr++;
-    if (l)
-    {
-        if (ptr + l > end)
-        {
-            return NULL;
-        }
-        url.assign(ptr, l);
-    }
-    ptr += l;
 
     if (ptr + sizeof(int) + 1 > end)
     {
@@ -215,7 +196,6 @@ TextChat* TextChat::unserialize(class MegaClient *client, string *d)
     TextChat* chat = client->chats[id];
     chat->id = id;
     chat->priv = priv;
-    chat->url = url;
     chat->shard = shard;
     chat->userpriv = userpriv;
     chat->group = group;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -38,6 +38,7 @@ TextChat::TextChat()
     userpriv = NULL;
     group = false;
     ou = UNDEF;
+    resetTag();
 }
 
 TextChat::~TextChat()
@@ -201,8 +202,27 @@ TextChat* TextChat::unserialize(class MegaClient *client, string *d)
     chat->group = group;
     chat->title = title;
     chat->ou = ou;
+    chat->resetTag();
 
     return chat;
+}
+
+void TextChat::setTag(int tag)
+{
+    if (this->tag != 0)    // external changes prevail
+    {
+        this->tag = tag;
+    }
+}
+
+int TextChat::getTag()
+{
+    return tag;
+}
+
+void TextChat::resetTag()
+{
+    tag = -1;
 }
 #endif
 

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -219,7 +219,8 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
                             chat->getShard(),
                             privs, chat->isGroup(),
                             chat->getOriginatingUser(),
-                            chat->getTitle() ? chat->getTitle() : "");
+                            chat->getTitle() ? chat->getTitle() : "",
+                            chat->isOwnChange());
 
                 delete chats[chatid];
                 chats[chatid] = buf;
@@ -259,7 +260,8 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
                             chat->getShard(),
                             privs, chat->isGroup(),
                             chat->getOriginatingUser(),
-                            chat->getTitle() ? chat->getTitle() : "");
+                            chat->getTitle() ? chat->getTitle() : "",
+                            chat->isOwnChange());
 
                 delete chats[chatid];
                 chats[chatid] = buf;

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -216,7 +216,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
 
                 MegaTextChatPrivate *buf = new MegaTextChatPrivate(
                             chatid, chat->getOwnPrivilege(),
-                            chat->getUrl(), chat->getShard(),
+                            chat->getShard(),
                             privs, chat->isGroup(),
                             chat->getOriginatingUser(),
                             chat->getTitle() ? chat->getTitle() : "");
@@ -256,7 +256,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
 
                 MegaTextChatPrivate *buf = new MegaTextChatPrivate(
                             chatid, chat->getOwnPrivilege(),
-                            chat->getUrl(), chat->getShard(),
+                            chat->getShard(),
                             privs, chat->isGroup(),
                             chat->getOriginatingUser(),
                             chat->getTitle() ? chat->getTitle() : "");


### PR DESCRIPTION
 - Added the notification of chats updated via commands (it was totally missing)
 - Update chats in cache according to the commands result
 - Allow to differentiate between own changes and external changes in `MegaTextChat` notified objects