### PR TITLE
use https url for libuv

### DIFF
--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -453,7 +453,7 @@ libuv_pkg() {
     local install_dir=$2
     local name="libuv"
     local libuv_ver="v1.8.0"
-    local libuv_url="http://dist.libuv.org/dist/$libuv_ver/libuv-$libuv_ver.tar.gz"
+    local libuv_url="https://dist.libuv.org/dist/$libuv_ver/libuv-$libuv_ver.tar.gz"
     local libuv_md5="f4229c4360625e973ae933cb92e1faf7"
     local libuv_file="libuv-$libuv_ver.tar.gz"
     local libuv_dir="libuv-$libuv_ver"


### PR DESCRIPTION
the http redirect appears to be broken

```
$ wget http://dist.libuv.org/dist/v1.8.0/libuv-v1.8.0.tar.gz --no-hsts
--2018-03-17 20:50:34--  http://dist.libuv.org/dist/v1.8.0/libuv-v1.8.0.tar.gz
Resolving dist.libuv.org (dist.libuv.org)... 2604:a880:400:d0::b2c:a001, 138.197.224.240
Connecting to dist.libuv.org (dist.libuv.org)|2604:a880:400:d0::b2c:a001|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://nodejs.org/dist/v1.8.0/libuv-v1.8.0.tar.gz [following]
--2018-03-17 20:50:34--  https://nodejs.org/dist/v1.8.0/libuv-v1.8.0.tar.gz
Resolving nodejs.org (nodejs.org)... 2400:cb00:2048:1::6814:162e, 2400:cb00:2048:1::6814:172e, 104.20.22.46, ...
Connecting to nodejs.org (nodejs.org)|2400:cb00:2048:1::6814:162e|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2018-03-17 20:50:35 ERROR 404: Not Found.
```