### PR TITLE
Fix result tag for putua()

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -226,7 +226,7 @@ class MEGA_API CommandPutUA : public Command
     string av;  // attribute value
 
 public:
-    CommandPutUA(MegaClient*, attr_t at, const byte*, unsigned);
+    CommandPutUA(MegaClient*, attr_t at, const byte*, unsigned, int);
 
     void procresult();
 };

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2501,7 +2501,7 @@ void CommandPutUAVer::procresult()
     }
 }
 
-CommandPutUA::CommandPutUA(MegaClient* client, attr_t at, const byte* av, unsigned avl)
+CommandPutUA::CommandPutUA(MegaClient* client, attr_t at, const byte* av, unsigned avl, int ctag)
 {
     this->at = at;
     this->av.assign((const char*)av, avl);
@@ -2522,7 +2522,7 @@ CommandPutUA::CommandPutUA(MegaClient* client, attr_t at, const byte* av, unsign
 
     notself(client);
 
-    tag = client->reqtag;
+    tag = ctag;
 }
 
 void CommandPutUA::procresult()

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7751,7 +7751,7 @@ void MegaClient::putua(attr_t at, const byte* av, unsigned avl, int ctag)
 
     if (!needversion)
     {
-        reqs.add(new CommandPutUA(this, at, av, avl));
+        reqs.add(new CommandPutUA(this, at, av, avl, (ctag != -1) ? ctag : reqtag));
     }
     else
     {


### PR DESCRIPTION
When the `prd` user attribute is set internally, it requires 2 chained
requests, first one to get the value, second one to set the updated
value. The resulting request tag is wrongly set for the second request,
resulting in a request that never finishes. However, the request is kept
in the request's map until a logout, when it's forced to finish with
EACCESS.
Now, with this fix, the request is correctly finished and notified to
the app via `onRequestFinish()`