### PR TITLE
Defer a transfer when file storage not available

### DIFF
--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -381,7 +381,11 @@ void Transfer::failed(error e, dstime timeleft)
 
     for (file_list::iterator it = files.begin(); it != files.end(); it++)
     {
-        if ((*it)->failed(e) || e == API_ENOENT)
+        if ( (*it)->failed(e)
+                || (e == API_ENOENT // putnodes returned -9, file-storage server unavailable
+                    && type == PUT
+                    && slot && slot->tempurl.empty()
+                    && failcount < 16) )
         {
             defer = true;
         }

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -381,7 +381,7 @@ void Transfer::failed(error e, dstime timeleft)
 
     for (file_list::iterator it = files.begin(); it != files.end(); it++)
     {
-        if ((*it)->failed(e))
+        if ((*it)->failed(e) || e == API_ENOENT)
         {
             defer = true;
         }


### PR DESCRIPTION
It could happen that the PutFile command (`u`) returns -9 because there
are no file-storage servers available. It should be a very rare and
transient situation, where the client should retry rather than abort the
transfer directly.