### PR TITLE
Block sc requests during cs requests

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1385,6 +1385,7 @@ void MegaClient::exec()
                                 app->request_error(e);
                                 delete pendingcs;
                                 pendingcs = NULL;
+                                csretrying = false;
                                 break;
                             }
 
@@ -1424,6 +1425,7 @@ void MegaClient::exec()
                             {
                                 delete pendingcs;
                                 pendingcs = NULL;
+                                csretrying = false;
                                 break;
                             }
                         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1586,9 +1586,9 @@ void MegaClient::exec()
 
         // do not process the SC result until all preconfigured syncs are up and running
         // except if SC packets are required to complete a fetchnodes
-        if (!scpaused && jsonsc.pos && (syncsup || !statecurrent) && !syncdownrequired && !syncdownretry)
+        if (!scpaused && jsonsc.pos && (syncsup || !statecurrent) && !syncdownrequired && !syncdownretry && !pendingcs && !csretrying)
 #else
-        if (!scpaused && jsonsc.pos)
+        if (!scpaused && jsonsc.pos && !pendingcs && !csretrying)
 #endif
         {
             // FIXME: reload in case of bad JSON


### PR DESCRIPTION
This should fix race conditions between the two request channels that could corrupt the local cache