### PR TITLE
Fix out-of-sync `User::notified`

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -8921,6 +8921,8 @@ void MegaClient::purgenodesusersabortsc()
         }
         else
         {
+            u->dbid = 0;
+            u->notified = false;
             it++;
         }
     }


### PR DESCRIPTION
The `usernotify` vector is cleared but the object corresponding to the
own user is kept in memory with the `notified` flag to true, so it never
gets notified again.

Already tested by @carolzato 