### PR TITLE
Change the type of the returned value by `getExpirationTime` (WP & UWP bindings)

### DIFF
--- a/bindings/wp8/MNode.cpp
+++ b/bindings/wp8/MNode.cpp
@@ -176,9 +176,9 @@ int MNode::getTag()
     return megaNode ? megaNode->getTag() : 0;
 }
 
-uint64 MNode::getExpirationTime()
+int64 MNode::getExpirationTime()
 {
-    return megaNode ? megaNode->getExpirationTime() : 0;
+    return megaNode ? megaNode->getExpirationTime() : -1;
 }
 
 MegaHandle MNode::getPublicHandle()

--- a/bindings/wp8/MNode.h
+++ b/bindings/wp8/MNode.h
@@ -81,7 +81,7 @@ namespace mega
         uint64 getParentHandle();
         String^ getBase64Key();
         int getTag();
-        uint64 getExpirationTime();
+        int64 getExpirationTime();
         MegaHandle getPublicHandle();
         MNode^ getPublicNode();
         String^ getPublicLink(bool includeKey);


### PR DESCRIPTION
Changed from **uint64** to **int64** because the API returns the expiration time as an Epoch timestamp, 0 for non-expire links, and **-1** if the MegaNode is not exported.