### PR TITLE
Make `MegaApi::getUserAvatarColor()` static member

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -1903,7 +1903,7 @@ typedef NS_ENUM(NSInteger, HTTPServer) {
  * @return The RGB color as a string with 3 components in hex: #RGB. Ie. "#FF6A19"
  * If the user is not found, this function always returns the same color.
  */
-- (NSString *)avatarColorForUser:(MEGAUser *)user;
++ (NSString *)avatarColorForUser:(MEGAUser *)user;
 
 /**
  * @brief Get the default color for the avatar.
@@ -1915,7 +1915,7 @@ typedef NS_ENUM(NSInteger, HTTPServer) {
  * @return The RGB color as a string with 3 components in hex: #RGB. Ie. "#FF6A19"
  * If the user is not found, this function always returns the same color.
  */
-- (NSString *)avatarColorForBase64UserHandle:(NSString *)base64UserHandle;
++ (NSString *)avatarColorForBase64UserHandle:(NSString *)base64UserHandle;
 
 /**
  * @brief Set the avatar of the MEGA account.

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -718,8 +718,8 @@ static DelegateMEGALoggerListener *externalLogger = new DelegateMEGALoggerListen
     self.megaApi->getUserAvatar((emailOrHandle != nil) ? [emailOrHandle UTF8String] : NULL, (destinationFilePath != nil) ? [destinationFilePath UTF8String] : NULL);
 }
 
-- (NSString *)avatarColorForUser:(MEGAUser *)user {
-    const char *val = self.megaApi->getUserAvatarColor((user != nil) ? [user getCPtr] : NULL);
++ (NSString *)avatarColorForUser:(MEGAUser *)user {
+    const char *val = MegaApi::getUserAvatarColor((user != nil) ? [user getCPtr] : NULL);
     if (!val) return nil;
     
     NSString *ret = [[NSString alloc] initWithUTF8String:val];
@@ -728,8 +728,8 @@ static DelegateMEGALoggerListener *externalLogger = new DelegateMEGALoggerListen
     return ret;
 }
 
-- (NSString *)avatarColorForBase64UserHandle:(NSString *)base64UserHandle {
-    const char *val = self.megaApi->getUserAvatarColor((base64UserHandle != nil) ? [base64UserHandle UTF8String] : NULL);
++ (NSString *)avatarColorForBase64UserHandle:(NSString *)base64UserHandle {
+    const char *val = MegaApi::getUserAvatarColor((base64UserHandle != nil) ? [base64UserHandle UTF8String] : NULL);
     if (!val) return nil;
     
     NSString *ret = [[NSString alloc] initWithUTF8String:val];

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -5754,12 +5754,10 @@ class MegaApi
          *
          * You take the ownership of the returned value.
          *
-         * @param user MegaUser to get the color of the avatar. If this parameter is set to NULL, the color
-         *  is obtained for the active account.
+         * @param user MegaUser to get the color of the avatar.
          * @return The RGB color as a string with 3 components in hex: #RGB. Ie. "#FF6A19"
-         * If the user is not found, this function always returns the same color.
          */
-        char *getUserAvatarColor(MegaUser *user);
+        static char *getUserAvatarColor(MegaUser *user);
 
         /**
          * @brief Get the default color for the avatar.
@@ -5768,12 +5766,10 @@ class MegaApi
          *
          * You take the ownership of the returned value.
          *
-         * @param userhandle User handle (Base64 encoded) to get the avatar. If this parameter is
-         * set to NULL, the avatar is obtained for the active account.
+         * @param userhandle User handle (Base64 encoded) to get the avatar.
          * @return The RGB color as a string with 3 components in hex: #RGB. Ie. "#FF6A19"
-         * If the user is not found, this function  always returns the same color.
          */
-        char *getUserAvatarColor(const char *userhandle);
+        static char *getUserAvatarColor(const char *userhandle);
 
         /**
          * @brief Get an attribute of a MegaUser.

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1385,8 +1385,8 @@ class MegaApiImpl : public MegaApp
         void getUserAvatar(MegaUser* user, const char *dstFilePath, MegaRequestListener *listener = NULL);
         void setAvatar(const char *dstFilePath, MegaRequestListener *listener = NULL);
         void getUserAvatar(const char *email_or_handle, const char *dstFilePath, MegaRequestListener *listener = NULL);
-        char* getUserAvatarColor(MegaUser *user);
-        char *getUserAvatarColor(const char *userhandle);
+        static char* getUserAvatarColor(MegaUser *user);
+        static char *getUserAvatarColor(const char *userhandle);
         void getUserAttribute(MegaUser* user, int type, MegaRequestListener *listener = NULL);
         void getUserAttribute(const char* email_or_handle, int type, MegaRequestListener *listener = NULL);
         void setUserAttribute(int type, const char* value, MegaRequestListener *listener = NULL);
@@ -1975,7 +1975,7 @@ protected:
         void setNodeAttribute(MegaNode* node, int type, const char *srcFilePath, MegaRequestListener *listener = NULL);
         void getUserAttr(const char* email_or_handle, int type, const char *dstFilePath, MegaRequestListener *listener = NULL);
         void setUserAttr(int type, const char *value, MegaRequestListener *listener = NULL);
-        char *getAvatarColor(handle userhandle);
+        static char *getAvatarColor(handle userhandle);
 };
 
 class MegaHashSignatureImpl

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1642,12 +1642,12 @@ void MegaApi::getUserAvatar(const char *dstFilePath, MegaRequestListener *listen
 
 char *MegaApi::getUserAvatarColor(MegaUser *user)
 {
-    return pImpl->getUserAvatarColor(user);
+    return MegaApiImpl::getUserAvatarColor(user);
 }
 
 char *MegaApi::getUserAvatarColor(const char *userhandle)
 {
-    return pImpl->getUserAvatarColor(userhandle);
+    return MegaApiImpl::getUserAvatarColor(userhandle);
 }
 
 void MegaApi::setAvatar(const char *dstFilePath, MegaRequestListener *listener)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4633,12 +4633,12 @@ void MegaApiImpl::getUserAvatar(const char* email_or_handle, const char *dstFile
 
 char *MegaApiImpl::getUserAvatarColor(MegaUser *user)
 {
-    return getAvatarColor(user ? (handle) user->getHandle() : client->me);
+    return user ? MegaApiImpl::getAvatarColor((handle) user->getHandle()) : NULL;
 }
 
 char *MegaApiImpl::getUserAvatarColor(const char *userhandle)
 {
-    return getAvatarColor(userhandle ? MegaApiImpl::base64ToUserHandle(userhandle) : client->me);
+    return userhandle ? MegaApiImpl::getAvatarColor(MegaApiImpl::base64ToUserHandle(userhandle)) : NULL;
 }
 
 void MegaApiImpl::setAvatar(const char *dstFilePath, MegaRequestListener *listener)


### PR DESCRIPTION
In case the app does not have Internet connection (not logged in, not fetched nodes), the own userhandle is UNDEF, reporting the wrong avatar color. Better to have this method static