### PR TITLE
Support for "Password reminder dialog"

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -84,12 +84,13 @@ typedef NS_ENUM(NSInteger, MEGAUserAttribute) {
     MEGAUserAttributeLastname          = 2, // public - char array
     MEGAUserAttributeAuthRing          = 3, // private - byte array
     MEGAUserAttributeLastInteraction   = 4, // private - byte array
-    MEGAUserAttributeED25519PublicKey  = 5, // public - char array
-    MEGAUserAttributeCU25519PublicKey  = 6, // public - char array
+    MEGAUserAttributeED25519PublicKey  = 5, // public - byte array
+    MEGAUserAttributeCU25519PublicKey  = 6, // public - byte array
     MEGAUserAttributeKeyring           = 7, // private - byte array
-    MEGAUserAttributeSigRsaPublicKey   = 8, // public - char array
-    MEGAUserAttributeSigCU255PublicKey = 9, // public - char array
-    MEGAUserAttributeLanguage          = 14 // private - byte array
+    MEGAUserAttributeSigRsaPublicKey   = 8, // public - byte array
+    MEGAUserAttributeSigCU255PublicKey = 9, // public - byte array
+    MEGAUserAttributeLanguage          = 14, // private - char array
+    MEGAUserAttributePwdReminder       = 15  // private- char array
 };
 
 typedef NS_ENUM(NSInteger, MEGAPaymentMethod) {
@@ -2155,6 +2156,8 @@ typedef NS_ENUM(NSUInteger, PushNotificationTokenType) {
  * Get the lastname of the user (public)
  * MEGAUserAttributeLanguage = 14
  * Get the preferred language of the user (private, non-encrypted)
+ * MEGAUserAttributePwdReminder = 15
+ * Get the password-reminder-dialog information (private, non-encrypted)
  *
  */
 - (void)getUserAttributeForUser:(MEGAUser *)user type:(MEGAUserAttribute)type;
@@ -2183,6 +2186,8 @@ typedef NS_ENUM(NSUInteger, PushNotificationTokenType) {
  * Get the lastname of the user (public)
  * MEGAUserAttributeLanguage = 14
  * Get the preferred language of the user (private, non-encrypted)
+ * MEGAUserAttributePwdReminder = 15
+ * Get the password-reminder-dialog information (private, non-encrypted)
  *
  * @param delegate MEGARequestDelegate to track this request
  */
@@ -2209,6 +2214,8 @@ typedef NS_ENUM(NSUInteger, PushNotificationTokenType) {
  * Get the lastname of the user (public)
  * MEGAUserAttributeLanguage = 14
  * Get the preferred language of the user (private, non-encrypted)
+ * MEGAUserAttributePwdReminder = 15
+ * Get the password-reminder-dialog information (private, non-encrypted)
  */
 - (void)getUserAttributeType:(MEGAUserAttribute)type;
 
@@ -2233,6 +2240,8 @@ typedef NS_ENUM(NSUInteger, PushNotificationTokenType) {
  * Get the lastname of the user (public)
  * MEGAUserAttributeLanguage = 14
  * Get the preferred language of the user (private, non-encrypted)
+ * MEGAUserAttributePwdReminder = 15
+ * Get the password-reminder-dialog information (private, non-encrypted)
  *
  * @param delegate MEGARequestDelegate to track this request
  */
@@ -2463,6 +2472,42 @@ typedef NS_ENUM(NSUInteger, PushNotificationTokenType) {
  * @param newPassword New password.
  */
 - (void)changePassword:(NSString *)oldPassword newPassword:(NSString *)newPassword;
+
+/**
+ * @brief Notify the user has exported the master key
+ *
+ * This function should be called when the user exports the master key by
+ * clicking on "Copy" or "Save file" options.
+ *
+ * As result, the user attribute MEGAUserAttributePwdReminder will be updated
+ * to remember the user has a backup of his/her master key. In consequence,
+ * MEGA will not ask the user to remind the password for the account.
+ *
+ * The associated request type with this request is MEGARequestTypeSetAttrUser
+ * Valid data in the MEGARequest object received on callbacks:
+ * - [MEGARequest paramType] - Returns the attribute type MEGAUserAttributePwdReminder
+ * - [MEGARequest: text] - Returns the new value for the attribute
+ *
+ * @param delegate MEGARequestDelegate to track this request
+ */
+- (void)masterKeyExportedWithDelegate:(id<MEGARequestDelegate>)delegate;
+
+/**
+ * @brief Notify the user has exported the master key
+ *
+ * This function should be called when the user exports the master key by
+ * clicking on "Copy" or "Save file" options.
+ *
+ * As result, the user attribute MEGAUserAttributePwdReminder will be updated
+ * to remember the user has a backup of his/her master key. In consequence,
+ * MEGA will not ask the user to remind the password for the account.
+ *
+ * The associated request type with this request is MEGARequestTypeSetAttrUser
+ * Valid data in the MEGARequest object received on callbacks:
+ * - [MEGARequest paramType] - Returns the attribute type MEGAUserAttributePwdReminder
+ * - [MEGARequest: text] - Returns the new value for the attribute
+ */
+- (void)masterKeyExported;
 
 /**
  * @brief Use HTTPS communications only

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -890,6 +890,14 @@ using namespace mega;
     self.megaApi->changePassword((oldPassword != nil) ? [oldPassword UTF8String] : NULL, (newPassword != nil) ? [newPassword UTF8String] : NULL);
 }
 
+- (void)masterKeyExportedWithDelegate:(id<MEGARequestDelegate>)delegate {
+    self.megaApi->masterKeyExported([self createDelegateMEGARequestListener:delegate singleListener:YES]);
+}
+
+- (void)masterKeyExported {
+    self.megaApi->masterKeyExported();
+}
+
 - (void)useHttpsOnly:(BOOL)httpsOnly delegate:(id<MEGARequestDelegate>)delegate {
     self.megaApi->useHttpsOnly(httpsOnly, [self createDelegateMEGARequestListener:delegate singleListener:YES]);
 }

--- a/bindings/ios/MEGAUser.h
+++ b/bindings/ios/MEGAUser.h
@@ -42,7 +42,8 @@ typedef NS_ENUM(NSInteger, MEGAUserChangeType) {
     MEGAUserChangeTypePubKeyEd255    = 0x400,
     MEGAUserChangeTypeSigPubKeyRsa   = 0x800,
     MEGAUserChangeTypeSigPubKeyCu255 = 0x1000,
-    MEGAUserChangeTypeLanguage       = 0x2000
+    MEGAUserChangeTypeLanguage       = 0x2000,
+    MEGAUserChangeTypePwdReminder    = 0x4000
 };
 
 /**
@@ -148,6 +149,9 @@ typedef NS_ENUM(NSInteger, MEGAUserChangeType) {
  *
  * - MEGAUserChangeTypeLanguage        = 0x2000
  * Check if the user has modified the preferred language
+ *
+ * - MEGAUserChangeTypePwdReminder     = 0x4000
+ * Check if the data related to the password reminder dialog has changed
  */
 @property (readonly, nonatomic) MEGAUserChangeType changes;
 
@@ -214,8 +218,14 @@ typedef NS_ENUM(NSInteger, MEGAUserChangeType) {
  * - MEGAUserChangeTypeSigPubKeyRsa    = 0x800
  * Check if the user has new or modified signature for RSA public key
  *
- * - MEGAUserChangeTypeSigPubKeyCu255  = 0x1600
+ * - MEGAUserChangeTypeSigPubKeyCu255  = 0x1000
  * Check if the user has new or modified signature for Cu25519 public key
+ *
+ * - MEGAUserChangeTypeLanguage        = 0x2000
+ * Check if the user has new or modified signature for RSA public key
+ *
+ * - MEGAUserChangeTypePwdReminder     = 0x4000
+ * Check if the data related to the password reminder dialog has changed
  *
  * @return YES if this user has an specific change
  */

--- a/bindings/java/nz/mega/sdk/MegaApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaApiJava.java
@@ -3008,6 +3008,27 @@ public class MegaApiJava {
     }
 
     /**
+     * Notify the user has exported the master key
+     *
+     * This function should be called when the user exports the master key by
+     * clicking on "Copy" or "Save file" options.
+     *
+     * As result, the user attribute MegaApi::USER_ATTR_PWD_REMINDER will be updated
+     * to remember the user has a backup of his/her master key. In consequence,
+     * MEGA will not ask the user to remind the password for the account.
+     *
+     * The associated request type with this request is MegaRequest::TYPE_SET_ATTR_USER
+     * Valid data in the MegaRequest object received on callbacks:
+     * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_PWD_REMINDER
+     * - MegaRequest::getText - Returns the new value for the attribute
+     *
+     * @param listener MegaRequestListener to track this request
+     */
+    public void masterKeyExported(MegaRequestListenerInterface listener){
+        megaApi.masterKeyExported(createDelegateRequestListener(listener));
+    }
+
+    /**
      * Change the password of the MEGA account.
      * <p>
      * The associated request type with this request is MegaRequest.TYPE_CHANGE_PW

--- a/bindings/wp8/MUser.h
+++ b/bindings/wp8/MUser.h
@@ -39,12 +39,21 @@ namespace mega
 
     public enum class MUserChangeType
     {
-        CHANGE_TYPE_AUTH        = 0x01,
-        CHANGE_TYPE_LSTINT      = 0x02,
-        CHANGE_TYPE_AVATAR      = 0x04,
-        CHANGE_TYPE_FIRSTNAME   = 0x08,
-        CHANGE_TYPE_LASTNAME    = 0x10,
-        CHANGE_TYPE_EMAIL       = 0x20
+        CHANGE_TYPE_AUTHRING            = 0x01,
+        CHANGE_TYPE_LSTINT              = 0x02,
+        CHANGE_TYPE_AVATAR              = 0x04,
+        CHANGE_TYPE_FIRSTNAME           = 0x08,
+        CHANGE_TYPE_LASTNAME            = 0x10,
+        CHANGE_TYPE_EMAIL               = 0x20,
+        CHANGE_TYPE_KEYRING             = 0x40,
+        CHANGE_TYPE_COUNTRY             = 0x80,
+        CHANGE_TYPE_BIRTHDAY            = 0x100,
+        CHANGE_TYPE_PUBKEY_CU255        = 0x200,
+        CHANGE_TYPE_PUBKEY_ED255        = 0x400,
+        CHANGE_TYPE_SIG_PUBKEY_RSA      = 0x800,
+        CHANGE_TYPE_SIG_PUBKEY_CU255    = 0x1000,
+        CHANGE_TYPE_LANGUAGE            = 0x2000,
+        CHANGE_TYPE_PWD_REMINDER        = 0x4000
     };
 
 	public ref class MUser sealed

--- a/bindings/wp8/MegaSDK.cpp
+++ b/bindings/wp8/MegaSDK.cpp
@@ -2092,6 +2092,16 @@ String^ MegaSDK::exportMasterKey()
 	return ref new String((wchar_t *)utf16key.data());
 }
 
+void MegaSDK::masterKeyExported(MRequestListenerInterface^ listener)
+{
+    megaApi->masterKeyExported(createDelegateMRequestListener(listener));
+}
+
+void MegaSDK::masterKeyExported()
+{
+    megaApi->masterKeyExported();
+}
+
 void MegaSDK::changePassword(String^ oldPassword, String^ newPassword, MRequestListenerInterface^ listener)
 {
 	std::string utf8oldPassword;

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -91,11 +91,18 @@ namespace mega
     };
 
     public enum class MUserAttrType{
-        USER_ATTR_AVATAR            = 0,
-        USER_ATTR_FIRSTNAME         = 1,
-        USER_ATTR_LASTNAME          = 2,
-        USER_ATTR_AUTHRING          = 3,
-        USER_ATTR_LAST_INTERACTION  = 4
+        USER_ATTR_AVATAR                = 0,    // public - char array
+        USER_ATTR_FIRSTNAME             = 1,    // public - char array
+        USER_ATTR_LASTNAME              = 2,    // public - char array
+        USER_ATTR_AUTHRING              = 3,    // private - byte array
+        USER_ATTR_LAST_INTERACTION      = 4,    // private - byte array
+        USER_ATTR_ED25519_PUBLIC_KEY    = 5,    // public - byte array
+        USER_ATTR_CU25519_PUBLIC_KEY    = 6,    // public - byte array
+        USER_ATTR_KEYRING               = 7,    // private - byte array
+        USER_ATTR_SIG_RSA_PUBLIC_KEY    = 8,    // public - byte array
+        USER_ATTR_SIG_CU255_PUBLIC_KEY  = 9,    // public - byte array
+        USER_ATTR_LANGUAGE              = 14,   // private - char array
+        USER_ATTR_PWD_REMINDER          = 15    // private - char array
     };
 
     public enum class MPaymentMethod {
@@ -325,6 +332,8 @@ namespace mega
         void getPaymentMethods();
 
         String^ exportMasterKey();
+        void masterKeyExported(MRequestListenerInterface^ listener);
+        void masterKeyExported();
 
         void changePassword(String^ oldPassword, String^ newPassword, MRequestListenerInterface^ listener);
         void changePassword(String^ oldPassword, String^ newPassword);

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -407,7 +407,8 @@ typedef enum {
     ATTR_BIRTHDAY = 11,         // public - char array - non-versioned
     ATTR_BIRTHMONTH = 12,       // public - char array - non-versioned
     ATTR_BIRTHYEAR = 13,        // public - char array - non-versioned
-    ATTR_LANGUAGE = 14          // private, non-encrypted - char array in B64 - non-versioned
+    ATTR_LANGUAGE = 14,         // private, non-encrypted - char array in B64 - non-versioned
+    ATTR_PWD_REMINDER = 15      // private, non-encrypted - char array in B64 - non-versioned
 } attr_t;
 typedef map<attr_t, string> userattr_map;
 

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -63,6 +63,7 @@ struct MEGA_API User : public Cachable
         bool birthday : 1;  // wraps status of birthday, birthmonth, birthyear
         bool email : 1;
         bool language : 1;  // preferred language code
+        bool pwdReminder : 1;   // password-reminder-dialog information
     } changed;
 
     // user's public key

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -104,6 +104,7 @@ public:
     static attr_t string2attr(const char *name);
     static bool needversioning(attr_t at);
     static char scope(attr_t at);
+    static bool mergePwdReminderData(int numDetails, const char *data, unsigned int size, string *newValue);
 
     bool setChanged(attr_t at);
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1099,7 +1099,8 @@ class MegaUser
             CHANGE_TYPE_PUBKEY_ED255    = 0x400,
             CHANGE_TYPE_SIG_PUBKEY_RSA  = 0x800,
             CHANGE_TYPE_SIG_PUBKEY_CU255 = 0x1000,
-            CHANGE_TYPE_LANGUAGE        = 0x2000
+            CHANGE_TYPE_LANGUAGE        = 0x2000,
+            CHANGE_TYPE_PWD_REMINDER    = 0x4000
         };
 
         /**
@@ -1154,6 +1155,9 @@ class MegaUser
          * - MegaUser::CHANGE_TYPE_LANGUAGE         = 0x2000
          * Check if the user has modified the preferred language
          *
+         * - MegaUser::CHANGE_TYPE_PWD_REMINDER     = 0x4000
+         * Check if the data related to the password reminder dialog has changed
+         *
          * @return true if this user has an specific change
          */
         virtual bool hasChanged(int changeType);
@@ -1207,6 +1211,9 @@ class MegaUser
          *
          * - MegaUser::CHANGE_TYPE_LANGUAGE         = 0x2000
          * Check if the user has modified the preferred language
+         *
+         * - MegaUser::CHANGE_TYPE_PWD_REMINDER     = 0x4000
+         * Check if the data related to the password reminder dialog has changed
          */
         virtual int getChanges();
 
@@ -4574,7 +4581,8 @@ class MegaApi
             USER_ATTR_KEYRING = 7,              // private - byte array
             USER_ATTR_SIG_RSA_PUBLIC_KEY = 8,   // public - byte array
             USER_ATTR_SIG_CU255_PUBLIC_KEY = 9, // public - byte array
-            USER_ATTR_LANGUAGE = 14             // private - char array
+            USER_ATTR_LANGUAGE = 14,            // private - char array
+            USER_ATTR_PWD_REMINDER = 15         // private - char array
         };
 
         enum {
@@ -6157,6 +6165,8 @@ class MegaApi
          * Get the signature of Cu25519 public key of the user (public)
          * MegaApi::USER_ATTR_LANGUAGE = 14
          * Get the preferred language of the user (private, non-encrypted)
+         * MegaApi::USER_ATTR_PWD_REMINDER = 15
+         * Get the password-reminder-dialog information (private, non-encrypted)
          *
          * @param listener MegaRequestListener to track this request
          */
@@ -6204,6 +6214,8 @@ class MegaApi
          * Get the signature of Cu25519 public key of the user (public)
          * MegaApi::USER_ATTR_LANGUAGE = 14
          * Get the preferred language of the user (private, non-encrypted)
+         * MegaApi::USER_ATTR_PWD_REMINDER = 15
+         * Get the password-reminder-dialog information (private, non-encrypted)
          *
          * @param listener MegaRequestListener to track this request
          */
@@ -6248,6 +6260,8 @@ class MegaApi
          * Get the signature of Cu25519 public key of the user (public)
          * MegaApi::USER_ATTR_LANGUAGE = 14
          * Get the preferred language of the user (private, non-encrypted)
+         * MegaApi::USER_ATTR_PWD_REMINDER = 15
+         * Get the password-reminder-dialog information (private, non-encrypted)
          *
          * @param listener MegaRequestListener to track this request
          */
@@ -6738,6 +6752,25 @@ class MegaApi
          * @return Base64-encoded master key
          */
         char *exportMasterKey();
+
+        /**
+         * @brief Notify the user has exported the master key
+         *
+         * This function should be called when the user exports the master key by
+         * clicking on "Copy" or "Save file" options.
+         *
+         * As result, the user attribute MegaApi::USER_ATTR_PWD_REMINDER will be updated
+         * to remember the user has a backup of his/her master key. In consequence,
+         * MEGA will not ask the user to remind the password for the account.
+         *
+         * The associated request type with this request is MegaRequest::TYPE_SET_ATTR_USER
+         * Valid data in the MegaRequest object received on callbacks:
+         * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_PWD_REMINDER
+         * - MegaRequest::getText - Returns the new value for the attribute
+         *
+         * @param listener MegaRequestListener to track this request
+         */
+        void masterKeyExported(MegaRequestListener *listener = NULL);
 
         /**
          * @brief Change the password of the MEGA account

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1508,6 +1508,8 @@ class MegaApiImpl : public MegaApp
         void getPaymentMethods(MegaRequestListener *listener = NULL);
 
         char *exportMasterKey();
+        void updatePwdReminderData(bool lastSuccess, bool lastSkipped, bool mkExported, bool dontShowAgain, bool lastLogin, MegaRequestListener *listener = NULL);
+        void mergePwdReminderData(int numDetails, const char *data, unsigned int size, string *newValue);
 
         void changePassword(const char *oldPassword, const char *newPassword, MegaRequestListener *listener = NULL);
         void inviteContact(const char* email, const char* message, int action, MegaRequestListener* listener = NULL);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1509,7 +1509,7 @@ class MegaApiImpl : public MegaApp
 
         char *exportMasterKey();
         void updatePwdReminderData(bool lastSuccess, bool lastSkipped, bool mkExported, bool dontShowAgain, bool lastLogin, MegaRequestListener *listener = NULL);
-        void mergePwdReminderData(int numDetails, const char *data, unsigned int size, string *newValue);
+        bool mergePwdReminderData(int numDetails, const char *data, unsigned int size, string *newValue);
 
         void changePassword(const char *oldPassword, const char *newPassword, MegaRequestListener *listener = NULL);
         void inviteContact(const char* email, const char* message, int action, MegaRequestListener* listener = NULL);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1509,7 +1509,6 @@ class MegaApiImpl : public MegaApp
 
         char *exportMasterKey();
         void updatePwdReminderData(bool lastSuccess, bool lastSkipped, bool mkExported, bool dontShowAgain, bool lastLogin, MegaRequestListener *listener = NULL);
-        bool mergePwdReminderData(int numDetails, const char *data, unsigned int size, string *newValue);
 
         void changePassword(const char *oldPassword, const char *newPassword, MegaRequestListener *listener = NULL);
         void inviteContact(const char* email, const char* message, int action, MegaRequestListener* listener = NULL);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2474,11 +2474,6 @@ void CommandPutUA::procresult()
         e = API_OK;
 
         User *u = client->ownuser();
-        if (User::scope(at) == '^') // store in binary format
-        {
-            string avB64 = av;
-            Base64::atob(avB64, av);
-        }
         u->setattr(at, &av, NULL);
         u->setTag(tag ? tag : -1);
         client->notifyuser(u);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1851,6 +1851,11 @@ char *MegaApi::exportMasterKey()
     return pImpl->exportMasterKey();
 }
 
+void MegaApi::masterKeyExported(MegaRequestListener *listener)
+{
+    pImpl->updatePwdReminderData(false, false, true, false, false, listener);
+}
+
 void MegaApi::changePassword(const char *oldPassword, const char *newPassword, MegaRequestListener *listener)
 {
     pImpl->changePassword(oldPassword, newPassword, listener);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10422,10 +10422,7 @@ void MegaApiImpl::login_result(error result)
     if (result == API_OK && request->getEmail() &&
             (request->getPassword() || request->getPrivateKey()))
     {
-        int creqtag = client->reqtag;
-        client->reqtag = 0;
         updatePwdReminderData(false, false, false, false, true);
-        client->reqtag = creqtag;
     }
 
     fireOnRequestFinish(request, megaError);

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -528,8 +528,8 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
         oldValue.assign(data, size);
 
         // ensure the old value has a valid format
-        if ( (std::count(oldValue.begin(), oldValue.end(), ':') != 4) ||
-             (oldValue.length() < 9) )
+        if (std::count(oldValue.begin(), oldValue.end(), ':') != 4
+                || oldValue.length() < 9)
         {
             oldValue = "0:0:0:0:0";
         }
@@ -550,10 +550,6 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     // Timestamp for last successful validation of password in PRD
     time_t tsLastSuccess;
     size_t len = oldValue.find(":");
-    if (len == string::npos || len + 1 >= oldValue.length())
-    {
-        return false;
-    }
     string buf = oldValue.substr(0, len) + "#"; // add character control '#' for conversion
     oldValue = oldValue.substr(len + 1);    // skip ':'
     if (lastSuccess)
@@ -575,10 +571,6 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     // Timestamp for last time the PRD was skipped
     time_t tsLastSkipped;
     len = oldValue.find(":");
-    if (len == string::npos || len + 1 >= oldValue.length())
-    {
-        return false;
-    }
     buf = oldValue.substr(0, len) + "#";
     oldValue = oldValue.substr(len + 1);
     if (lastSkipped)
@@ -600,7 +592,7 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     // Flag for Recovery Key exported
     bool flagMkExported;
     len = oldValue.find(":");
-    if (len != 1 || len + 1 == oldValue.length())
+    if (len != 1)
     {
         return false;
     }
@@ -656,12 +648,8 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     }
 
     // Timestamp for last time user logged in
-     time_t tsLastLogin;
+    time_t tsLastLogin = 0;
     len = oldValue.length();
-    if (len < 1)
-    {
-        return false;
-    }
     if (lastLogin)
     {
         tsLastLogin = time(NULL);

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -377,6 +377,10 @@ string User::attr2string(attr_t type)
             attrname = "^!lang";
             break;
 
+        case ATTR_PWD_REMINDER:
+            attrname = "^!prd";
+            break;
+
         case ATTR_UNKNOWN:  // empty string
             break;
     }
@@ -446,6 +450,10 @@ attr_t User::string2attr(const char* name)
     {
         return ATTR_LANGUAGE;
     }
+    else if(!strcmp(name, "^!prd"))
+    {
+        return ATTR_PWD_REMINDER;
+    }
     else
     {
         return ATTR_UNKNOWN;   // attribute not recognized
@@ -464,6 +472,7 @@ bool User::needversioning(attr_t at)
         case ATTR_BIRTHMONTH:
         case ATTR_BIRTHYEAR:
         case ATTR_LANGUAGE:
+        case ATTR_PWD_REMINDER:
             return 0;
 
         case ATTR_AUTHRING:
@@ -497,6 +506,7 @@ char User::scope(attr_t at)
             return '+';
 
         case ATTR_LANGUAGE:
+        case ATTR_PWD_REMINDER:
             return '^';
 
         default:
@@ -571,6 +581,10 @@ bool User::setChanged(attr_t at)
 
         case ATTR_LANGUAGE:
             changed.language = true;
+            break;
+
+        case ATTR_PWD_REMINDER:
+            changed.pwdReminder = true;
             break;
 
         default:

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -633,7 +633,7 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     {
         return false;
     }
-    buf = oldValue.substr(0, len);
+    buf = oldValue.substr(0, len) + "#";
     oldValue = oldValue.substr(len + 1);
     if (dontShowAgain && !(buf.at(0) == '1'))
     {

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -662,7 +662,6 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     {
         return false;
     }
-    buf = oldValue.substr(0, len) + "#";
     if (lastLogin)
     {
         tsLastLogin = time(NULL);
@@ -670,6 +669,8 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     }
     else
     {
+        buf = oldValue.substr(0, len) + "#";
+
         char *pEnd = NULL;
         tsLastLogin = strtol(buf.data(), &pEnd, 10);
         if (*pEnd != '#' || tsLastLogin == LONG_MAX || tsLastLogin == LONG_MIN)

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1394,6 +1394,8 @@ TEST_F(SdkTest, SdkTestTransfers)
  *
  * - Modify firstname
  * = Check firstname of a contact
+ * = Set master key as exported
+ * = Get preferred language
  * - Load avatar
  * = Check avatar of a contact
  * - Delete avatar
@@ -1582,6 +1584,23 @@ TEST_F(SdkTest, SdkTestContacts)
     delete u;
 
 
+    // --- Set master key already as exported
+
+    u = megaApi[0]->getMyUser();
+
+    requestFlags[0][MegaRequest::TYPE_SET_ATTR_USER] = false;
+    megaApi[0]->masterKeyExported();
+    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_USER]) );
+
+    ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_PWD_REMINDER, maxTimeout, 0));
+    string pwdReminder = attributeValue;
+    int offset = pwdReminder.find(':');
+    offset += pwdReminder.find(':', offset);
+    ASSERT_EQ( pwdReminder.at(offset+1), '1' ) << "Password reminder attribute not updated";
+
+    delete u;
+
+
     // --- Get language preference
 
     u = megaApi[0]->getMyUser();
@@ -1591,6 +1610,8 @@ TEST_F(SdkTest, SdkTestContacts)
     ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_LANGUAGE, maxTimeout, 0));
     string language = attributeValue;
     ASSERT_TRUE(!strcmp(langCode.c_str(), language.c_str())) << "Language code is wrong";
+
+    delete u;
 
 
     // --- Load avatar ---

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1595,8 +1595,8 @@ TEST_F(SdkTest, SdkTestContacts)
     ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_PWD_REMINDER, maxTimeout, 0));
     string pwdReminder = attributeValue;
     int offset = pwdReminder.find(':');
-    offset += pwdReminder.find(':', offset);
-    ASSERT_EQ( pwdReminder.at(offset+1), '1' ) << "Password reminder attribute not updated";
+    offset += pwdReminder.find(':', offset+1);
+    ASSERT_EQ( pwdReminder.at(offset), '1' ) << "Password reminder attribute not updated";
 
     delete u;
 


### PR DESCRIPTION
It automatically updates the `^!prd` user attribute to store the last login timestamp when the SDK is logged in with email+pwd. Additionally, a new method `MegaApi::masterKeyExported()` also updates the attribute correspondingly. This method shoudl be called when the apps show the master key (recovery key) and the user clicks on _Save file_ or _Copy_
This PR also solves an issue related to the `^!lang` attribute, whose value was set in Base64 incorrectly.