### PR TITLE
Ignore ua packets based on ua version

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2337,8 +2337,6 @@ CommandPutMultipleUAVer::CommandPutMultipleUAVer(MegaClient *client, const usera
         endarray();
     }
 
-    notself(client);
-
     tag = ctag;
 }
 
@@ -2467,8 +2465,6 @@ CommandPutUAVer::CommandPutUAVer(MegaClient* client, attr_t at, const byte* av, 
 
     endarray();
 
-    notself(client);
-
     tag = ctag;
 }
 
@@ -2532,8 +2528,6 @@ CommandPutUA::CommandPutUA(MegaClient* client, attr_t at, const byte* av, unsign
     {
         arg(an.c_str(), av, avl);
     }
-
-    notself(client);
 
     tag = ctag;
 }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4722,13 +4722,12 @@ void MegaClient::sc_userattr()
                 else if (ualist.size() == uavlist.size())
                 {
                     // invalidate only out-of-date attributes
-                    const string *cacheduav;
                     for (itua = ualist.begin(), ituav = uavlist.begin();
                          itua != ualist.end();
                          itua++, ituav++)
                     {
                         attr_t type = User::string2attr(itua->c_str());
-                        cacheduav = u->getattrversion(type);
+                        const string *cacheduav = u->getattrversion(type);
                         if (cacheduav)
                         {
                             if (*cacheduav != *ituav)
@@ -4740,6 +4739,11 @@ void MegaClient::sc_userattr()
                                     resetKeyring();
                                 }
 #endif
+                            }
+                            else
+                            {
+                                LOG_info << "User attribute already up to date";
+                                return;
                             }
                         }
                         else


### PR DESCRIPTION
API will eventually start sending in user-attribute actionpackets the most recent version of the attribute, rather than every single update. That change will also remove the `i` in the APs, so clients will need to
filter ua packets based on the version. If the version is known, then the ua was set by the client and can ignore the AP.

The version given by API in response to a `up` (putua) is not included, so the approach above would need to (a) change API to return the attribute's version instead of the own user handle (as it happens currently) or (b) start using the `upv` (putua with version) for every attribute.
(a) is not possible, since the ephemeral session is started with a `up` and the userhandle is required in the response.
(b) would be too much effort, probably, leading to new issues.