### PR TITLE
Get children files and folders independently

### DIFF
--- a/bindings/java/nz/mega/sdk/MegaApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaApiJava.java
@@ -4372,6 +4372,63 @@ public class MegaApiJava {
     }
 
     /**
+     * Get file and folder children of a MegaNode separatedly
+     *
+     * If the parent node doesn't exist or it isn't a folder, this function
+     * returns NULL
+     *
+     * You take the ownership of the returned value
+     *
+     * @param parent Parent node
+     * @param order Order for the returned lists
+     * Valid values for this parameter are:
+     * - MegaApi::ORDER_NONE = 0
+     * Undefined order
+     *
+     * - MegaApi::ORDER_DEFAULT_ASC = 1
+     * Folders first in alphabetical order, then files in the same order
+     *
+     * - MegaApi::ORDER_DEFAULT_DESC = 2
+     * Files first in reverse alphabetical order, then folders in the same order
+     *
+     * - MegaApi::ORDER_SIZE_ASC = 3
+     * Sort by size, ascending
+     *
+     * - MegaApi::ORDER_SIZE_DESC = 4
+     * Sort by size, descending
+     *
+     * - MegaApi::ORDER_CREATION_ASC = 5
+     * Sort by creation time in MEGA, ascending
+     *
+     * - MegaApi::ORDER_CREATION_DESC = 6
+     * Sort by creation time in MEGA, descending
+     *
+     * - MegaApi::ORDER_MODIFICATION_ASC = 7
+     * Sort by modification time of the original file, ascending
+     *
+     * - MegaApi::ORDER_MODIFICATION_DESC = 8
+     * Sort by modification time of the original file, descending
+     *
+     * - MegaApi::ORDER_ALPHABETICAL_ASC = 9
+     * Sort in alphabetical order, ascending
+     *
+     * - MegaApi::ORDER_ALPHABETICAL_DESC = 10
+     * Sort in alphabetical order, descending
+     *
+     * @return MegaChildren object with two ArrayLists: fileList and FolderList
+     */
+    public MegaChildren getFileFolderChildren(MegaNode parent, int order){
+        MegaChildren children = new MegaChildren();
+
+        MegaChildrenLists childrenList = megaApi.getFileFolderChildren(parent, order);
+
+        children.setFileList(nodeListToArray(childrenList.getFileList()));
+        children.setFolderList(nodeListToArray(childrenList.getFolderList()));
+
+        return children;
+    }
+
+    /**
      * Get all children of a MegaNode.
      * <p>
      * If the parent node does not exist or if it is not a folder, this function.

--- a/bindings/java/nz/mega/sdk/MegaChildren.java
+++ b/bindings/java/nz/mega/sdk/MegaChildren.java
@@ -1,0 +1,40 @@
+/*
+ * (c) 2013-2015 by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,\
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * @copyright Simplified (2-clause) BSD License.
+ * You should have received a copy of the license along with this
+ * program.
+ */
+ package nz.mega.sdk;
+
+import java.util.ArrayList;
+
+public class MegaChildren {
+
+ private ArrayList<MegaNode> fileList = new ArrayList<MegaNode>();
+ private ArrayList<MegaNode> folderList = new ArrayList<MegaNode>();
+
+ public ArrayList<MegaNode> getFileList(){
+  return fileList;
+ }
+
+ public ArrayList<MegaNode> getFolderList(){
+  return folderList;
+ }
+
+ public void setFileList (ArrayList<MegaNode> fileList){
+  this.fileList = fileList;
+ }
+
+ public void setFolderList (ArrayList<MegaNode> folderList){
+  this.folderList = folderList;
+ }
+}

--- a/bindings/megaapi.i
+++ b/bindings/megaapi.i
@@ -243,6 +243,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)
 %newobject mega::MegaTransferList::copy;
 %newobject mega::MegaNode::copy;
 %newobject mega::MegaNodeList::copy;
+%newobject mega::MegaChildrenList::copy;
 %newobject mega::MegaShare::copy;
 %newobject mega::MegaShareList::copy;
 %newobject mega::MegaUser::copy;

