### PR TITLE
Create thumbnail file for videos even if the device is locked

### DIFF
--- a/src/gfx/GfxProcCG.mm
+++ b/src/gfx/GfxProcCG.mm
@@ -92,10 +92,17 @@ bool GfxProcCG::readbitmap(FileAccess* fa, string* name, int size) {
         UIImage *thumbnailImage = [[UIImage alloc] initWithCGImage:imgRef];
         CGImageRelease(imgRef);
         
-        [UIImageJPEGRepresentation(thumbnailImage, 1) writeToFile:nameString.stringByDeletingPathExtension atomically:YES];
+        NSError *error;
+        if ([UIImageJPEGRepresentation(thumbnailImage, 1) writeToFile:nameString.stringByDeletingPathExtension options:NSDataWritingFileProtectionNone error:&error]) {
+            dataProvider = CGDataProviderCreateWithFilename([nameString.stringByDeletingPathExtension UTF8String]);
+            if (![[NSFileManager defaultManager] removeItemAtPath:nameString.stringByDeletingPathExtension error:&error]) {
+                LOG_err << "removeItemAtPath failed with error: " << error.localizedDescription <<  "code: " << error.code << "domain: " << error.domain;
+            }
+        } else {
+            LOG_err << "writeToFile failed with error: " << error.localizedDescription << "code: " << error.code << "domain: " << error.domain;
+        }
         
-        dataProvider = CGDataProviderCreateWithFilename([nameString.stringByDeletingPathExtension UTF8String]);
-        [[NSFileManager defaultManager] removeItemAtPath:nameString.stringByDeletingPathExtension error:nil];
+        
     } else {
         dataProvider = CGDataProviderCreateWithFilename(name->c_str());
     }


### PR DESCRIPTION
The iOS app uses the capability Data Protection. It adds a level of security to files stored on disk by our app in the app’s container (using the built-in encryption hardware present on specific devices to store files in an encrypted format on disk).
The default level of protection is complete protection, in which files are encrypted and inaccessible when the device is locked.
`writeToURL:atomically:` fails when the device is locked if the device has enabled the passcode, so some videos can be uploaded without thumbnail.
Using `writeToFile:options:error:` we fix this problem.