### PR TITLE
Fix WP compilation issue

### DIFF
--- a/include/mega/pubkeyaction.h
+++ b/include/mega/pubkeyaction.h
@@ -32,10 +32,11 @@ class MEGA_API PubKeyAction
 {
 public:
     int tag;
-    CommandPubKeyRequest *cmd = NULL;
+    CommandPubKeyRequest *cmd;
 
     virtual void proc(MegaClient*, User*) = 0;
 
+    PubKeyAction();
     virtual ~PubKeyAction() { }
 };
 

--- a/src/pubkeyaction.cpp
+++ b/src/pubkeyaction.cpp
@@ -24,6 +24,11 @@
 #include "mega/command.h"
 
 namespace mega {
+PubKeyAction::PubKeyAction()
+{ 
+    cmd = NULL; 
+};
+
 PubKeyActionPutNodes::PubKeyActionPutNodes(NewNode* newnodes, int numnodes, int ctag)
 {
     nn = newnodes;

--- a/src/pubkeyaction.cpp
+++ b/src/pubkeyaction.cpp
@@ -27,7 +27,7 @@ namespace mega {
 PubKeyAction::PubKeyAction()
 { 
     cmd = NULL; 
-};
+}
 
 PubKeyActionPutNodes::PubKeyActionPutNodes(NewNode* newnodes, int numnodes, int ctag)
 {


### PR DESCRIPTION
Error c2864: Only static const integral data members can be initialized within a class