### PR TITLE
Effectively delete inactive users

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -347,6 +347,7 @@ class MEGA_API CommandPubKeyRequest : public Command
 
 public:
     void procresult();
+    void invalidateUser();
 
     CommandPubKeyRequest(MegaClient*, User*);
 };

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1131,6 +1131,7 @@ public:
 
     // queue public key request for user
     void queuepubkeyreq(User*, PubKeyAction*);
+    void queuepubkeyreq(const char*, PubKeyAction*);
 
     // rewrite foreign keys of the node (tree)
     void rewriteforeignkeys(Node* n);

--- a/include/mega/pubkeyaction.h
+++ b/include/mega/pubkeyaction.h
@@ -32,6 +32,7 @@ class MEGA_API PubKeyAction
 {
 public:
     int tag;
+    CommandPubKeyRequest *cmd = NULL;
 
     virtual void proc(MegaClient*, User*) = 0;
 

--- a/include/mega/share.h
+++ b/include/mega/share.h
@@ -36,7 +36,6 @@ struct MEGA_API Share
 
     PendingContactRequest* pcr;
 
-    void removeshare(handle);
     void update(accesslevel_t, m_time_t, PendingContactRequest* = NULL);
 
     void serialize(string*);

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -66,6 +66,7 @@ using namespace std;
 struct AttrMap;
 class BackoffTimer;
 class Command;
+class CommandPubKeyRequest;
 struct DirectRead;
 struct DirectReadNode;
 struct DirectReadSlot;

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -66,7 +66,11 @@ struct MEGA_API User : public Cachable
 
     // user's public key
     AsymmCipher pubk;
-    int pubkrequested;
+    struct
+    {
+        bool pubkrequested : 1;
+        bool isTemporary : 1;
+    };
 
     // actions to take after arrival of the public key
     deque<class PubKeyAction*> pkrs;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2890,7 +2890,7 @@ void CommandPubKeyRequest::procresult()
         u->pkrs.pop_front();
     }
 
-    if (len_pubk)
+    if (len_pubk && !ISUNDEF(u->userhandle))
     {
         client->notifyuser(u);
     }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2890,15 +2890,12 @@ void CommandPubKeyRequest::procresult()
         u->pkrs.pop_front();
     }
 
-    bool isTempUser = (u != client->finduser(u->userhandle) &&
-            u != client->finduser(u->email.c_str()));
-
-    if (len_pubk && !isTempUser)
+    if (len_pubk && !u->isTemporary)
     {
         client->notifyuser(u);
     }
 
-    if (isTempUser)
+    if (u->isTemporary)
     {
         delete u;
         u = NULL;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2890,10 +2890,20 @@ void CommandPubKeyRequest::procresult()
         u->pkrs.pop_front();
     }
 
-    if (len_pubk && !ISUNDEF(u->userhandle))
+    bool isTempUser = (u != client->finduser(u->userhandle) &&
+            u != client->finduser(u->email.c_str()));
+
+    if (len_pubk && !isTempUser)
     {
         client->notifyuser(u);
     }
+
+    if (isTempUser)
+    {
+        delete u;
+        u = NULL;
+    }
+
     return;
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2849,6 +2849,11 @@ void CommandPubKeyRequest::procresult()
                     break;
 
                 case EOO:
+                    if (!u) // user has cancelled the account
+                    {
+                        return;
+                    }
+
                     if (!ISUNDEF(uh))
                     {
                         client->mapuser(uh, u->email.c_str());
@@ -2902,6 +2907,11 @@ void CommandPubKeyRequest::procresult()
     }
 
     return;
+}
+
+void CommandPubKeyRequest::invalidateUser()
+{
+    u = NULL;
 }
 
 CommandGetUserData::CommandGetUserData(MegaClient *client)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6773,6 +6773,7 @@ void MegaClient::discarduser(handle uh)
         {
             pka->cmd->invalidateUser();
         }
+        pka->proc(this, u);
         delete pka;
         u->pkrs.pop_front();
     }
@@ -6797,6 +6798,7 @@ void MegaClient::discarduser(const char *email)
         {
             pka->cmd->invalidateUser();
         }
