### PR TITLE
Disable clock-gettime in libevent for iOS to maintain backwards compa…

### DIFF
--- a/bindings/ios/3rdparty/build-libevent2.sh
+++ b/bindings/ios/3rdparty/build-libevent2.sh
@@ -67,9 +67,9 @@ export CXXFLAGS="${CPPFLAGS}"
 ./autogen.sh
 
 if [ "${ARCH}" == "arm64" ]; then
-./configure --host=aarch64-apple-darwin --enable-static --disable-shared --disable-libevent-regress --disable-tests --disable-samples
+./configure --host=aarch64-apple-darwin --enable-static --disable-shared --disable-libevent-regress --disable-tests --disable-samples --disable-clock-gettime
 else
-./configure --host=${ARCH}-apple-darwin --enable-static --disable-shared --disable-libevent-regress --disable-tests --disable-samples
+./configure --host=${ARCH}-apple-darwin --enable-static --disable-shared --disable-libevent-regress --disable-tests --disable-samples --disable-clock-gettime
 fi
 
 make -j8


### PR DESCRIPTION
…tibility with versions prior to iOS 10