### PR TITLE
Don't generate thumbnails for the iOS File Provider extension and fix crash generating thumbnails in iOS 11

### DIFF
--- a/include/mega/gfx/GfxProcCG.h
+++ b/include/mega/gfx/GfxProcCG.h
@@ -32,8 +32,8 @@ class MEGA_API GfxProcCG : public mega::GfxProc
     CGImageSourceRef imageSource;
     CFDictionaryRef imageParams;
     CFMutableDictionaryRef thumbnailParams;
-    CGImageRef createThumbnailWithMaxSize(int size);
-    int maxSizeForThumbnail(const int rw, const int rh);
+    CGImageRef createThumbnailWithMaxSize(double size);
+    double maxSizeForThumbnail(const int rw, const int rh);
 private: // mega::GfxProc implementations
     const char* supportedformats();
     bool readbitmap(mega::FileAccess*, mega::string*, int);

--- a/include/mega/gfx/GfxProcCG.h
+++ b/include/mega/gfx/GfxProcCG.h
@@ -32,8 +32,8 @@ class MEGA_API GfxProcCG : public mega::GfxProc
     CGImageSourceRef imageSource;
     CFDictionaryRef imageParams;
     CFMutableDictionaryRef thumbnailParams;
-    CGImageRef createThumbnailWithMaxSize(double size);
-    double maxSizeForThumbnail(const int rw, const int rh);
+    CGImageRef createThumbnailWithMaxSize(int size);
+    int maxSizeForThumbnail(const int rw, const int rh);
 private: // mega::GfxProc implementations
     const char* supportedformats();
     bool readbitmap(mega::FileAccess*, mega::string*, int);

--- a/src/gfx/GfxProcCG.mm
+++ b/src/gfx/GfxProcCG.mm
@@ -61,11 +61,7 @@ GfxProcCG::~GfxProcCG() {
 extern const char *__progname;
 
 const char* GfxProcCG::supportedformats() {
-    if (strcmp(((char *)__progname), "MEGAPickerFileProvider")!=0) {
-        return ".jpg.png.bmp.tif.tiff.jpeg.gif.pdf.ico.cur.mov.mp4.m4v.3gp.heic.";
-    } else {
-        return "";
-    }
+    return ".jpg.png.bmp.tif.tiff.jpeg.gif.pdf.ico.cur.mov.mp4.m4v.3gp.heic.";
 }
 
 bool GfxProcCG::readbitmap(FileAccess* fa, string* name, int size) {
@@ -201,6 +197,11 @@ int GfxProcCG::maxSizeForThumbnail(const int rw, const int rh) {
 
 bool GfxProcCG::resizebitmap(int rw, int rh, string* jpegout) {
     if (!imageSource) {
+        return false;
+    }
+    
+    // Don't generate previews with the File Provider to avoid crashes due to memory limitations
+    if (rh && strcmp(((char *)__progname), "MEGAPickerFileProvider")==0) {
         return false;
     }
 

--- a/src/gfx/GfxProcCG.mm
+++ b/src/gfx/GfxProcCG.mm
@@ -165,9 +165,8 @@ bool GfxProcCG::readbitmap(FileAccess* fa, string* name, int size) {
     return w && h;
 }
 
-CGImageRef GfxProcCG::createThumbnailWithMaxSize(int size) {
-    const double maxSizeDouble = size;
-    CFNumberRef maxSize = CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &maxSizeDouble);
+CGImageRef GfxProcCG::createThumbnailWithMaxSize(double size) {
+    CFNumberRef maxSize = CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &size);
     CFDictionarySetValue(thumbnailParams, kCGImageSourceThumbnailMaxPixelSize, maxSize);
     CFRelease(maxSize);
 
@@ -192,12 +191,12 @@ static inline CGRect tileRect(size_t w, size_t h)
     return res;
 }
 
-int GfxProcCG::maxSizeForThumbnail(const int rw, const int rh) {
+double GfxProcCG::maxSizeForThumbnail(const int rw, const int rh) {
     if (rh) { // rectangular rw*rh bounding box
         return std::max(rw, rh);
     }
     // square rw*rw crop thumbnail
-    return (int)(rw * std::max(w, h) / std::min(w, h));
+    return ceil(rw * ((double)std::max(w, h) / (double)std::min(w, h)));
 }
 
 bool GfxProcCG::resizebitmap(int rw, int rh, string* jpegout) {

--- a/src/gfx/GfxProcCG.mm
+++ b/src/gfx/GfxProcCG.mm
@@ -165,8 +165,8 @@ bool GfxProcCG::readbitmap(FileAccess* fa, string* name, int size) {
     return w && h;
 }
 
-CGImageRef GfxProcCG::createThumbnailWithMaxSize(double size) {
-    CFNumberRef maxSize = CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &size);
+CGImageRef GfxProcCG::createThumbnailWithMaxSize(int size) {
+    CFNumberRef maxSize = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &size);
     CFDictionarySetValue(thumbnailParams, kCGImageSourceThumbnailMaxPixelSize, maxSize);
     CFRelease(maxSize);
 
@@ -191,7 +191,7 @@ static inline CGRect tileRect(size_t w, size_t h)
     return res;
 }
 
-double GfxProcCG::maxSizeForThumbnail(const int rw, const int rh) {
+int GfxProcCG::maxSizeForThumbnail(const int rw, const int rh) {
     if (rh) { // rectangular rw*rh bounding box
         return std::max(rw, rh);
     }

--- a/src/gfx/GfxProcCG.mm
+++ b/src/gfx/GfxProcCG.mm
@@ -58,8 +58,14 @@ GfxProcCG::~GfxProcCG() {
     }
 }
 
+extern const char *__progname;
+
 const char* GfxProcCG::supportedformats() {
-    return ".jpg.png.bmp.tif.tiff.jpeg.gif.pdf.ico.cur.mov.mp4.m4v.3gp.heic.";
+    if (strcmp(((char *)__progname), "MEGAPickerFileProvider")!=0) {
+        return ".jpg.png.bmp.tif.tiff.jpeg.gif.pdf.ico.cur.mov.mp4.m4v.3gp.heic.";
+    } else {
+        return "";
+    }
 }
 
 bool GfxProcCG::readbitmap(FileAccess* fa, string* name, int size) {


### PR DESCRIPTION
Due to the memory limitations of the new iOS 11 File Provider extension, thumbnails/previews cannot be generated while using it (because the system kills the app). This is a workaround that avoid the crashes.