--- a/bindings/wp8/MChildrenLists.cpp
+++ b/bindings/wp8/MChildrenLists.cpp
@@ -1,0 +1,52 @@
+/**
+* @file MChildrenLists.cpp
+* @brief Lists of file and folder children MegaNode objects.
+*
+* (c) 2013-2014 by Mega Limited, Auckland, New Zealand
+*
+* This file is part of the MEGA SDK - Client Access Engine.
+*
+* Applications using the MEGA API must present a valid application key
+* and comply with the the rules set forth in the Terms of Service.
+*
+* The MEGA SDK is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*
+* @copyright Simplified (2-clause) BSD License.
+*
+* You should have received a copy of the license along with this
+* program.
+*/
+
+#include "MChildrenLists.h"
+
+using namespace mega;
+using namespace Platform;
+
+MChildrenLists::MChildrenLists(MegaChildrenLists *childrenLists, bool cMemoryOwn)
+{
+    this->childrenLists = childrenLists;
+    this->cMemoryOwn = cMemoryOwn;
+}
+
+MChildrenLists::~MChildrenLists()
+{
+    if (cMemoryOwn)
+        delete childrenLists;
+}
+
+MChildrenLists^ MChildrenLists::copy()
+{
+    return childrenLists ? ref new MChildrenLists(childrenLists->copy(), true) : nullptr;
+}
+
+MNodeList^ MChildrenLists::getFolderList()
+{
+    return childrenLists ? ref new MNodeList(childrenLists->getFolderList(), true) : nullptr;
+}
+
+MNodeList^ MChildrenLists::getFileList()
+{
+    return childrenLists ? ref new MNodeList(childrenLists->getFileList(), true) : nullptr;
+}

--- a/bindings/wp8/MChildrenLists.cpp
+++ b/bindings/wp8/MChildrenLists.cpp
@@ -43,10 +43,10 @@ MChildrenLists^ MChildrenLists::copy()
 
 MNodeList^ MChildrenLists::getFolderList()
 {
-    return childrenLists ? ref new MNodeList(childrenLists->getFolderList(), true) : nullptr;
+    return childrenLists ? ref new MNodeList(childrenLists->getFolderList()->copy(), true) : nullptr;
 }
 
 MNodeList^ MChildrenLists::getFileList()
 {
-    return childrenLists ? ref new MNodeList(childrenLists->getFileList(), true) : nullptr;
+    return childrenLists ? ref new MNodeList(childrenLists->getFileList()->copy(), true) : nullptr;
 }

