### PR TITLE
Add webclient-compatibility fix for `sigPubk`

### DIFF
--- a/include/mega/crypto/cryptopp.h
+++ b/include/mega/crypto/cryptopp.h
@@ -359,14 +359,13 @@ public:
     void serializekey(string* d, int keytype);
 
     /**
-     * @brief Serialize key for compatibility with the webclient.
+     * @brief Serialize public key for compatibility with the webclient.
      *
      * @param d String to take the serialized key without size-headers
-     * @param keytype Key type indication by number of integers for key type
-     *     (AsymmCipher::PRIVKEY or AsymmCipher::PUBKEY).
+     * @param fixedSize Boolean to indicate if PUB_E size is forced to 4 bytes
      * @return Void.
      */
-    void serializekeyforjs(string* d, int keytype);
+    void serializekeyforjs(string& d, bool fixedSize = false);
 
     /**
      * @brief Generates an RSA key pair of a given key size.

--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -466,12 +466,12 @@ void AsymmCipher::resetkey()
 
 void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
 {
-    unsigned sizePQ = key[PUB_PQ].ByteCount();    // 4 bytes for exponent, as used in Webclient
+    unsigned sizePQ = key[PUB_PQ].ByteCount();
     unsigned sizeE = key[PUB_E].ByteCount();
     char c;
 
     d.clear();
-    d.reserve(sizePQ + 4);
+    d.reserve(sizePQ + sizeE);
 
     for (int j = key[PUB_PQ].ByteCount(); j--;)
     {
@@ -483,6 +483,7 @@ void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
     {
         // accounts created by webclient use 4 bytes for serialization of exponent
         // --> add left-padding up to 4 bytes for compatibility reasons
+        d.reserve(sizePQ + 4);        
         c = 0;
         for (unsigned j = 0; j < 4 - sizeE; j++)
         {
@@ -492,7 +493,7 @@ void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
 
     for (int j = sizeE; j--;)
     {
-        c = key[1].GetByte(j);  // returns 0 if out-of-range
+        c = key[PUB_E].GetByte(j);  // returns 0 if out-of-range
         d.append(&c, sizeof c);
     }
 }

--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -464,9 +464,37 @@ void AsymmCipher::resetkey()
     }
 }
 
-void AsymmCipher::serializekeyforjs(string* d, int keytype)
+void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
 {
-    serializeintarray(key, keytype, d, false);
+    unsigned sizePQ = key[PUB_PQ].ByteCount();    // 4 bytes for exponent, as used in Webclient
+    unsigned sizeE = key[PUB_E].ByteCount();
+    char c;
+
+    d.clear();
+    d.reserve(sizePQ + 4);
+
+    for (int j = key[PUB_PQ].ByteCount(); j--;)
+    {
+        c = key[PUB_PQ].GetByte(j);
+        d.append(&c, sizeof c);
+    }
+
+    if (fixedSize)
+    {
+        // accounts created by webclient use 4 bytes for serialization of exponent
+        // --> add left-padding up to 4 bytes for compatibility reasons
+        c = 0;
+        for (unsigned j = 0; j < 4 - sizeE; j++)
+        {
+            d.append(&c, sizeof c);
+        }
+    }
+
+    for (int j = sizeE; j--;)
+    {
+        c = key[1].GetByte(j);  // returns 0 if out-of-range
+        d.append(&c, sizeof c);
+    }
 }
 
 void AsymmCipher::serializekey(string* d, int keytype)

--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -471,7 +471,7 @@ void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
     char c;
 
     d.clear();
-    d.reserve(sizePQ + sizeE);
+    d.reserve(!fixedSize ? sizePQ + sizeE : sizePQ + 4);
 
     for (int j = key[PUB_PQ].ByteCount(); j--;)
     {
@@ -483,7 +483,6 @@ void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
     {
         // accounts created by webclient use 4 bytes for serialization of exponent
         // --> add left-padding up to 4 bytes for compatibility reasons
-        d.reserve(sizePQ + 4);        
         c = 0;
         for (unsigned j = 0; j < 4 - sizeE; j++)
         {


### PR DESCRIPTION
Signatures of public RSA keys generated by weclient use 4 bytes for
serialization of exponent, while the SDK uses the minimum required
bytes, which results on verification failure for accounts confirmed in
webclient.