### PR TITLE
Search for fetchnodes request

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -9285,10 +9285,21 @@ void MegaApiImpl::unlink_result(handle h, error e)
 void MegaApiImpl::fetchnodes_result(error e)
 {    
     MegaError megaError(e);
-    MegaRequestPrivate* request;
+    MegaRequestPrivate* request = NULL;
     if (!client->restag)
     {
-        request = new MegaRequestPrivate(MegaRequest::TYPE_FETCH_NODES);
+        for (map<int, MegaRequestPrivate *>::iterator it = requestMap.begin(); it != requestMap.end(); it++)
+        {
+            if (it->second->getType() == MegaRequest::TYPE_FETCH_NODES)
+            {
+                request = it->second;
+                break;
+            }
+        }
+        if (!request)
+        {
+            request = new MegaRequestPrivate(MegaRequest::TYPE_FETCH_NODES);
+        }
         fireOnRequestFinish(request, megaError);
         return;
     }


### PR DESCRIPTION
During fetchnodes, when retrieving the waitlink and we receive a -6 (too
many), another fetchnodes is launched with tag = 0. Upon completion of the second fetchnodes, a new request is created to notify the `onRequestFinish()`. MEGAsync uses a dedicated listener for the request, so it never receives the callback.