### PR TITLE
Fixed for compilation in Windows.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,7 +191,7 @@ case $host in
     WIN32=yes
     ;;
   *-*-mingw*)
-    LIBS_EXTRA="-lws2_32 -lcrypt32 -lole32 -lwinmm -lshlwapi"
+    LIBS_EXTRA="-lws2_32 -lcrypt32 -lole32 -lwinmm -lshlwapi -lshell32"
     CXXFLAGS="$CXXFLAGS -DUNICODE -DWINVER=0x0501 -DHAVE_STRUCT_TIMESPEC"
     WIN32=yes
     ;;

--- a/examples/include.am
+++ b/examples/include.am
@@ -100,6 +100,7 @@ examples_mega_cmd_server_LDADD = $(LIBS_EXTRA) $(FI_LDFLAGS) $(FI_LIBS) $(ZLIB_L
 
 examples_mega_exec_CXXFLAGS += -D_WIN32=1
 examples_mega_exec_LDADD = $(LIBS_EXTRA)
+examples_mega_cmd_LDADD += $(LIBS_EXTRA)
 
 
 else

--- a/examples/include.am
+++ b/examples/include.am
@@ -93,6 +93,7 @@ if WIN32
 noinst_HEADERS += examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.h include/mega/thread.h include/mega/thread/win32thread.h include/mega/logging.h
 examples_mega_cmd_SOURCES += examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp src/thread/win32thread.cpp src/logging.cpp
 examples_mega_exec_SOURCES += examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp src/thread/win32thread.cpp src/logging.cpp
+examples_mega_cmd_server_SOURCES += examples/megacmd/comunicationsmanagernamedpipes.cpp
 
 examples_mega_cmd_server_CXXFLAGS = -D_WIN32=1 -Iinclude/ -Iinclude/mega/win32 $(FI_CXXFLAGS) $(ZLIB_CXXFLAGS) $(LIBUV_CXXFLAGS) $(LIBCURL_FLAGS) $(CRYPTO_CXXFLAGS) $(DB_CXXFLAGS) $(WINHTTP_CXXFLAGS) $(SODIUM_CXXFLAGS)
 examples_mega_cmd_server_LDADD = $(LIBS_EXTRA) $(FI_LDFLAGS) $(FI_LIBS) $(ZLIB_LDFLAGS) $(ZLIB_LIBS) $(LIBUV_LDFLAGS) $(LIBUV_LIBS) $(CRYPTO_LDFLAGS) $(CRYPTO_LIBS) $(DB_LDFLAGS) $(DB_LIBS) $(WINHTTP_LDFLAGS) $(WINHTTP_LIBS)  $(SODIUM_LDFLAGS) $(SODIUM_LIBS) $(top_builddir)/src/libmega.la $(LIBS_EXTRA)

--- a/examples/megacmd/comunicationsmanagernamedpipes.cpp
+++ b/examples/megacmd/comunicationsmanagernamedpipes.cpp
@@ -86,7 +86,13 @@ HANDLE ComunicationsManagerNamedPipes::create_new_namedPipe(int *pipeId)
 
         if (*pipeId)
         {
+    #ifdef __MINGW32__
+            wostringstream wos;
+            wos << *pipeId;
+            nameOfPipe += wos.str();
+    #else
             nameOfPipe += std::to_wstring(*pipeId);
+    #endif
         }
 
         // Create a pipe to send data
@@ -333,7 +339,12 @@ CmdPetition * ComunicationsManagerNamedPipes::getPetition()
     string receivedutf8;
 
     wbuffer[n]='\0';
+#ifdef __MINGW32__
+    wstring ws = wbuffer;
+    localwtostring(&ws,&receivedutf8);
+#else
     localwtostring(&wstring(wbuffer),&receivedutf8);
+#endif
 
     int namedPipe_id = 0; // this value shouldn't matter
     inf->outNamedPipe = create_new_namedPipe(&namedPipe_id);

--- a/examples/megacmd/comunicationsmanagerportsockets.cpp
+++ b/examples/megacmd/comunicationsmanagerportsockets.cpp
@@ -469,7 +469,12 @@ CmdPetition * ComunicationsManagerPortSockets::getPetition()
     if (n != SOCKET_ERROR)
     {
         wbuffer[n]='\0';
+#ifdef __MINGW32__
+        wstring ws=wbuffer;
+        localwtostring(&ws,&receivedutf8);
+#else
         localwtostring(&wstring(wbuffer),&receivedutf8);
+#endif
     }
     else
     {

--- a/examples/megacmd/megacmdshell/megacmdshell.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshell.cpp
@@ -913,10 +913,10 @@ int getcharacterreadlineUTF16support (FILE *stream)
 
     while (1)
     {
-        int oldmode = _setmode(fileno(stream), _O_U16TEXT);
+        int oldmode = _setmode(_fileno(stream), _O_U16TEXT);
 
         result = read (fileno (stream), &b, 10);
-        _setmode(fileno(stream), oldmode);
+        _setmode(_fileno(stream), oldmode);
 
         if (result == 0)
         {
@@ -1690,9 +1690,9 @@ void mycompletefunct(char **c, int num_matches, int max_length)
         string option = c[i];
 
         OUTSTREAM << setw(min(cols-1,max_length+1)) << left;
-        int oldmode = _setmode(fileno(stdout), _O_U16TEXT);
+        int oldmode = _setmode(_fileno(stdout), _O_U16TEXT);
         OUTSTREAM << c[i];
-        _setmode(fileno(stdout), oldmode);
+        _setmode(_fileno(stdout), oldmode);
 
         if ( (i%nelements_per_col == 0) && (i != num_matches))
         {

--- a/examples/megacmd/megacmdshell/megacmdshell.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshell.cpp
@@ -61,6 +61,13 @@ enum
 #else
 #include <fcntl.h>
 #include <io.h>
+#include <stdio.h>
+#ifndef _O_U16TEXT
+#define _O_U16TEXT 0x00020000
+#endif
+#ifndef _O_U8TEXT
+#define _O_U8TEXT 0x00040000
+#endif
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/examples/megacmd/megacmdshell/megacmdshellcommunications.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshellcommunications.cpp
@@ -324,9 +324,9 @@ int MegaCmdShellCommunications::createSocket(int number, bool initializeserver, 
 
                 wchar_t foldercontainingexec[MAX_PATH+1];
                 bool okgetcontaningfolder = false;
-                if (!SHGetSpecialFolderPathW(NULL,(LPWSTR)foldercontainingexec,CSIDL_LOCAL_APPDATA,false))
+                if (!SHGetFolderPathW(NULL,CSIDL_LOCAL_APPDATA,NULL,0,(LPWSTR)foldercontainingexec))
                 {
-                    if(!SHGetSpecialFolderPathW(NULL,(LPWSTR)foldercontainingexec,CSIDL_COMMON_APPDATA,false))
+                    if(!SHGetFolderPathW(NULL,CSIDL_COMMON_APPDATA,NULL,0,(LPWSTR)foldercontainingexec))
                     {
                         cerr << " Could not get LOCAL nor COMMON App Folder : " << ERRNO << endl;
                     }

--- a/examples/megacmd/megacmdshell/megacmdshellcommunications.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshellcommunications.cpp
@@ -54,6 +54,10 @@
 #define INVALID_SOCKET -1
 #endif
 
+#ifndef ENOTCONN
+#define ENOTCONN 107
+#endif
+
 #ifndef SSTR
     #define SSTR( x ) static_cast< std::ostringstream & >( \
         ( std::ostringstream() << std::dec << x ) ).str()
@@ -746,9 +750,9 @@ int MegaCmdShellCommunications::executeCommand(string command, bool (*readconfir
 
             wstring wbuffer;
             stringtolocalw((const char*)&buffer,&wbuffer);
-            int oldmode = _setmode(fileno(stdout), _O_U16TEXT);
+            int oldmode = _setmode(_fileno(stdout), _O_U16TEXT);
             output << wbuffer;
-            _setmode(fileno(stdout), oldmode);
+            _setmode(_fileno(stdout), oldmode);
 #else
             buffer[n]='\0';
             output << buffer;

--- a/examples/megacmd/megacmdshell/megacmdshellcommunications.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshellcommunications.cpp
@@ -33,6 +33,13 @@
 
 #include <fcntl.h>
 #include <io.h>
+#include <stdio.h>
+#ifndef _O_U16TEXT
+#define _O_U16TEXT 0x00020000
+#endif
+#ifndef _O_U8TEXT
+#define _O_U8TEXT 0x00040000
+#endif
 
 #else
 #include <fcntl.h>

--- a/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
@@ -37,6 +37,14 @@
 
 #include <fcntl.h>
 #include <io.h>
+#include <stdio.h>
+#ifndef _O_U16TEXT
+#define _O_U16TEXT 0x00020000
+#endif
+#ifndef _O_U8TEXT
+#define _O_U8TEXT 0x00040000
+#endif
+
 #if defined(_WIN32) && !defined(WINDOWS_PHONE)
 #include "mega/thread/win32thread.h"
 class MegaThread : public mega::Win32Thread {};

--- a/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
@@ -389,9 +389,9 @@ HANDLE MegaCmdShellCommunicationsNamedPipes::createNamedPipe(int number, bool in
 
                 wchar_t foldercontainingexec[MAX_PATH+1];
                 bool okgetcontaningfolder = false;
-                if (!SHGetSpecialFolderPathW(NULL,(LPWSTR)foldercontainingexec,CSIDL_LOCAL_APPDATA,false))
+                if (!SHGetFolderPathW(NULL,CSIDL_LOCAL_APPDATA,NULL,0,(LPWSTR)foldercontainingexec))
                 {
-                    if(!SHGetSpecialFolderPathW(NULL,(LPWSTR)foldercontainingexec,CSIDL_COMMON_APPDATA,false))
+                    if(!SHGetFolderPathW(NULL,CSIDL_COMMON_APPDATA,NULL,0,(LPWSTR)foldercontainingexec))
                     {
                         cerr << " Could not get LOCAL nor COMMON App Folder : " << ERRNO << endl;
                     }

--- a/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
@@ -332,7 +332,13 @@ HANDLE MegaCmdShellCommunicationsNamedPipes::createNamedPipe(int number, bool in
 
     if (number)
     {
+#ifdef __MINGW32__
+        wostringstream wos;
+        wos << number;
+        nameOfPipe += wos.str();
+#else
         nameOfPipe += std::to_wstring(number);
+#endif
     }
 
     // Open the named pipe

--- a/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
+++ b/examples/megacmd/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
@@ -608,16 +608,16 @@ int MegaCmdShellCommunicationsNamedPipes::executeCommand(string command, bool (*
                 // In non-interactive mode, at least in powershell, when outputting to a file/pipe, things get rough
                 // Powershell tries to interpret the output as a string and would meddle with the UTF16 encoding, resulting
                 // in unusable output, So we disable the UTF-16 in such cases (this might cause that the output could be truncated!).
-//                oldmode = _setmode(fileno(stdout), _O_U16TEXT);
+//                oldmode = _setmode(_fileno(stdout), _O_U16TEXT);
 //            }
 
-            oldmode = _setmode(fileno(stdout), _O_U8TEXT);
+            oldmode = _setmode(_fileno(stdout), _O_U8TEXT);
             output << wbuffer << flush;
-            _setmode(fileno(stdout), oldmode);
+            _setmode(_fileno(stdout), oldmode);
 
 //            if (interactiveshell || outputtobinaryorconsole() || true)
 //            {
-//                _setmode(fileno(stdout), oldmode);
+//                _setmode(_fileno(stdout), oldmode);
 //            }
         }
     } while(n == BUFFERSIZE && readok);

--- a/examples/megacmd/megacmdutils.cpp
+++ b/examples/megacmd/megacmdutils.cpp
@@ -23,7 +23,7 @@
 
 #ifdef USE_PCRE
 #include <pcrecpp.h>
-#elif __cplusplus >= 201103L
+#elif __cplusplus >= 201103L && !defined(__MINGW32__)
 #include <regex>
 #endif
 
@@ -793,7 +793,7 @@ bool isRegExp(string what)
     bool isregex = strcmp(what.c_str(), ns.c_str());
     return isregex;
 
-#elif __cplusplus >= 201103L
+#elif __cplusplus >= 201103L && !defined(__MINGW32__)
     //TODO??
 #endif
     return hasWildCards(what);
@@ -863,7 +863,7 @@ bool patternMatches(const char *what, const char *pattern, bool usepcre)
             LOG_warn << "Invalid PCRE regex: " << re.error();
             return false;
         }
-#elif __cplusplus >= 201103L
+#elif __cplusplus >= 201103L && !defined(__MINGW32__)
         try
         {
             return std::regex_match(what, std::regex(pattern));

--- a/include/mega/thread/cppthread.h
+++ b/include/mega/thread/cppthread.h
@@ -31,6 +31,10 @@
 
 #include "mega/thread.h"
 
+#if defined(WINDOWS_PHONE) && !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS
+#endif
+
 #include <thread>
 #include <mutex>
 #include <condition_variable>

--- a/src/thread/cppthread.cpp
+++ b/src/thread/cppthread.cpp
@@ -28,6 +28,9 @@
 #include <ctime>
 #include <chrono>
 
+#ifdef _WIN32
+#include "windows.h"
+#endif
 
 namespace mega {
 

--- a/src/thread/posixthread.cpp
+++ b/src/thread/posixthread.cpp
@@ -28,6 +28,14 @@
 #include <errno.h>
 
 #ifdef USE_PTHREAD
+#if defined (__MINGW32__) && !defined(__struct_timespec_defined)
+struct timespec
+{
+  long long	tv_sec; 	/* seconds */
+  long  	tv_nsec;	/* nanoseconds */
+};
+# define __struct_timespec_defined  1
+#endif
 
 namespace mega {
 

--- a/src/thread/win32thread.cpp
+++ b/src/thread/win32thread.cpp
@@ -26,6 +26,10 @@
 #include "mega/logging.h"
 #include <limits.h>
 
+#ifdef _WIN32
+#include "windows.h"
+#endif
+
 namespace mega {
 //Thread
 Win32Thread::Win32Thread()

--- a/src/thread/win32thread.cpp
+++ b/src/thread/win32thread.cpp
@@ -24,6 +24,7 @@
 
 #include "mega/thread/win32thread.h"
 #include "mega/logging.h"
+#include <limits.h>
 
 namespace mega {
 //Thread


### PR DESCRIPTION
For MINGW and megacmd, this produced a succesful make 
make all CPPFLAGS="-D_WIN32_WINNT=0x501 -std=gnu++11" LDFLAGS="-lws2_32 -lshlwapi"
