### PR TITLE
Initialize the `pos` pointer for tests

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -34,6 +34,7 @@ TEST(JSON, storeobject)
 {
     std::string in_str("Test");
     JSON j;
+    j.begin(in_str.data());
     j.storeobject(&in_str);
 }
 


### PR DESCRIPTION
It seems the compiler in my new environment does initialize `JSON::pos` variable, resulting in the test for JSON fail.