--- a/bindings/wp8/MChildrenLists.h
+++ b/bindings/wp8/MChildrenLists.h
@@ -1,6 +1,6 @@
 /**
-* @file MNodeList.h
-* @brief List of MNode objects.
+* @file MChildrenLists.h
+* @brief Lists of file and folder children MegaNode objects.
 *
 * (c) 2013-2014 by Mega Limited, Auckland, New Zealand
 *
@@ -21,30 +21,28 @@
 
 #pragma once
 
-#include "MNode.h"
+#include "MNodeList.h"
 
 #include "megaapi.h"
 
 namespace mega
 {
-	using namespace Windows::Foundation;
-	using Platform::String;
+    using namespace Windows::Foundation;
+    using Platform::String;
 
-	public ref class MNodeList sealed
-	{
-		friend ref class MegaSDK;
-        friend ref class MChildrenLists;
-		friend class DelegateMListener;
-		friend class DelegateMGlobalListener;
+    public ref class MChildrenLists sealed
+    {
+        friend ref class MegaSDK;
 
-	public:
-		virtual ~MNodeList();
-		MNode^ get(int i);
-		int size();
+    public:
+        virtual ~MChildrenLists();
+        MChildrenLists^ copy();
+        MNodeList^ getFolderList();
+        MNodeList^ getFileList();
 
-	private:
-		MNodeList(MegaNodeList *nodeList, bool cMemoryOwn);
-		MegaNodeList *nodeList;
-		bool cMemoryOwn;
-	};
+    private:
+        MChildrenLists(MegaChildrenLists *childrenLists, bool cMemoryOwn);
+        MegaChildrenLists *childrenLists;
+        bool cMemoryOwn;
+    };
 }

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -2905,6 +2905,16 @@ MNodeList^ MegaSDK::getChildren(MNode^ parent)
 	return ref new MNodeList(megaApi->getChildren((parent != nullptr) ? parent->getCPtr() : NULL), true);
 }
 
+MChildrenLists^ MegaSDK::getFileFolderChildren(MNode^ parent, int order)
+{
+    return ref new MChildrenLists(megaApi->getFileFolderChildren((parent != nullptr) ? parent->getCPtr() : NULL, order), true);
+}
+
+MChildrenLists^ MegaSDK::getFileFolderChildren(MNode^ parent)
+{
+    return ref new MChildrenLists(megaApi->getFileFolderChildren((parent != nullptr) ? parent->getCPtr() : NULL), true);
+}
+
 bool MegaSDK::hasChildren(MNode^ parent)
 {
     return megaApi->hasChildren((parent != nullptr) ? parent->getCPtr() : NULL);

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -52,6 +52,7 @@
 #include "MContactRequestList.h"
 #include "MInputStreamAdapter.h"
 #include "MInputStream.h"
+#include "MChildrenLists.h"
 
 #include <megaapi.h>
 #include <set>
@@ -450,6 +451,8 @@ namespace mega
         int getNumChildFolders(MNode^ parent);
         MNodeList^ getChildren(MNode^ parent, int order);
         MNodeList^ getChildren(MNode^ parent);
+        MChildrenLists^ getFileFolderChildren(MNode^ parent, int order);
+        MChildrenLists^ getFileFolderChildren(MNode^ parent);
         bool hasChildren(MNode^ parent);
         int getIndex(MNode^ node, int order);
         int getIndex(MNode^ node);

--- a/bindings/wp8/vs2013/mega.vcxproj
+++ b/bindings/wp8/vs2013/mega.vcxproj
@@ -396,6 +396,7 @@
     <ClInclude Include="..\MAccountPurchase.h" />
     <ClInclude Include="..\MAccountSession.h" />
     <ClInclude Include="..\MAccountTransaction.h" />
+    <ClInclude Include="..\MChildrenLists.h" />
     <ClInclude Include="..\MContactRequest.h" />
     <ClInclude Include="..\MContactRequestList.h" />
     <ClInclude Include="..\MegaSDK.h" />
@@ -477,6 +478,7 @@
     <ClCompile Include="..\MAccountPurchase.cpp" />
     <ClCompile Include="..\MAccountSession.cpp" />
     <ClCompile Include="..\MAccountTransaction.cpp" />
+    <ClCompile Include="..\MChildrenLists.cpp" />
     <ClCompile Include="..\MContactRequest.cpp" />
     <ClCompile Include="..\MContactRequestList.cpp" />
     <ClCompile Include="..\MegaSDK.cpp" />

--- a/bindings/wp8/vs2013/mega.vcxproj.filters
+++ b/bindings/wp8/vs2013/mega.vcxproj.filters
@@ -276,6 +276,9 @@
     <ClInclude Include="..\MTransferData.h">
       <Filter>Bindings</Filter>
     </ClInclude>
+    <ClInclude Include="..\MChildrenLists.h">
+      <Filter>Bindings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\attrmap.cpp">
@@ -486,6 +489,9 @@
       <Filter>SDK\Source</Filter>
     </ClCompile>
     <ClCompile Include="..\MTransferData.cpp">
+      <Filter>Bindings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\MChildrenLists.cpp">
       <Filter>Bindings</Filter>
     </ClCompile>
   </ItemGroup>

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1779,6 +1779,34 @@ class MegaNodeList
 };
 
 /**
+ * @brief Lists of file and folder children MegaNode objects
+ *
+ * A MegaChildrenLists object has the ownership of the MegaNodeList objects that it contains,
+ * so they will be only valid until the MegaChildrenLists is deleted. If you want to retain
+ * a MegaNodeList returned by a MegaChildrenLists, use MegaNodeList::copy.
+ *
+ * Objects of this class are immutable.
+ */
+class MegaChildrenLists
+{
+public:
+    virtual ~MegaChildrenLists();
+    virtual MegaChildrenLists *copy();
+
+    /**
+     * @brief Get the list of folder MegaNode objects
+     * @return List of MegaNode folders
+     */
+    virtual MegaNodeList* getFolderList();
+
+    /**
+     * @brief Get the list of file MegaNode objects
+     * @return List of MegaNode files
+     */
+    virtual MegaNodeList* getFileList();
+};
+
+/**
  * @brief List of MegaUser objects
  *
  * A MegaUserList has the ownership of the MegaUser objects that it contains, so they will be
@@ -8178,6 +8206,54 @@ class MegaApi
 		 * @return List with all child MegaNode objects
 		 */
         MegaNodeList* getChildren(MegaNode *parent, int order = 1);
