### PR TITLE
Patch for RSA public key with padding

### DIFF
--- a/include/mega/crypto/cryptopp.h
+++ b/include/mega/crypto/cryptopp.h
@@ -278,6 +278,8 @@ public:
     static const int MAXKEYLENGTH = 1026;   // in bytes, allows for RSA keys up
                                             // to 8192 bits
 
+    bool usePadding = false;
+
     /**
      * @brief Sets a key from a buffer.
      *
@@ -362,11 +364,13 @@ public:
     /**
      * @brief Serialize public key for compatibility with the webclient.
      *
+     * It also add padding (PUB_E size is forced to 4 bytes) in case the
+     * of the key, at reception from server, indicates it has zero-padding.
+     *
      * @param d String to take the serialized key without size-headers
-     * @param fixedSize Boolean to indicate if PUB_E size is forced to 4 bytes
      * @return Void.
      */
-    void serializekeyforjs(string& d, bool fixedSize = false);
+    void serializekeyforjs(string& d);
 
     /**
      * @brief Generates an RSA key pair of a given key size.

--- a/include/mega/crypto/cryptopp.h
+++ b/include/mega/crypto/cryptopp.h
@@ -274,11 +274,10 @@ public:
     static const int PUBKEY = 2;
 
     CryptoPP::Integer key[PRIVKEY];
+    unsigned int padding;
 
     static const int MAXKEYLENGTH = 1026;   // in bytes, allows for RSA keys up
                                             // to 8192 bits
-
-    bool usePadding = false;
 
     /**
      * @brief Sets a key from a buffer.

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2910,12 +2910,6 @@ void CommandPubKeyRequest::procresult()
                     if (client->fetchingkeys && u->userhandle == client->me && len_pubk)
                     {
                         client->pubk.setkey(AsymmCipher::PUBKEY, pubkbuf, len_pubk);
-
-                        // Webclient adds padding to the 1/2/3 bytes used by exponent
-                        if (len_pubk == 264)
-                        {
-                            client->pubk.usePadding = true;
-                        }
                         return;
                     }
     #endif

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2910,6 +2910,12 @@ void CommandPubKeyRequest::procresult()
                     if (client->fetchingkeys && u->userhandle == client->me && len_pubk)
                     {
                         client->pubk.setkey(AsymmCipher::PUBKEY, pubkbuf, len_pubk);
+
+                        // Webclient adds padding to the 1/2/3 bytes used by exponent
+                        if (len_pubk == 264)
+                        {
+                            client->pubk.usePadding = true;
+                        }
                         return;
                     }
     #endif

--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -464,14 +464,14 @@ void AsymmCipher::resetkey()
     }
 }
 
-void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
+void AsymmCipher::serializekeyforjs(string& d)
 {
     unsigned sizePQ = key[PUB_PQ].ByteCount();
     unsigned sizeE = key[PUB_E].ByteCount();
     char c;
 
     d.clear();
-    d.reserve(!fixedSize ? sizePQ + sizeE : sizePQ + 4);
+    d.reserve(!usePadding ? sizePQ + sizeE : sizePQ + 4);
 
     for (int j = key[PUB_PQ].ByteCount(); j--;)
     {
@@ -479,7 +479,7 @@ void AsymmCipher::serializekeyforjs(string& d, bool fixedSize)
         d.append(&c, sizeof c);
     }
 
-    if (fixedSize)
+    if (usePadding)
     {
         // accounts created by webclient use 4 bytes for serialization of exponent
         // --> add left-padding up to 4 bytes for compatibility reasons

--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -454,7 +454,7 @@ int AsymmCipher::decrypt(const byte* cipher, int cipherlen, byte* out, int numby
 int AsymmCipher::setkey(int numints, const byte* data, int len)
 {
     int ret = decodeintarray(key, numints, data, len);
-    padding = (numints == PUBKEY) ? (len - key[PUB_PQ].ByteCount() - key[PUB_E].ByteCount() - 4) : 0;
+    padding = (numints == PUBKEY && ret) ? (len - key[PUB_PQ].ByteCount() - key[PUB_E].ByteCount() - 4) : 0;
     return ret;
 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -9548,26 +9548,16 @@ void MegaClient::initializekeys()
                                     &sigPubk,
                                     (unsigned char*) puEd255.data()))
         {
-            // Verification could fail because a legacy bug in Webclient. Retry...
-            LOG_warn << "Failed to verify signature. Retrying with webclient compatibility fix...";
+            LOG_warn << "Verification of signature of public key for RSA failed";
 
-            pubk.serializekeyforjs(pubkstr, true);
-            if (!signkey->verifyKey((unsigned char*) pubkstr.data(),
-                                        pubkstr.size(),
-                                        &sigPubk,
-                                        (unsigned char*) puEd255.data()))
-            {
-                LOG_warn << "Verification of signature of public key for RSA failed";
+            int creqtag = reqtag;
+            reqtag = 0;
+            sendevent(99414, "Verification of signature of public key for RSA failed");
+            reqtag = creqtag;
 
-                int creqtag = reqtag;
-                reqtag = 0;
-                sendevent(99414, "Verification of signature of public key for RSA failed");
-                reqtag = creqtag;
-
-                clearKeys();
-                resetKeyring();
-                return;
-            }
+            clearKeys();
+            resetKeyring();
+            return;
         }
 
         // if we reached this point, everything is OK


### PR DESCRIPTION
It prevents to create invalid `sigPubk` when RSA keypair is generated by
Webclient and the signature is created by the SDK.