### PR TITLE
Fix jpeg images preview/thumbnail generation

### DIFF
--- a/include/mega/gfx/freeimage.h
+++ b/include/mega/gfx/freeimage.h
@@ -29,6 +29,17 @@ namespace mega {
 // bitmap graphics processor
 class MEGA_API GfxProcFreeImage : public GfxProc
 {
+    enum {
+        ROTATION_UP             = 1,    // No rotation (top-left)
+        ROTATION_UP_MIRRORED    = 2,    // Horizontal mirrored (top-right)
+        ROTATION_DOWN           = 3,    // Rotated 180 degrees (bottom-right)
+        ROTATION_DOWN_MIRRORED  = 4,    // Vertical mirrored (bottom-left)
+        ROTATION_LEFT_MIRRORED  = 5,    // Rotated and mirrored (left-top)
+        ROTATION_LEFT           = 6,    // Rotated 270 degrees (left-bottom)
+        ROTATION_RIGHT_MIRRORED = 7,    // Rotated and mirrored (right-bottom)
+        ROTATION_RIGHT          = 8     // Rotated 90 degrees (right-top)
+    };
+
     FIBITMAP* dib;
 
     bool readbitmap(FileAccess*, string*, int);

--- a/include/mega/gfx/freeimage.h
+++ b/include/mega/gfx/freeimage.h
@@ -29,17 +29,6 @@ namespace mega {
 // bitmap graphics processor
 class MEGA_API GfxProcFreeImage : public GfxProc
 {
-    enum {
-        ROTATION_UP             = 1,    // No rotation (top-left)
-        ROTATION_UP_MIRRORED    = 2,    // Horizontal mirrored (top-right)
-        ROTATION_DOWN           = 3,    // Rotated 180 degrees (bottom-right)
-        ROTATION_DOWN_MIRRORED  = 4,    // Vertical mirrored (bottom-left)
-        ROTATION_LEFT_MIRRORED  = 5,    // Rotated and mirrored (left-top)
-        ROTATION_LEFT           = 6,    // Rotated 270 degrees (left-bottom)
-        ROTATION_RIGHT_MIRRORED = 7,    // Rotated and mirrored (right-bottom)
-        ROTATION_RIGHT          = 8     // Rotated 90 degrees (right-top)
-    };
-
     FIBITMAP* dib;
 
     bool readbitmap(FileAccess*, string*, int);

--- a/src/gfx/freeimage.cpp
+++ b/src/gfx/freeimage.cpp
@@ -90,62 +90,6 @@ bool GfxProcFreeImage::readbitmap(FileAccess* fa, string* localname, int size)
 #endif
             return false;
         }
-        
-        int rotation = 0; // Image rotation degrees. Default value: no rotation
-        if (FreeImage_GetMetadata(FIMD_EXIF_MAIN, dib, "Orientation", &tag))
-        {
-            switch (tag == NULL ? 0 : *((short *)FreeImage_GetTagValue(tag)))
-            {
-                case ROTATION_DOWN:
-                case ROTATION_DOWN_MIRRORED:
-                    rotation = 180;
-                    break;                
-                
-                case ROTATION_LEFT:
-                case ROTATION_LEFT_MIRRORED:
-                    rotation = 270;
-                    break;                
-
-                case ROTATION_RIGHT:
-                case ROTATION_RIGHT_MIRRORED:
-                    rotation = 90;
-                    break;
-
-                case ROTATION_UP:
-                case ROTATION_UP_MIRRORED:
-                default:
-                    rotation = 0;
-                    break;
-            }
-        }
-
-        if (FreeImage_GetMetadata(FIMD_COMMENTS, dib, "OriginalJPEGWidth", &tag))
-        {
-            if (rotation == 90 || rotation == 270)
-            {
-                h = atoi((char*)FreeImage_GetTagValue(tag));
-            }
-            else
-            {
-                w = atoi((char*)FreeImage_GetTagValue(tag));
-            }
-        }
-        else
-        {
-            w = FreeImage_GetWidth(dib);
-        }
-
-        if (FreeImage_GetMetadata(FIMD_COMMENTS, dib, "OriginalJPEGHeight", &tag))
-        {
-            if (rotation == 90 || rotation == 270)
-                w = atoi((char*)FreeImage_GetTagValue(tag));
-            else
-                h = atoi((char*)FreeImage_GetTagValue(tag));
-        }
-        else
-        {
-            h = FreeImage_GetHeight(dib);
-        }
     }
     else
 #endif
@@ -163,10 +107,10 @@ bool GfxProcFreeImage::readbitmap(FileAccess* fa, string* localname, int size)
 #endif
             return false;
         }
-
-        w = FreeImage_GetWidth(dib);
-        h = FreeImage_GetHeight(dib);
     }
+
+    w = FreeImage_GetWidth(dib);
+    h = FreeImage_GetHeight(dib);
 
     if (!w || !h)
     {

--- a/src/gfx/freeimage.cpp
+++ b/src/gfx/freeimage.cpp
@@ -90,10 +90,45 @@ bool GfxProcFreeImage::readbitmap(FileAccess* fa, string* localname, int size)
 #endif
             return false;
         }
+        
+        int rotation = 0; // Image rotation degrees. Default value: no rotation
+        if (FreeImage_GetMetadata(FIMD_EXIF_MAIN, dib, "Orientation", &tag))
+        {
+            switch (tag == NULL ? 0 : *((short *)FreeImage_GetTagValue(tag)))
+            {
+                case ROTATION_DOWN:
+                case ROTATION_DOWN_MIRRORED:
+                    rotation = 180;
+                    break;                
+                
+                case ROTATION_LEFT:
+                case ROTATION_LEFT_MIRRORED:
+                    rotation = 270;
+                    break;                
+
+                case ROTATION_RIGHT:
+                case ROTATION_RIGHT_MIRRORED:
+                    rotation = 90;
+                    break;
+
+                case ROTATION_UP:
+                case ROTATION_UP_MIRRORED:
+                default:
+                    rotation = 0;
+                    break;
+            }
+        }
 
         if (FreeImage_GetMetadata(FIMD_COMMENTS, dib, "OriginalJPEGWidth", &tag))
         {
-            w = atoi((char*)FreeImage_GetTagValue(tag));
+            if (rotation == 90 || rotation == 270)
+            {
+                h = atoi((char*)FreeImage_GetTagValue(tag));
+            }
+            else
+            {
+                w = atoi((char*)FreeImage_GetTagValue(tag));
+            }
         }
         else
         {
@@ -102,7 +137,10 @@ bool GfxProcFreeImage::readbitmap(FileAccess* fa, string* localname, int size)
 
         if (FreeImage_GetMetadata(FIMD_COMMENTS, dib, "OriginalJPEGHeight", &tag))
         {
-            h = atoi((char*)FreeImage_GetTagValue(tag));
+            if (rotation == 90 || rotation == 270)
+                w = atoi((char*)FreeImage_GetTagValue(tag));
+            else
+                h = atoi((char*)FreeImage_GetTagValue(tag));
         }
         else
         {


### PR DESCRIPTION
Fix the preview/thumbnail generation of jpeg images when some rotation information is present in the image's metadata.