### PR TITLE
Update WP & UWP bindings

### DIFF
--- a/bindings/wp8/MAccountDetails.cpp
+++ b/bindings/wp8/MAccountDetails.cpp
@@ -128,6 +128,11 @@ uint64 MAccountDetails::getNumFolders(uint64 handle)
 	return accountDetails ? accountDetails->getNumFolders(handle) : 0;
 }
 
+MAccountDetails^ MAccountDetails::copy()
+{
+    return accountDetails ? ref new MAccountDetails(accountDetails->copy(), true) : nullptr;
+}
+
 int MAccountDetails::getNumBalances()
 {
     return accountDetails ? accountDetails->getNumBalances() : 0;
@@ -176,4 +181,9 @@ int MAccountDetails::getTemporalBandwidthInterval()
 uint64 MAccountDetails::getTemporalBandwidth()
 {
     return accountDetails ? accountDetails->getTemporalBandwidth() : 0;
+}
+
+bool MAccountDetails::isTemporalBandwidthValid()
+{
+    return accountDetails ? accountDetails->isTemporalBandwidthValid() : false;
 }

--- a/bindings/wp8/MAccountDetails.h
+++ b/bindings/wp8/MAccountDetails.h
@@ -71,6 +71,8 @@ namespace mega
 		uint64 getNumFiles(uint64 handle);
 		uint64 getNumFolders(uint64 handle);
 
+        MAccountDetails^ copy();
+
         int getNumBalances();
         MAccountBalance^ getBalance(int i);
 
@@ -85,6 +87,8 @@ namespace mega
 
         int getTemporalBandwidthInterval();
         uint64 getTemporalBandwidth();
+
+        bool isTemporalBandwidthValid();
 
 	private:
 		MAccountDetails(MegaAccountDetails *accountDetails, bool cMemoryOwn);

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -2687,6 +2687,11 @@ bool MegaSDK::isWaiting()
     return megaApi->isWaiting();
 }
 
+bool MegaSDK::areServersBusy()
+{
+    return megaApi->areServersBusy();
+}
+
 int MegaSDK::getNumPendingUploads()
 {
 	return megaApi->getNumPendingUploads();
@@ -2722,6 +2727,11 @@ void MegaSDK::updateStats()
     megaApi->updateStats();
 }
 
+uint64 MegaSDK::getNumNodes()
+{
+    return megaApi->getNumNodes();
+}
+
 uint64 MegaSDK::getTotalDownloadedBytes()
 {
     return megaApi->getTotalDownloadedBytes();
@@ -2730,6 +2740,16 @@ uint64 MegaSDK::getTotalDownloadedBytes()
 uint64 MegaSDK::getTotalUploadedBytes()
 {
     return megaApi->getTotalUploadedBytes();
+}
+
+uint64 MegaSDK::getTotalDownloadBytes()
+{
+    return megaApi->getTotalDownloadBytes();
+}
+
+uint64 MegaSDK::getTotalUploadBytes()
+{
+    return megaApi->getTotalUploadBytes();
 }
 
 int MegaSDK::getNumChildren(MNode^ parent)
@@ -2755,6 +2775,11 @@ MNodeList^ MegaSDK::getChildren(MNode^ parent, int order)
 MNodeList^ MegaSDK::getChildren(MNode^ parent)
 {
 	return ref new MNodeList(megaApi->getChildren((parent != nullptr) ? parent->getCPtr() : NULL), true);
+}
+
+bool MegaSDK::hasChildren(MNode^ parent)
+{
+    return megaApi->hasChildren((parent != nullptr) ? parent->getCPtr() : NULL);
 }
 
 int MegaSDK::getIndex(MNode^ node, int order)

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -3247,6 +3247,15 @@ void MegaSDK::changeApiUrl(String^ apiURL)
     megaApi->changeApiUrl((apiURL != nullptr) ? utf8apiURL.c_str() : NULL, false);
 }
 
+bool MegaSDK::setLanguage(String^ languageCode)
+{
+    std::string utf8languageCode;
+    if (languageCode != nullptr)
+        MegaApi::utf16ToUtf8(languageCode->Data(), languageCode->Length(), &utf8languageCode);
+
+    return megaApi->setLanguage((languageCode != nullptr) ? utf8languageCode.c_str() : NULL);
+}
+
 bool MegaSDK::createThumbnail(String^ imagePath, String^ dstPath)
 {
     std::string utf8imagePath;

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -3229,6 +3229,24 @@ MNode^ MegaSDK::authorizeNode(MNode^ node)
     return ref new MNode(megaApi->authorizeNode((node != nullptr) ? node->getCPtr() : NULL), true);
 }
 
+void MegaSDK::changeApiUrl(String^ apiURL, bool disablepkp)
+{
+    std::string utf8apiURL;
+    if (apiURL != nullptr)
+        MegaApi::utf16ToUtf8(apiURL->Data(), apiURL->Length(), &utf8apiURL);
+
+    megaApi->changeApiUrl((apiURL != nullptr) ? utf8apiURL.c_str() : NULL, disablepkp);
+}
+
+void MegaSDK::changeApiUrl(String^ apiURL)
+{
+    std::string utf8apiURL;
+    if (apiURL != nullptr)
+        MegaApi::utf16ToUtf8(apiURL->Data(), apiURL->Length(), &utf8apiURL);
+
+    megaApi->changeApiUrl((apiURL != nullptr) ? utf8apiURL.c_str() : NULL, false);
+}
+
 bool MegaSDK::createThumbnail(String^ imagePath, String^ dstPath)
 {
     std::string utf8imagePath;

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -511,6 +511,9 @@ namespace mega
 
         MNode^ authorizeNode(MNode^ node);
         
+        void changeApiUrl(String^ apiURL, bool disablepkp);
+        void changeApiUrl(String^ apiURL);
+
         bool createThumbnail(String^ imagePath, String^ dstPath);
         bool createPreview(String^ imagePath, String^ dstPath);
 

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -421,6 +421,7 @@ namespace mega
         MTransferList^ getChildTransfers(int transferTag);
         
         bool isWaiting();
+        bool areServersBusy();
 
         //Statistics
         int getNumPendingUploads();
@@ -430,8 +431,11 @@ namespace mega
         void resetTotalDownloads();
         void resetTotalUploads();
         void updateStats();
+        uint64 getNumNodes();
         uint64 getTotalDownloadedBytes();
         uint64 getTotalUploadedBytes();
+        uint64 getTotalDownloadBytes();
+        uint64 getTotalUploadBytes();
         
         //Filesystem
         int getNumChildren(MNode^ parent);
@@ -439,6 +443,7 @@ namespace mega
         int getNumChildFolders(MNode^ parent);
         MNodeList^ getChildren(MNode^ parent, int order);
         MNodeList^ getChildren(MNode^ parent);
+        bool hasChildren(MNode^ parent);
         int getIndex(MNode^ node, int order);
         int getIndex(MNode^ node);
         MNode^ getChildNode(MNode^ parent, String^ name);

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -513,6 +513,7 @@ namespace mega
         
         void changeApiUrl(String^ apiURL, bool disablepkp);
         void changeApiUrl(String^ apiURL);
+        bool setLanguage(String^ languageCode);
 
         bool createThumbnail(String^ imagePath, String^ dstPath);
         bool createPreview(String^ imagePath, String^ dstPath);


### PR DESCRIPTION
- Check if the temporal bandwidth usage is valid after an overquota error.
- Allow change the API URL.
- Allow to set the language code.