### PR TITLE
Several fixes for the management of HTTPS connections:

### DIFF
--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2288,6 +2288,7 @@ public:
 
     //tls stuff:
     evt_tls_t *evt_tls;
+    std::list<char*> writePointers;
 
     // Request information
     bool range;

--- a/src/mega_evt_tls.cpp
+++ b/src/mega_evt_tls.cpp
@@ -214,7 +214,7 @@ static int evt__send_pending(evt_tls_t *conn)
     if ( !(pending > 0) )
         return 0;
 
-    void *buf = calloc(1, pending);
+    void *buf = new char[pending];
     assert(buf != NULL && "Memory alloc failed");
     if (!buf) return 0;
 
@@ -223,7 +223,6 @@ static int evt__send_pending(evt_tls_t *conn)
 
     assert( conn->writer != NULL && "You need to set network writer first");
     p = conn->writer(conn, buf, p);
-    free(buf);
     return p;
 }
 


### PR DESCRIPTION
- Prevent the deletion of buffers sent by the TLS writer before they are delivered
- Fixed several possible memory leaks if uv_write fails synchronously
- Prevent the execution of async actions or writes when the request has finished
- Wait until all data has been delivered before closing the connection
- Added more logs