### PR TITLE
Better management of the local cache of nodes

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -776,6 +776,9 @@ public:
     // state cache table for logged in user
     DbTable* sctable;
 
+    // there is data to commit to the database when possible
+    bool pendingsccommit;
+
     // transfer cache table
     DbTable* tctable;
     // scsn as read from sctable

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1485,6 +1485,7 @@ void CommandLogin::procresult()
                         client->sctable->remove();
                         delete client->sctable;
                         client->sctable = NULL;
+                        client->pendingsccommit = false;
                         client->cachedscsn = UNDEF;
                         client->dbaccess->currentDbVersion = DbAccess::DB_VERSION;
 
@@ -3898,6 +3899,7 @@ void CommandFetchNodes::procresult()
                 client->mergenewshares(0);
                 client->applykeys();
                 client->initsc();
+                client->pendingsccommit = false;
                 client->fetchnodestag = tag;
 
                 WAIT_CLASS::bumpds();

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14280,7 +14280,7 @@ void MegaApiImpl::sendPendingRequests()
                     client->sctable->remove();
                     delete client->sctable;
                     client->sctable = NULL;
-
+                    client->pendingsccommit = false;
                     client->cachedscsn = UNDEF;
                 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3440,7 +3440,7 @@ bool MegaClient::procsc()
                     notifypurge();
                     if (sctable)
                     {
-                        if (!pendingcs && !csretrying)
+                        if (!pendingcs && !csretrying && !reqs.cmdspending())
                         {
                             sctable->commit();
                             sctable->begin();


### PR DESCRIPTION
To allow the reception of action packets in parallel with requests, but
also prevent the corruption of the cache due to race conditions between
requests and action packets.