### PR TITLE
Avoid reset asymmkey when it's not set

### DIFF
--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -458,6 +458,9 @@ int AsymmCipher::setkey(int numints, const byte* data, int len)
 
 void AsymmCipher::resetkey()
 {
+    if (!isvalid(PRIVKEY))
+        return;
+
     for (int i = 0; i < PRIVKEY; i++)
     {
         key[i] = Integer::Zero();


### PR DESCRIPTION
If key is reset more than once while logged out (no logins performed in
between), the second attempt will result in a segfault.