### PR TITLE
remove usage of openssl engine

### DIFF
--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -304,7 +304,7 @@ openssl_pkg() {
         local cwd=$(pwd)
         cd $openssl_dir
         perl -pi -e 's/install: all install_docs install_sw/install: install_docs install_sw/g' Makefile.org
-        ./config shared no-ssl2 no-ssl3 no-comp no-hw --prefix=$install_dir
+        ./config shared no-ssl2 no-ssl3 no-comp no-hw no-engine --prefix=$install_dir
         make depend || exit 1
         cd $cwd
     else

--- a/include/mega/mega_evt_tls.h
+++ b/include/mega/mega_evt_tls.h
@@ -18,7 +18,6 @@ extern "C" {
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/conf.h>
-#include <openssl/engine.h>
 #include "mega_evt_queue.h"
 
 #ifdef _WIN32

--- a/src/mega_evt_tls.cpp
+++ b/src/mega_evt_tls.cpp
@@ -423,7 +423,6 @@ void evt_ctx_free(evt_ctx_t *ctx)
     ctx->ctx = NULL;
 
     ERR_remove_state(0);
-    ENGINE_cleanup();
     CONF_modules_unload(1);
     ERR_free_strings();
     EVP_cleanup();


### PR DESCRIPTION
According to: https://www.openssl.org/docs/man1.1.0/crypto/ENGINE_cleanup.html ENGINE_cleanup was not necessary given there was no ENGINE_* calls