### PR TITLE
(obsolete) New features related to MEGAchat

### DIFF
--- a/bindings/ios/3rdparty/build-curl.sh
+++ b/bindings/ios/3rdparty/build-curl.sh
@@ -36,7 +36,7 @@ set -e
 
 if [ ! -e "curl-${CURL_VERSION}.tar.gz" ]
 then
-wget "https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz"
+curl -LO "https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz"
 fi
 
 for ARCH in ${ARCHS}
@@ -51,6 +51,9 @@ fi
 rm -rf curl-${CURL_VERSION}
 tar zxf curl-${CURL_VERSION}.tar.gz
 pushd "curl-${CURL_VERSION}"
+
+# Do not resolve IPs!!
+sed -i '' $'s/\#define USE_RESOLVE_ON_IPS 1//' lib/curl_setup.h
 
 export BUILD_TOOLS="${DEVELOPER}"
 export BUILD_DEVROOT="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"

--- a/include/mega/http.h
+++ b/include/mega/http.h
@@ -196,7 +196,7 @@ struct MEGA_API HttpReq
     reqstatus_t status;
     m_off_t pos;
 
-    int httpstatus;
+    long httpstatus;
 
     httpmethod_t method;
     contenttype_t type;

--- a/include/mega/http.h
+++ b/include/mega/http.h
@@ -197,6 +197,7 @@ struct MEGA_API HttpReq
     string in;
     size_t inpurge;
     size_t outpos;
+    string ip;
 
     string outbuf;
 
@@ -221,6 +222,9 @@ struct MEGA_API HttpReq
 
     // post request to the network
     void post(MegaClient*, const char* = NULL, unsigned = 0);
+
+    // send a DNS request
+    void dnsrequest(MegaClient*, const char*);
 
     // store chunk of incoming data with optional purging
     void put(void*, unsigned, bool = false);

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -277,8 +277,8 @@ struct MEGA_API MegaApp
     // account confirmation via signup link
     virtual void notify_confirmation(const char* email) { }
 
-    // DNS request finished
-    virtual void dns_result(error, string*) { }
+    // HTTP request finished
+    virtual void http_result(error, int, byte*, int) { }
 
     virtual ~MegaApp() { }
 };

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -277,6 +277,9 @@ struct MEGA_API MegaApp
     // account confirmation via signup link
     virtual void notify_confirmation(const char* email) { }
 
+    // DNS request finished
+    virtual void dns_result(error, string*) { }
+
     virtual ~MegaApp() { }
 };
 } // namespace

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -411,6 +411,8 @@ public:
     // get a local ssl certificate for communications with the webclient
     void getlocalsslcertificate();
 
+    void dnsrequest(const char*);
+
     // maximum outbound throughput (per target server)
     int putmbpscap;
 
@@ -741,6 +743,8 @@ public:
     // reqs[r] is open for adding commands
     // reqs[r^1] is being processed on the API server
     HttpReq* pendingcs;
+
+    pendingdns_map pendingdns;
 
     // record type indicator for sctable
     enum { CACHEDSCSN, CACHEDNODE, CACHEDUSER, CACHEDLOCALNODE, CACHEDPCR, CACHEDTRANSFER, CACHEDFILE, CACHEDCHAT } sctablerectype;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -411,7 +411,17 @@ public:
     // get a local ssl certificate for communications with the webclient
     void getlocalsslcertificate();
 
+    // send a DNS request to resolve a hostname
     void dnsrequest(const char*);
+
+    // send a GeLB request for a service with a timeout (in ms) and a number of retries
+    void gelbrequest(const char*, int, int);
+
+    // send chat stats
+    void sendchatstats(const char*);
+
+    // send a HTTP request
+    void httprequest(const char*, int, bool = false, const char* = NULL, int = 1);
 
     // maximum outbound throughput (per target server)
     int putmbpscap;
@@ -555,6 +565,12 @@ public:
 
     // root URL for API requests
     static string APIURL;
+
+    // root URL for GeLB requests
+    static string GELBURL;
+
+    // root URL for chat stats
+    static string CHATSTATSURL;
 
     // account auth for public folders
     string accountauth;
@@ -744,7 +760,8 @@ public:
     // reqs[r^1] is being processed on the API server
     HttpReq* pendingcs;
 
