### PR TITLE
Update WP & UWP bindings

### DIFF
--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -2883,6 +2883,12 @@ MShareList^ MegaSDK::getInSharesList()
     return ref new MShareList(megaApi->getInSharesList(), true);
 }
 
+MUser^ MegaSDK::getUserFromInShare(MNode^ node)
+{
+    MegaUser *user = megaApi->getUserFromInShare((node != nullptr) ? node->getCPtr() : NULL);
+    return user ? ref new MUser(user, true) : nullptr;
+}
+
 bool MegaSDK::isShared(MNode^ node)
 {
     return megaApi->isShared(node->getCPtr());

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -2891,22 +2891,22 @@ MUser^ MegaSDK::getUserFromInShare(MNode^ node)
 
 bool MegaSDK::isShared(MNode^ node)
 {
-    return megaApi->isShared(node->getCPtr());
+    return megaApi->isShared((node != nullptr) ? node->getCPtr() : NULL);
 }
 
 bool MegaSDK::isOutShare(MNode^ node)
 {
-    return megaApi->isOutShare(node->getCPtr());
+    return megaApi->isOutShare((node != nullptr) ? node->getCPtr() : NULL);
 }
 
 bool MegaSDK::isInShare(MNode^ node)
 {
-    return megaApi->isInShare(node->getCPtr());
+    return megaApi->isInShare((node != nullptr) ? node->getCPtr() : NULL);
 }
 
 bool MegaSDK::isPendingShare(MNode^ node)
 {
-    return megaApi->isPendingShare(node->getCPtr());
+    return megaApi->isPendingShare((node != nullptr) ? node->getCPtr() : NULL);
 }
 
 MShareList^ MegaSDK::getOutShares()

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -3143,6 +3143,12 @@ MNode^ MegaSDK::getRootNode()
 	return node ? ref new MNode(node, true) : nullptr;
 }
 
+MNode^ MegaSDK::getRootNode(MNode^ node)
+{
+    MegaNode *rootNode = megaApi->getRootNode((node != nullptr) ? node->getCPtr() : NULL);
+    return rootNode ? ref new MNode(rootNode, true) : nullptr;
+}
+
 MNode^ MegaSDK::getInboxNode()
 {
     MegaNode *node = megaApi->getInboxNode();
@@ -3153,6 +3159,21 @@ MNode^ MegaSDK::getRubbishNode()
 {
 	MegaNode *node = megaApi->getRubbishNode();
 	return node ? ref new MNode(node, true) : nullptr;
+}
+
+bool MegaSDK::isInCloud(MNode^ node)
+{
+    return megaApi->isInCloud((node != nullptr) ? node->getCPtr() : NULL);
+}
+
+bool MegaSDK::isInRubbish(MNode^ node)
+{
+    return megaApi->isInRubbish((node != nullptr) ? node->getCPtr() : NULL);
+}
+
+bool MegaSDK::isInInbox(MNode^ node)
+{
+    return megaApi->isInInbox((node != nullptr) ? node->getCPtr() : NULL);
 }
 
 uint64 MegaSDK::getBandwidthOverquotaDelay()

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -494,8 +494,12 @@ namespace mega
 
         bool isFilesystemAvailable();
         MNode^ getRootNode();
+        MNode^ getRootNode(MNode^ node);
         MNode^ getInboxNode();
         MNode^ getRubbishNode();
+        bool isInCloud(MNode^ node);
+        bool isInRubbish(MNode^ node);
+        bool isInInbox(MNode^ node);
 
         uint64 getBandwidthOverquotaDelay();
 

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -454,6 +454,7 @@ namespace mega
         MNodeList^ getInShares(MUser^ user);
         MNodeList^ getInShares();
         MShareList^ getInSharesList();
+        MUser^ getUserFromInShare(MNode^ node);
         bool isShared(MNode^ node);
         bool isOutShare(MNode^ node);
         bool isInShare(MNode^ node);


### PR DESCRIPTION
- Get user from incoming share
- Check if node belongs to a rootnode
- Fix WP & UWP bindings. Protect `isShared`, `isOutShare`, `isInShare` and `isPendingShare` against NULL