+        pka->proc(this, u);
         delete pka;
         u->pkrs.pop_front();
     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3432,9 +3432,25 @@ void MegaClient::updatesc()
             // 2. write new or update modified users
             for (user_vector::iterator it = usernotify.begin(); it != usernotify.end(); it++)
             {
-                if (!(complete = sctable->put(CACHEDUSER, *it, &key)))
+                char base64[12];
+                if ((*it)->show == INACTIVE)
                 {
-                    break;
+                    if ((*it)->dbid)
+                    {
+                        LOG_verbose << "Removing inactive user from database: " << (Base64::btoa((byte*)&((*it)->userhandle),MegaClient::USERHANDLE,base64) ? base64 : "");
+                        if (!(complete = sctable->del((*it)->dbid)))
+                        {
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    LOG_verbose << "Adding/updating user to database: " << (Base64::btoa((byte*)&((*it)->userhandle),MegaClient::USERHANDLE,base64) ? base64 : "");
+                    if (!(complete = sctable->put(CACHEDUSER, *it, &key)))
+                    {
+                        break;
+                    }
                 }
             }
         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5037,8 +5037,13 @@ void MegaClient::notifypurge(void)
                 for (handle_set::iterator it = u->sharing.begin(); it != u->sharing.end(); it++)
                 {
                     Node *n = nodebyhandle(*it);
-                    nodes.erase(n->nodehandle);
-                    delete n;
+                    if (n && !n->changed.removed)
+                    {
+                        int creqtag = reqtag;
+                        reqtag = 0;
+                        sendevent(99435, "Orphan incoming share");
+                        reqtag = creqtag;
+                    }
                 }
                 u->sharing.clear();
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5017,6 +5017,15 @@ void MegaClient::notifypurge(void)
 
             if (u->show == INACTIVE && u->userhandle != me)
             {
+                // delete any remaining shares with this user
+                for (handle_set::iterator it = u->sharing.begin(); it != u->sharing.end(); it++)
+                {
+                    Node *n = nodebyhandle(*it);
+                    nodes.erase(n->nodehandle);
+                    delete n;
+                }
+                u->sharing.clear();
+
                 discarduser(u->userhandle);
             }
         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6718,7 +6718,7 @@ void MegaClient::mapuser(handle uh, const char* email)
         u = &users[hit->second];
 
         um_map::iterator mit = umindex.find(nuid);
-        if (mit != umindex.end() && mit->second != hit->second)
+        if (mit != umindex.end() && mit->second != hit->second && users[mit->second].show != INACTIVE)
         {
             // duplicated user: one by email, one by handle
             assert(!users[mit->second].sharing.size());

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5192,7 +5192,7 @@ void MegaClient::putnodes(const char* user, NewNode* newnodes, int numnodes)
 
     restag = reqtag;
 
-    if (!(u = finduser(user, 0)) || !user)
+    if (!(u = finduser(user, 0)) && !user)
     {
         return app->putnodes_result(API_EARGS, USER_HANDLE, newnodes);
     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6901,6 +6901,7 @@ void MegaClient::queuepubkeyreq(User* u, PubKeyAction* pka)
         if (!u->pubkrequested)
         {
             reqs.add(new CommandPubKeyRequest(this, u));
+            u->pubkrequested = true;
         }
     }
 }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6919,6 +6919,7 @@ void MegaClient::queuepubkeyreq(const char *uid, PubKeyAction *pka)
 
             u = new User(nuid.c_str());
             u->uid = nuid;
+            u->isTemporary = true;
         }
         else    // not an e-mail address: must be ASCII handle
         {
@@ -6928,6 +6929,7 @@ void MegaClient::queuepubkeyreq(const char *uid, PubKeyAction *pka)
                 u = new User(NULL);
                 u->userhandle = uh;
                 u->uid = uid;
+                u->isTemporary = true;
             }
         }
     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4999,7 +4999,7 @@ void MegaClient::notifypurge(void)
         pcrnotify.clear();
     }
 
-    // users are never deleted
+    // users are never deleted (except at account cancellation)
     if ((t = usernotify.size()))
     {
         if (!fetchingnodes)
@@ -5014,6 +5014,11 @@ void MegaClient::notifypurge(void)
             u->notified = false;
             u->resetTag();
             memset(&(u->changed), 0, sizeof(u->changed));
+
+            if (u->show == INACTIVE && u->userhandle != me)
+            {
+                discarduser(u->userhandle);
+            }
         }
 
         usernotify.clear();

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -29,7 +29,8 @@ User::User(const char* cemail)
     userhandle = UNDEF;
     show = VISIBILITY_UNKNOWN;
     ctime = 0;
-    pubkrequested = 0;
+    pubkrequested = false;
+    isTemporary = false;
     resetTag();
 
     if (cemail)


### PR DESCRIPTION
since keeping them as inactive users may cause conflicts when a new user
is registered under the same email address than the cancelled account.