### PR TITLE
Save memory avoiding to save short names if it's not needed

### DIFF
--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -235,7 +235,7 @@ struct MEGA_API LocalNode : public File
     localnode_map children;
 
     // for botched filesystems with legacy secondary ("short") names
-    string slocalname;
+    string *slocalname;
     localnode_map schildren;
 
     // local filesystem node ID (inode...) for rename/move detection

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -937,9 +937,11 @@ void LocalNode::setnameparent(LocalNode* newparent, string* newlocalpath)
         // remove existing child linkage
         parent->children.erase(&localname);
 
-        if (slocalname.size())
+        if (slocalname)
         {
-            parent->schildren.erase(&slocalname);
+            parent->schildren.erase(slocalname);
+            delete slocalname;
+            slocalname = NULL;
         }
     }
 
@@ -1047,9 +1049,18 @@ void LocalNode::setnameparent(LocalNode* newparent, string* newlocalpath)
         // (we don't construct a UTF-8 or sname for the root path)
         parent->children[&localname] = this;
 
-        if (sync->client->fsaccess->getsname(newlocalpath, &slocalname))
+        if (!slocalname)
         {
-            parent->schildren[&slocalname] = this;
+            slocalname = new string();
+        }
+        if (sync->client->fsaccess->getsname(newlocalpath, slocalname) && slocalname->size() && *slocalname != localname)
+        {
+            parent->schildren[slocalname] = this;
+        }
+        else
+        {
+            delete slocalname;
+            slocalname = NULL;
         }
 
         treestate(TREESTATE_NONE);
@@ -1105,6 +1116,7 @@ void LocalNode::init(Sync* csync, nodetype_t ctype, LocalNode* cparent, string* 
     syncxfer = true;
     newnode = NULL;
     parent_dbid = 0;
+    slocalname = NULL;
 
     ts = TREESTATE_NONE;
     dts = TREESTATE_NONE;
@@ -1349,6 +1361,12 @@ LocalNode::~LocalNode()
             sync->client->movetosyncdebris(node, sync->inshare);
         }
     }
+
+    if (slocalname)
+    {
+        delete slocalname;
+        slocalname = NULL;
+    }
 }
 
 void LocalNode::getlocalpath(string* path, bool sdisable) const
@@ -1361,9 +1379,9 @@ void LocalNode::getlocalpath(string* path, bool sdisable) const
     {
         // use short name, if available (less likely to overflow MAXPATH,
         // perhaps faster?) and sdisable not set
-        if (!sdisable && l->slocalname.size())
+        if (!sdisable && l->slocalname)
         {
-            path->insert(0, l->slocalname);
+            path->insert(0, *(l->slocalname));
         }
         else
         {
@@ -1575,6 +1593,7 @@ LocalNode* LocalNode::unserialize(Sync* sync, string* d)
     l->fsid = fsid;
 
     l->localname.assign(localname, localnamelen);
+    l->slocalname = NULL;
     l->name.assign(localname, localnamelen);
     sync->client->fsaccess->local2name(&l->name);
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1053,7 +1053,7 @@ void LocalNode::setnameparent(LocalNode* newparent, string* newlocalpath)
         {
             slocalname = new string();
         }
-        if (sync->client->fsaccess->getsname(newlocalpath, slocalname) && slocalname->size() && *slocalname != localname)
+        if (sync->client->fsaccess->getsname(newlocalpath, slocalname) && *slocalname != localname)
         {
             parent->schildren[slocalname] = this;
         }
@@ -1424,7 +1424,7 @@ LocalNode* LocalNode::childbyname(string* localname)
 {
     localnode_map::iterator it;
 
-    if ((it = children.find(localname)) == children.end() && (it = schildren.find(localname)) == schildren.end())
+    if (!localname || ((it = children.find(localname)) == children.end() && (it = schildren.find(localname)) == schildren.end()))
     {
         return NULL;
     }

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -779,7 +779,7 @@ bool WinFileSystemAccess::getsname(string* name, string* sname) const
         sname->erase(0, (char*)ptr - sname->data() + sizeof(wchar_t));
     }
 
-    return true;
+    return sname->size();
 #endif
 }
 


### PR DESCRIPTION
Also, when it's not needed, a string is not allocated.