### PR TITLE
Fix wp and uwp compilation

### DIFF
--- a/bindings/wp8/vs2013/mega.vcxproj
+++ b/bindings/wp8/vs2013/mega.vcxproj
@@ -358,6 +358,7 @@
     <ClInclude Include="..\..\..\include\mega\http.h" />
     <ClInclude Include="..\..\..\include\mega\json.h" />
     <ClInclude Include="..\..\..\include\mega\logging.h" />
+    <ClInclude Include="..\..\..\include\mega\mediafileattribute.h" />
     <ClInclude Include="..\..\..\include\mega\megaapp.h" />
     <ClInclude Include="..\..\..\include\mega\megaclient.h" />
     <ClInclude Include="..\..\..\include\mega\node.h" />
@@ -444,6 +445,7 @@
     <ClCompile Include="..\..\..\src\http.cpp" />
     <ClCompile Include="..\..\..\src\json.cpp" />
     <ClCompile Include="..\..\..\src\logging.cpp" />
+    <ClCompile Include="..\..\..\src\mediafileattribute.cpp" />
     <ClCompile Include="..\..\..\src\megaapi.cpp" />
     <ClCompile Include="..\..\..\src\megaapi_impl.cpp" />
     <ClCompile Include="..\..\..\src\megaclient.cpp" />

--- a/bindings/wp8/vs2013/mega.vcxproj.filters
+++ b/bindings/wp8/vs2013/mega.vcxproj.filters
@@ -282,6 +282,9 @@
     <ClInclude Include="..\MAchievementsDetails.h">
       <Filter>Bindings</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\include\mega\mediafileattribute.h">
+      <Filter>SDK\Header</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\attrmap.cpp">
@@ -502,6 +505,9 @@
     </ClCompile>
     <ClCompile Include="..\MAchievementsDetails.cpp">
       <Filter>Bindings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\mediafileattribute.cpp">
+      <Filter>SDK\Source</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/bindings/wp8/vs2015/mega.vcxproj
+++ b/bindings/wp8/vs2015/mega.vcxproj
@@ -47,6 +47,7 @@
     <ClInclude Include="..\..\..\include\mega\http.h" />
     <ClInclude Include="..\..\..\include\mega\json.h" />
     <ClInclude Include="..\..\..\include\mega\logging.h" />
+    <ClInclude Include="..\..\..\include\mega\mediafileattribute.h" />
     <ClInclude Include="..\..\..\include\mega\megaapp.h" />
     <ClInclude Include="..\..\..\include\mega\megaclient.h" />
     <ClInclude Include="..\..\..\include\mega\mega_http_parser.h" />
@@ -134,6 +135,7 @@
     <ClCompile Include="..\..\..\src\http.cpp" />
     <ClCompile Include="..\..\..\src\json.cpp" />
     <ClCompile Include="..\..\..\src\logging.cpp" />
+    <ClCompile Include="..\..\..\src\mediafileattribute.cpp" />
     <ClCompile Include="..\..\..\src\megaapi.cpp" />
     <ClCompile Include="..\..\..\src\megaapi_impl.cpp" />
     <ClCompile Include="..\..\..\src\megaclient.cpp" />

--- a/bindings/wp8/vs2015/mega.vcxproj.filters
+++ b/bindings/wp8/vs2015/mega.vcxproj.filters
@@ -277,6 +277,9 @@
     <ClInclude Include="..\MAchievementsDetails.h">
       <Filter>Bindings</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\include\mega\mediafileattribute.h">
+      <Filter>SDK\Header</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\DelegateMGfxProcessor.cpp">
@@ -503,6 +506,9 @@
     </ClCompile>
     <ClCompile Include="..\MAchievementsDetails.cpp">
       <Filter>Bindings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\mediafileattribute.cpp">
+      <Filter>SDK\Source</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add mediafileattribute to the SDK projects for vs2013 (Windows Phone) and vs2015 (UWP).