-    pendingdns_map pendingdns;
+    // pending HTTP requests
+    pendinghttp_map pendinghttp;
 
     // record type indicator for sctable
     enum { CACHEDSCSN, CACHEDNODE, CACHEDUSER, CACHEDLOCALNODE, CACHEDPCR, CACHEDTRANSFER, CACHEDFILE, CACHEDCHAT } sctablerectype;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -76,6 +76,7 @@ struct FileAttributeFetchChannel;
 struct FileFingerprint;
 struct FileFingerprintCmp;
 struct HttpReq;
+struct GenericHttpReq;
 struct HttpReqCommandPutFA;
 struct LocalNode;
 class MegaClient;
@@ -111,9 +112,9 @@ typedef enum { REQ_READY, REQ_PREPARED, REQ_INFLIGHT, REQ_SUCCESS, REQ_FAILURE, 
 
 typedef enum { USER_HANDLE, NODE_HANDLE } targettype_t;
 
-// FIXME: We should probably add a new enum for HTTP methods (POST, GET)
-// and put the DNS type there instead of here.
-typedef enum { REQ_BINARY, REQ_JSON, REQ_DNS } contenttype_t;
+typedef enum { METHOD_POST, METHOD_GET, METHOD_NONE} httpmethod_t;
+
+typedef enum { REQ_BINARY, REQ_JSON } contenttype_t;
 
 // new node source types
 typedef enum { NEW_NODE, NEW_PUBLIC, NEW_UPLOAD } newnodesource_t;
@@ -275,7 +276,7 @@ typedef deque<Transfer*> transfer_list;
 typedef map<int, vector<uint32_t> > pendingdbid_map;
 
 // map a request tag with a pending dns request
-typedef map<int, HttpReq*> pendingdns_map;
+typedef map<int, GenericHttpReq*> pendinghttp_map;
 
 // map a request tag with pending paths of temporary files
 typedef map<int, vector<string> > pendingfiles_map;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -111,7 +111,9 @@ typedef enum { REQ_READY, REQ_PREPARED, REQ_INFLIGHT, REQ_SUCCESS, REQ_FAILURE, 
 
 typedef enum { USER_HANDLE, NODE_HANDLE } targettype_t;
 
-typedef enum { REQ_BINARY, REQ_JSON } contenttype_t;
+// FIXME: We should probably add a new enum for HTTP methods (POST, GET)
+// and put the DNS type there instead of here.
+typedef enum { REQ_BINARY, REQ_JSON, REQ_DNS } contenttype_t;
 
 // new node source types
 typedef enum { NEW_NODE, NEW_PUBLIC, NEW_UPLOAD } newnodesource_t;
@@ -271,6 +273,9 @@ typedef deque<Transfer*> transfer_list;
 
 // map a request tag with pending dbids of transfers and files
 typedef map<int, vector<uint32_t> > pendingdbid_map;
+
+// map a request tag with a pending dns request
+typedef map<int, HttpReq*> pendingdns_map;
 
 // map a request tag with pending paths of temporary files
 typedef map<int, vector<string> > pendingfiles_map;

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -9020,7 +9020,7 @@ class MegaApi
          * @param hostname Hostname to resolve
          * @param listener MegaRequestListener to track this request
          */
-        void queryDNS(char *hostname, MegaRequestListener *listener = NULL);
+        void queryDNS(const char *hostname, MegaRequestListener *listener = NULL);
 
         /**
          * @brief queryGeLB Query the GeLB server for a given service
@@ -9037,7 +9037,7 @@ class MegaApi
          * @param timeoutms Timeout for the request, including all possible retries
          * @param listener MegaRequestListener to track this request
          */
-        void queryGeLB(char *service, int timeoutms = 4000, int maxretries = 4, MegaRequestListener *listener = NULL);
+        void queryGeLB(const char *service, int timeoutms = 4000, int maxretries = 4, MegaRequestListener *listener = NULL);
 
         /**
          * @brief Download a file using a HTTP GET request
@@ -9057,7 +9057,7 @@ class MegaApi
          * @param dstpath Destination path for the downloaded file
          * @param listener MegaRequestListener to track this request
          */
-        void downloadFile(char *url, char *dstpath, MegaRequestListener *listener = NULL);
+        void downloadFile(const char *url, const char *dstpath, MegaRequestListener *listener = NULL);
 
         /**
          * @brief Get the User-Agent header used by the SDK

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1969,7 +1969,7 @@ class MegaRequest
             TYPE_CHAT_UPDATE_PERMISSIONS, TYPE_CHAT_TRUNCATE, TYPE_CHAT_SET_TITLE, TYPE_SET_MAX_CONNECTIONS,
             TYPE_PAUSE_TRANSFER, TYPE_MOVE_TRANSFER, TYPE_CHAT_PRESENCE_URL, TYPE_REGISTER_PUSH_NOTIFICATION,
             TYPE_GET_USER_EMAIL, TYPE_APP_VERSION, TYPE_GET_LOCAL_SSL_CERT, TYPE_SEND_SIGNUP_LINK,
-            TYPE_QUERY_DNS,
+            TYPE_QUERY_DNS, TYPE_QUERY_GELB, TYPE_CHAT_STATS, TYPE_DOWNLOAD_FILE,
             TOTAL_OF_REQUEST_TYPES
         };
 
@@ -8999,11 +8999,55 @@ class MegaApi
         void getLocalSSLCertificate(MegaRequestListener *listener = NULL);
 
         /**
-         * @brief FIXME: Add documentation
-         * @param hostname
-         * @param listener
+         * @brief Send a DNS request to resolve a hostname
+         *
+         * The associated request type with this request is MegaRequest::TYPE_QUERY_DNS
+         *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getText - Returns the IP of the hostname
+         *
+         * @param hostname Hostname to resolve
+         * @param listener MegaRequestListener to track this request
          */
         void queryDNS(char *hostname, MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief queryGeLB Query the GeLB server for a given service
+         *
+         * The associated request type with this request is MegaRequest::TYPE_QUERY_GELB
+         *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getNumber - Return the HTTP status code from the GeLB server
+         * - MegaRequest::getText - Returns the JSON response from the GeLB server
+         * - MegaRequest::getTotalBytes - Returns the number of bytes in the response
+         *
+         * @param service Service to check
+         * @param timeoutms Timeout for the request, including all possible retries
+         * @param listener MegaRequestListener to track this request
+         */
+        void queryGeLB(char *service, int timeoutms = 4000, int maxretries = 4, MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Download a file using a HTTP GET request
+         *
+         * The associated request type with this request is MegaRequest::TYPE_DOWNLOAD_FILE
+         *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getNumber - Return the HTTP status code from the server
+         * - MegaRequest::getTotalBytes - Returns the number of bytes of the file
+         *
+         * If the request finishes with the error code MegaError::API_OK, the destination path
+         * contains the downloaded file. If it's not possible to write in the destination path
+         * the error code will be MegaError::API_EWRITE
+         *
+         * @param url URL of the file
+         * @param dstpath Destination path for the downloaded file
+         * @param listener MegaRequestListener to track this request
+         */
+        void downloadFile(char *url, char *dstpath, MegaRequestListener *listener = NULL);
 
         /**
          * @brief Get the User-Agent header used by the SDK
@@ -9795,6 +9839,22 @@ class MegaApi
          * @param listener MegaRequestListener to track this request
          */
         void registerPushNotifications(int deviceType, const char *token, MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Send data related to MEGAchat to the stats server
+         *
+         * The associated request type with this request is MegaRequest::TYPE_CHAT_STATS
+         *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getNumber - Return the HTTP status code from the stats server
+         * - MegaRequest::getText - Returns the JSON response from the stats server
+         * - MegaRequest::getTotalBytes - Returns the number of bytes in the response
+         *
+         * @param data JSON data to send to the stats server
+         * @param listener MegaRequestListener to track this request
+         */
+        void sendChatStats(const char *data, MegaRequestListener *listener = NULL);
 
         /**
          * @brief Get the list of chatrooms for this account

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -9005,13 +9005,17 @@ class MegaApi
         void getLocalSSLCertificate(MegaRequestListener *listener = NULL);
 
         /**
-         * @brief Send a DNS request to resolve a hostname
+         * @brief Get the IP of a MegaChat server
+         *
+         * This function allows to get the correct IP to connect to a MEGAchat server
+         * using Websockets.
          *
          * The associated request type with this request is MegaRequest::TYPE_QUERY_DNS
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
-         * - MegaRequest::getText - Returns the IP of the hostname
+         * - MegaRequest::getText - Returns the IP of the hostname. 
+         * IPv6 addresses are returned between brackets
          *
          * @param hostname Hostname to resolve
          * @param listener MegaRequestListener to track this request

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1969,6 +1969,7 @@ class MegaRequest
             TYPE_CHAT_UPDATE_PERMISSIONS, TYPE_CHAT_TRUNCATE, TYPE_CHAT_SET_TITLE, TYPE_SET_MAX_CONNECTIONS,
             TYPE_PAUSE_TRANSFER, TYPE_MOVE_TRANSFER, TYPE_CHAT_PRESENCE_URL, TYPE_REGISTER_PUSH_NOTIFICATION,
             TYPE_GET_USER_EMAIL, TYPE_APP_VERSION, TYPE_GET_LOCAL_SSL_CERT, TYPE_SEND_SIGNUP_LINK,
+            TYPE_QUERY_DNS,
             TOTAL_OF_REQUEST_TYPES
         };
 
@@ -8996,6 +8997,13 @@ class MegaApi
          * @param listener MegaRequestListener to track this request
          */
         void getLocalSSLCertificate(MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief FIXME: Add documentation
+         * @param hostname
+         * @param listener
+         */
+        void queryDNS(char *hostname, MegaRequestListener *listener = NULL);
 
         /**
          * @brief Get the User-Agent header used by the SDK

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1625,6 +1625,8 @@ class MegaApiImpl : public MegaApp
         void getLastAvailableVersion(const char *appKey, MegaRequestListener *listener = NULL);
         void getLocalSSLCertificate(MegaRequestListener *listener = NULL);
         void queryDNS(char *hostname, MegaRequestListener *listener = NULL);
+        void queryGeLB(char *service, int timeoutms, int maxretries, MegaRequestListener *listener = NULL);
+        void downloadFile(char *url, char *dstpath, MegaRequestListener *listener = NULL);
         const char *getUserAgent();
         const char *getBasePath();
 
@@ -1699,6 +1701,7 @@ class MegaApiImpl : public MegaApp
         void setChatTitle(MegaHandle chatid, const char *title, MegaRequestListener *listener = NULL);
         void getChatPresenceURL(MegaRequestListener *listener = NULL);
         void registerPushNotification(int deviceType, const char *token, MegaRequestListener *listener = NULL);
+        void sendChatStats(const char *data, MegaRequestListener *listener = NULL);
         MegaTextChatList *getChatList();
         MegaHandleList *getAttachmentAccess(MegaHandle chatid, MegaHandle h);
         bool hasAccessToAttachment(MegaHandle chatid, MegaHandle h, MegaHandle uh);
@@ -2008,7 +2011,8 @@ protected:
         // notify about account confirmation
         virtual void notify_confirmation(const char*);
 
-        virtual void dns_result(error, string*);
+        // notify about a finished HTTP request
+        virtual void http_result(error, int, byte *, int);
 
         void sendPendingRequests();
         void sendPendingTransfers();

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1624,9 +1624,9 @@ class MegaApiImpl : public MegaApp
         char *getOperatingSystemVersion();
         void getLastAvailableVersion(const char *appKey, MegaRequestListener *listener = NULL);
         void getLocalSSLCertificate(MegaRequestListener *listener = NULL);
-        void queryDNS(char *hostname, MegaRequestListener *listener = NULL);
-        void queryGeLB(char *service, int timeoutms, int maxretries, MegaRequestListener *listener = NULL);
-        void downloadFile(char *url, char *dstpath, MegaRequestListener *listener = NULL);
+        void queryDNS(const char *hostname, MegaRequestListener *listener = NULL);
+        void queryGeLB(const char *service, int timeoutms, int maxretries, MegaRequestListener *listener = NULL);
+        void downloadFile(const char *url, const char *dstpath, MegaRequestListener *listener = NULL);
         const char *getUserAgent();
         const char *getBasePath();
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1624,6 +1624,7 @@ class MegaApiImpl : public MegaApp
         char *getOperatingSystemVersion();
         void getLastAvailableVersion(const char *appKey, MegaRequestListener *listener = NULL);
         void getLocalSSLCertificate(MegaRequestListener *listener = NULL);
+        void queryDNS(char *hostname, MegaRequestListener *listener = NULL);
         const char *getUserAgent();
         const char *getBasePath();
 
@@ -2006,6 +2007,8 @@ protected:
 
         // notify about account confirmation
         virtual void notify_confirmation(const char*);
+
+        virtual void dns_result(error, string*);
 
         void sendPendingRequests();
         void sendPendingTransfers();

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -349,6 +349,26 @@ void HttpReq::post(MegaClient* client, const char* data, unsigned len)
     httpio->post(this, data, len);
 }
 
+void HttpReq::dnsrequest(MegaClient *client, const char *hostname)
+{
+    if (httpio)
+    {
+        LOG_warn << "Ensuring that the request is finished before sending it again";
+        httpio->cancel(this);
+        init();
+    }
+
+    //FIXME: Instead of adding a protocol to make the URL parser happy
+    //we could just change the parser to allow to set the hostname
+    //only or to use a prefix like dns://
+    //Another option is to allow to set a protocol to not only get
+    //the IP but also ensure that it's possible to connect
+    posturl = string("http://") + hostname;
+    type = REQ_DNS;
+    httpio = client->httpio;
+    httpio->post(this);
+}
+
 void HttpReq::disconnect()
 {
     if (httpio)
@@ -395,6 +415,7 @@ void HttpReq::init()
     timeleft = -1;
     lastdata = NEVER;
     outpos = 0;
+    ip.clear();
 }
 
 void HttpReq::setreq(const char* u, contenttype_t t)

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2497,6 +2497,11 @@ void MegaApi::getLocalSSLCertificate(MegaRequestListener *listener)
     pImpl->getLocalSSLCertificate(listener);
 }
 
+void MegaApi::queryDNS(char *hostname, MegaRequestListener *listener)
+{
+    pImpl->queryDNS(hostname, listener);
+}
+
 MegaNode *MegaApi::createForeignFolderNode(MegaHandle handle, const char *name, MegaHandle parentHandle, const char *privateAuth, const char *publicAuth)
 {
     return pImpl->createForeignFolderNode(handle, name, parentHandle, privateAuth, publicAuth);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2497,17 +2497,17 @@ void MegaApi::getLocalSSLCertificate(MegaRequestListener *listener)
     pImpl->getLocalSSLCertificate(listener);
 }
 
-void MegaApi::queryDNS(char *hostname, MegaRequestListener *listener)
+void MegaApi::queryDNS(const char *hostname, MegaRequestListener *listener)
 {
     pImpl->queryDNS(hostname, listener);
 }
 
-void MegaApi::queryGeLB(char *service, int timeoutms, int maxretries, MegaRequestListener *listener)
+void MegaApi::queryGeLB(const char *service, int timeoutms, int maxretries, MegaRequestListener *listener)
 {
     pImpl->queryGeLB(service, timeoutms, maxretries, listener);
 }
 
-void MegaApi::downloadFile(char *url, char *dstpath, MegaRequestListener *listener)
+void MegaApi::downloadFile(const char *url, const char *dstpath, MegaRequestListener *listener)
 {
     pImpl->downloadFile(url, dstpath, listener);
 }

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2502,6 +2502,16 @@ void MegaApi::queryDNS(char *hostname, MegaRequestListener *listener)
     pImpl->queryDNS(hostname, listener);
 }
 
+void MegaApi::queryGeLB(char *service, int timeoutms, int maxretries, MegaRequestListener *listener)
+{
+    pImpl->queryGeLB(service, timeoutms, maxretries, listener);
+}
+
+void MegaApi::downloadFile(char *url, char *dstpath, MegaRequestListener *listener)
+{
+    pImpl->downloadFile(url, dstpath, listener);
+}
+
 MegaNode *MegaApi::createForeignFolderNode(MegaHandle handle, const char *name, MegaHandle parentHandle, const char *privateAuth, const char *publicAuth)
 {
     return pImpl->createForeignFolderNode(handle, name, parentHandle, privateAuth, publicAuth);
@@ -3620,6 +3630,11 @@ void MegaApi::getChatPresenceURL(MegaRequestListener *listener)
 void MegaApi::registerPushNotifications(int deviceType, const char *token, MegaRequestListener *listener)
 {
     pImpl->registerPushNotification(deviceType, token, listener);
+}
+
+void MegaApi::sendChatStats(const char *data, MegaRequestListener *listener)
+{
+    pImpl->sendChatStats(data, listener);
 }
 
 MegaTextChatList* MegaApi::getChatList()

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -9954,12 +9954,9 @@ void MegaApiImpl::http_result(error e, int httpCode, byte *data, int size)
             || request->getType() == MegaRequest::TYPE_CHAT_STATS
             || request->getType() == MegaRequest::TYPE_QUERY_DNS)
     {
-        if (size)
-        {
-            string result;
-            result.assign((const char *)data, size);
-            request->setText(result.c_str());
-        }
+        string result;
+        result.assign((const char *)data, size);
+        request->setText(result.c_str());
     }
     else if (request->getType() == MegaRequest::TYPE_DOWNLOAD_FILE)
     {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7446,7 +7446,7 @@ void MegaApiImpl::getLocalSSLCertificate(MegaRequestListener *listener)
     waiter->notify();
 }
 
-void MegaApiImpl::queryDNS(char *hostname, MegaRequestListener *listener)
+void MegaApiImpl::queryDNS(const char *hostname, MegaRequestListener *listener)
 {
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_QUERY_DNS, listener);
     request->setName(hostname);
@@ -7454,7 +7454,7 @@ void MegaApiImpl::queryDNS(char *hostname, MegaRequestListener *listener)
     waiter->notify();
 }
 
-void MegaApiImpl::queryGeLB(char *service, int timeoutms, int maxretries, MegaRequestListener *listener)
+void MegaApiImpl::queryGeLB(const char *service, int timeoutms, int maxretries, MegaRequestListener *listener)
 {
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_QUERY_GELB, listener);
     request->setName(service);
@@ -7464,7 +7464,7 @@ void MegaApiImpl::queryGeLB(char *service, int timeoutms, int maxretries, MegaRe
     waiter->notify();
 }
 
-void MegaApiImpl::downloadFile(char *url, char *dstpath, MegaRequestListener *listener)
+void MegaApiImpl::downloadFile(const char *url, const char *dstpath, MegaRequestListener *listener)
 {
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_DOWNLOAD_FILE, listener);
     request->setLink(url);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1001,7 +1001,7 @@ void MegaClient::exec()
 
         if (pendinghttp.size())
         {
-            map<int, GenericHttpReq*>::iterator it = pendinghttp.begin();
+            pendinghttp_map::iterator it = pendinghttp.begin();
             while (it != pendinghttp.end())
             {
                 GenericHttpReq *req = it->second;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3122,7 +3122,7 @@ void MegaClient::dnsrequest(const char *hostname)
     req->tag = reqtag;
     req->maxretries = 0;
     pendinghttp[reqtag] = req;
-    req->posturl = string("dns://") + hostname;
+    req->posturl = string("http://") + hostname;
     req->dns(this);
 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2925,6 +2925,11 @@ void MegaClient::disconnect()
 
     abortlockrequest();
 
+    for (pendinghttp_map::iterator it = pendinghttp.begin(); it != pendinghttp.end(); it++)
+    {
+        it->second->disconnect();
+    }
+
     for (transferslot_list::iterator it = tslots.begin(); it != tslots.end(); it++)
     {
         (*it)->disconnect();

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -1920,7 +1920,6 @@ bool CurlHttpIO::multidoio(CURLM *curlmhandle)
                             req->in = httpctx->hostip;
                         }
                         req->httpstatus = 200;
-
                     }
                     
                     if (req->binary)


### PR DESCRIPTION
- Support for GET requests and DNS queries
- Support for timeout for individual network requests
- Support to select the number of retries allowed for a network request
- Support for timeout for network requests (including retries)
- Public key pinning for MEGAchat servers
- Support to download files via HTTP or HTTPS
- Support for GeLB requests
- Support to send chat stats
- Documentation for the new requests