+
+        /**
+         * @brief Get file and folder children of a MegaNode separatedly
+         *
+         * If the parent node doesn't exist or it isn't a folder, this function
+         * returns NULL
+         *
+         * You take the ownership of the returned value
+         *
+         * @param parent Parent node
+         * @param order Order for the returned lists
+         * Valid values for this parameter are:
+         * - MegaApi::ORDER_NONE = 0
+         * Undefined order
+         *
+         * - MegaApi::ORDER_DEFAULT_ASC = 1
+         * Folders first in alphabetical order, then files in the same order
+         *
+         * - MegaApi::ORDER_DEFAULT_DESC = 2
+         * Files first in reverse alphabetical order, then folders in the same order
+         *
+         * - MegaApi::ORDER_SIZE_ASC = 3
+         * Sort by size, ascending
+         *
+         * - MegaApi::ORDER_SIZE_DESC = 4
+         * Sort by size, descending
+         *
+         * - MegaApi::ORDER_CREATION_ASC = 5
+         * Sort by creation time in MEGA, ascending
+         *
+         * - MegaApi::ORDER_CREATION_DESC = 6
+         * Sort by creation time in MEGA, descending
+         *
+         * - MegaApi::ORDER_MODIFICATION_ASC = 7
+         * Sort by modification time of the original file, ascending
+         *
+         * - MegaApi::ORDER_MODIFICATION_DESC = 8
+         * Sort by modification time of the original file, descending
+         *
+         * - MegaApi::ORDER_ALPHABETICAL_ASC = 9
+         * Sort in alphabetical order, ascending
+         *
+         * - MegaApi::ORDER_ALPHABETICAL_DESC = 10
+         * Sort in alphabetical order, descending
+         *
+         * @return Lists with files and folders child MegaNode objects
+         */
+        MegaChildrenLists* getFileFolderChildren(MegaNode *p, int order = 1);
 
         /**
          * @brief Returns true if the node has children

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1083,6 +1083,22 @@ class MegaNodeListPrivate : public MegaNodeList
 		int s;
 };
 
+class MegaChildrenListsPrivate : public MegaChildrenLists
+{
+    public:
+        MegaChildrenListsPrivate();
+        MegaChildrenListsPrivate(MegaChildrenLists*);
+        MegaChildrenListsPrivate(MegaNodeListPrivate *folderList, MegaNodeListPrivate *fileList);
+        virtual ~MegaChildrenListsPrivate();
+        virtual MegaChildrenLists *copy();
+        virtual MegaNodeList* getFolderList();
+        virtual MegaNodeList* getFileList();
+
+    protected:
+        MegaNodeList *folders;
+        MegaNodeList *files;
+};
+
 class MegaUserListPrivate : public MegaUserList
 {
 	public:
@@ -1548,6 +1564,7 @@ class MegaApiImpl : public MegaApp
 		int getNumChildFiles(MegaNode* parent);
 		int getNumChildFolders(MegaNode* parent);
         MegaNodeList* getChildren(MegaNode *parent, int order=1);
+        MegaChildrenLists* getFileFolderChildren(MegaNode *parent, int order=1);
         bool hasChildren(MegaNode *parent);
         int getIndex(MegaNode* node, int order=1);
         MegaNode *getChildNode(MegaNode *parent, const char* name);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2805,6 +2805,11 @@ MegaNodeList *MegaApi::getChildren(MegaNode* p, int order)
     return pImpl->getChildren(p, order);
 }
 
+MegaChildrenLists *MegaApi::getFileFolderChildren(MegaNode *p, int order)
+{
+    return pImpl->getFileFolderChildren(p, order);
+}
+
 bool MegaApi::hasChildren(MegaNode *parent)
 {
     return pImpl->hasChildren(parent);
@@ -4481,4 +4486,24 @@ unsigned int MegaHandleList::size() const
 void MegaHandleList::addMegaHandle(MegaHandle megaHandle)
 {
 
+}
+
+MegaChildrenLists::~MegaChildrenLists()
+{
+
+}
+
+MegaChildrenLists *MegaChildrenLists::copy()
+{
+    return NULL;
+}
+
+MegaNodeList *MegaChildrenLists::getFileList()
+{
+    return NULL;
+}
+
+MegaNodeList *MegaChildrenLists::getFolderList()
+{
+    return NULL;
 }


### PR DESCRIPTION
A new `MegaChildrenLists` wrapper has been created in order to avoid two passes through the children vector, which would be required in case of two different APIs for files and folders.