### PR TITLE
Update own privilege when leave groupchat

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4665,7 +4665,10 @@ void CommandChatRemove::procresult()
                     client->app->chatremove_result(API_EINTERNAL);
                     return;
                 }
+            }
 
+            if (uh == client->me)
+            {
                 chat->priv = PRIV_RM;
             }
 


### PR DESCRIPTION
In case there were more peers in the group, your own privilege was not
updated.