### PR TITLE
Merge changes that were needed for building MEGAcmd 0.9.9 for NAS.

### DIFF
--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -787,6 +787,23 @@ freeimage_pkg() {
         export FREEIMAGE_LIBRARY_TYPE=STATIC
     fi
 
+cat << EOF > $build_dir/freeimage_neon_arm64_patch
+138c138
+< #  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_neon
+---
+> //#  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_neon
+1931,1932c1931,1932
+< PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_neon,
+<    (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
+---
+> //PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_neon,
+> //   (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
+EOF
+    # freeimage's LibPNG has a problem with deciding to use neon on 64 bit arm, resulting in a missing symbol
+    if [ "$ARCH" == "aarch64" ]; then
+      (patch `find . -name pngpriv.h` < $build_dir/freeimage_neon_arm64_patch)
+    fi 
+
     if [ "$(expr substr $(uname -s) 1 10)" != "MINGW32_NT" ]; then
         package_build $name $freeimage_dir
         # manually copy header and library

--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -215,7 +215,7 @@ add_library(Mega STATIC
             ${MegaDir}/src/json.cpp 
             ${MegaDir}/src/logging.cpp 
             ${MegaDir}/src/mediafileattribute.cpp 
-            ${MegaDir}/src/mega_ccronexpr.cpp
+#            ${MegaDir}/src/mega_ccronexpr.cpp
             ${MegaDir}/src/mega_http_parser.cpp 
             ${MegaDir}/src/mega_utf8proc.cpp 
             ${MegaDir}/src/mega_zxcvbn.cpp 

--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -1,0 +1,308 @@
+# This file enables building with cmake on windows  
+#
+# use cases
+#  - generate a visual studio solution and projects, eg: cmake . -G "Visual Studio 15 2017"
+#  - or for 64 bit: cmake . -G "Visual Studio 15 2017 Win64"
+#  - or set your build options before VS project generation by using the gui, eg:  cmake-gui.exe .
+#  - open this CMakeLists.txt as a 'cmake project' with Visual Studio 2017 or beyond, and you can build and test/debug on windows or on Linux from one IDE (eg. a virtualbox linux instance on the same machine)
+#       (though it seems in order for it to copy the needed build tree, this file must be copied up one level (to the mega root dir) and opened as a CMake project in VS from there
+
+cmake_minimum_required(VERSION 3.8)
+
+#set this to 1 if building 64 bit with eg. cmake . -G "Visual Studio 15 2017 Win64"
+#set this to 0 if building 32 bit with eg. cmake . -G "Visual Studio 15 2017"
+set (build_64_bit 1 CACHE TYPE BOOL)
+
+#indicate which dependent libraries to use in the build
+set (USE_CRYPTOPP 1 CACHE TYPE BOOL)
+set (USE_OPENSSL 0 CACHE TYPE BOOL)
+set (OPENSSL_IS_BORINGSSL 0 CACHE TYPE BOOL)
+set (USE_CURL 0 CACHE TYPE BOOL)
+set (USE_SQLITE 1 CACHE TYPE BOOL)
+set (USE_MEDIAINFO 1 CACHE TYPE BOOL)
+set (USE_FREEIMAGE 1 CACHE TYPE BOOL)
+set (USE_SODIUM 1 CACHE TYPE BOOL)
+set (ENABLE_SYNC 1 CACHE TYPE BOOL)
+set (ENABLE_CHAT 1 CACHE TYPE BOOL)
+
+if (WIN32)
+    set (NO_READLINE 1 CACHE TYPE BOOL)
+else(WIN32)
+    set(NO_READLINE 0)
+endif(WIN32)
+
+if(build_64_bit)
+    project (MegaSDK64 LANGUAGES CXX C)
+else(build_64_bit)
+    project (MegaSDK32 LANGUAGES CXX C)
+endif(build_64_bit)
+
+IF(WIN32)
+    set(MegaDir "${CMAKE_CURRENT_LIST_DIR}/../..")
+    if ("${Mega3rdPartyDir}" STREQUAL "")
+        set(Mega3rdPartyDir "${MegaDir}/../3rdparty")
+    endif()
+ELSE(WIN32)
+    set(MegaDir "${CMAKE_CURRENT_LIST_DIR}")
+ENDIF(WIN32)
+
+if (NOT CMAKE_BUILD_TYPE)
+    message("Generated with config types: ${CMAKE_CONFIGURATION_TYPES}")
+else(NOT CMAKE_BUILD_TYPE)
+    message("CMAKE_BUILD_TYPE is ${CMAKE_BUILD_TYPE}")
+endif(NOT CMAKE_BUILD_TYPE)
+
+#windows projects usually need _DEBUG and/or DEBUG set rather than NDEBUG not set
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
+
+IF(WIN32)
+    #Link against the static C/C++ libraries on windows
+    foreach(flag_var
+            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE 
+            CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+       if(${flag_var} MATCHES "/MD")
+          string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+       endif(${flag_var} MATCHES "/MD")
+    endforeach(flag_var)
+ENDIF(WIN32)
+
+
+function(ImportStaticLibrary libName includeDir lib32debug lib32release lib64debug lib64release)
+    add_library(${libName} STATIC IMPORTED)
+    set_property(TARGET ${libName} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${includeDir})
+    if(build_64_bit)
+        set_property(TARGET ${libName} PROPERTY IMPORTED_LOCATION_DEBUG ${lib64debug})
+        set_property(TARGET ${libName} PROPERTY IMPORTED_LOCATION_RELEASE  ${lib64release})
+    else(build_64_bit)
+        set_property(TARGET ${libName} PROPERTY IMPORTED_LOCATION_DEBUG ${lib32debug})
+        set_property(TARGET ${libName} PROPERTY IMPORTED_LOCATION_RELEASE  ${lib32release})
+    endif(build_64_bit)
+endfunction(ImportStaticLibrary)
+
+
+IF(WIN32)
+
+    IF(USE_CRYPTOPP)
+    ImportStaticLibrary(cryptopp        "${Mega3rdPartyDir}/cryptopp565/include"
+                                        "${Mega3rdPartyDir}/cryptopp565/Win32/Output/Debug/cryptlib.lib" 
+                                        "${Mega3rdPartyDir}/cryptopp565/Win32/Output/Release/cryptlib.lib" 
+                                        "${Mega3rdPartyDir}/cryptopp565/x64/Output/Debug/cryptlib.lib" 
+                                        "${Mega3rdPartyDir}/cryptopp565/x64/Output/Release/cryptlib.lib")
+    ENDIF(USE_CRYPTOPP)
+
+    IF(USE_SODIUM)
+    ImportStaticLibrary(sodium          "${Mega3rdPartyDir}/libsodium-1.0.15/src/libsodium/include"
+                                        "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Debug/Win32/libsodium.lib" 
+                                        "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Release/Win32/libsodium.lib" 
+                                        "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Debug/x64/libsodium.lib" 
+                                        "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Release/x64/libsodium.lib")
+    ENDIF(USE_SODIUM)
+
+    IF(USE_CURL)
+        ImportStaticLibrary(curl        "${Mega3rdPartyDir}/curl-7.56.0/include"
+                                        "${Mega3rdPartyDir}/curl-7.56.0/builds/libcurl-vc-x86-debug-static-ssl-static-cares-static-zlib-static-ipv6-sspi/lib/libcurl_a_debug.lib" 
+                                        "${Mega3rdPartyDir}/curl-7.56.0/builds/libcurl-vc-x86-release-static-ssl-static-cares-static-zlib-static-ipv6-sspi/lib/libcurl_a.lib"
+                                        "${Mega3rdPartyDir}/curl-7.56.0/builds/libcurl-vc-x64-debug-static-ssl-static-cares-static-zlib-static-ipv6-sspi/lib/libcurl_a_debug.lib" 
+                                        "${Mega3rdPartyDir}/curl-7.56.0/builds/libcurl-vc-x64-release-static-ssl-static-cares-static-zlib-static-ipv6-sspi/lib/libcurl_a.lib")
+
+        ImportStaticLibrary(cares       "${Mega3rdPartyDir}/c-ares-1.13.0/include"
+                                        "${Mega3rdPartyDir}/c-ares-1.13.0/built32/lib/libcaresd.lib"
+                                        "${Mega3rdPartyDir}/c-ares-1.13.0/built32/lib/libcares.lib"
+                                        "${Mega3rdPartyDir}/c-ares-1.13.0/built64/lib/libcaresd.lib"
+                                        "${Mega3rdPartyDir}/c-ares-1.13.0/built64/lib/libcares.lib")
+    ENDIF(USE_CURL)
+
+    IF(USE_OPENSSL)
+        ImportStaticLibrary(ssl         "${Mega3rdPartyDir}/openssl-1.1.0f/include"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_32d/lib/libssl.lib"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_32/lib/libssl.lib"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_64d/lib/libssl.lib"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_64/lib/libssl.lib")
+    ENDIF(USE_OPENSSL)
+    
+    ImportStaticLibrary(sslcrypto       "${Mega3rdPartyDir}/openssl-1.1.0f/include"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_32d/lib/libcrypto.lib"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_32/lib/libcrypto.lib"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_64d/lib/libcrypto.lib"
+                                        "${Mega3rdPartyDir}/openssl-1.1.0f/built_64/lib/libcrypto.lib")
+    
+
+    ImportStaticLibrary(zlib            "${Mega3rdPartyDir}/zlib-1.2.11"
+                                        "${Mega3rdPartyDir}/zlib-1.2.11/contrib/vstudio/vc14/x86/ZlibStatDebug/zlibstat.lib"
+                                        "${Mega3rdPartyDir}zlib-1.2.11/contrib/vstudio/vc14/x86/ZlibStatReleaseWithoutAsm/zlibstat.lib"
+                                        "${Mega3rdPartyDir}/zlib-1.2.11/contrib/vstudio/vc14/x64/ZlibStatDebug/zlibstat.lib"
+                                        "${Mega3rdPartyDir}/zlib-1.2.11/contrib/vstudio/vc14/x64/ZlibStatReleaseWithoutAsm/zlibstat.lib")
+
+    ImportStaticLibrary(gtest           "${Mega3rdPartyDir}/googletest/googletest/include"
+                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/Win32-Debug/gtestd.lib" 
+                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/Win32-Release/gtest.lib"
+                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/x64-Debug/gtestd.lib" 
+                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/x64-Release/gtest.lib")
+
+    IF(USE_MEDIAINFO)
+        ImportStaticLibrary(mediainfo   "${Mega3rdPartyDir}/MediaInfoLib-mw/Source"
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/Win32/Debug/MediaInfo-Static.lib" 
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/Win32/Release/MediaInfo-Static.lib"
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/x64/Debug/MediaInfo-Static.lib"
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/x64/Release/MediaInfo-Static.lib")
+
+        ImportStaticLibrary(zen         "${Mega3rdPartyDir}/ZenLib/Source"
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/Win32/Debug/ZenLib.lib"
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/Win32/Release/ZenLib.lib"
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/x64/Debug/ZenLib.lib"
+                                        "${Mega3rdPartyDir}/MediaInfoLib-mw/Project/MSVC2017/x64/Release/ZenLib.lib")
+    ENDIF(USE_MEDIAINFO)
+
+    IF(USE_FREEIMAGE)
+        ImportStaticLibrary(freeimage   "${Mega3rdPartyDir}/FreeImage3170/FreeImage/Source"
+                                        "${Mega3rdPartyDir}/FreeImage3170/FreeImage/Source/FreeImageLib/Win32/Debug/FreeImageLib.lib"
+                                        "${Mega3rdPartyDir}/FreeImage3170/FreeImage/Source/FreeImageLib/Win32/Release/FreeImageLib.lib"
+                                        "${Mega3rdPartyDir}/FreeImage3170/FreeImage/Source/FreeImageLib/x64/Debug/FreeImageLib.lib"
+                                        "${Mega3rdPartyDir}/FreeImage3170/FreeImage/Source/FreeImageLib/x64/Release/FreeImageLib.lib")
+
+    ENDIF(USE_FREEIMAGE)
+
+
+    IF(USE_SQLITE)
+        add_library(sqlite3 INTERFACE IMPORTED)
+        set_property(TARGET sqlite3 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${Mega3rdPartyDir}/sqlite-3.20.1")
+    ENDIF(USE_SQLITE)
+
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DCURL_STATICLIB -DCARES_STATICLIB -DWIN32_LEAN_AND_MEAN -DUNICODE -DSODIUM_STATIC -DPCRE_STATICWIN32 -D_CONSOLE)
+    SET(Mega_PlatformSpecificIncludes ${MegaDir}/include/mega/$<IF:${USE_CURL},wincurl,win32>)
+    SET(Mega_PlatformSpecificLibs ws2_32 winhttp Shlwapi)
+
+    get_target_property(sqlite3dir sqlite3 INTERFACE_INCLUDE_DIRECTORIES)
+    SET(Mega_PlatformSpecificFiles ${MegaDir}/src/win32/console.cpp 
+#    ${MegaDir}/src/win32/autocomplete.cpp 
+    ${MegaDir}/src/win32/consolewaiter.cpp 
+    ${MegaDir}/src/win32/fs.cpp 
+    $<IF:${USE_CURL},${MegaDir}/src/posix/net.cpp,${MegaDir}/src/win32/net.cpp>
+    ${MegaDir}/src/win32/waiter.cpp 
+    ${MegaDir}/src/thread/win32thread.cpp  
+    ${sqlite3dir}/sqlite3.c )
+
+
+ELSE(WIN32)
+
+    add_definitions(-DUSE_PTHREAD )
+    SET(Mega_PlatformSpecificFiles ${MegaDir}/src/posix/console.cpp ${MegaDir}/src/posix/consolewaiter.cpp ${MegaDir}/src/posix/fs.cpp ${MegaDir}/src/posix/net.cpp ${MegaDir}/src/posix/waiter.cpp ${MegaDir}/src/thread/posixthread.cpp )
+    SET(Mega_PlatformSpecificIncludes ${MegaDir}/include/mega/posix)
+    SET(Mega_PlatformSpecificLibs crypto pthread rt z)
+
+ENDIF(WIN32)
+
+
+SET(Mega_CryptoFiles ${MegaDir}/src/crypto/cryptopp.cpp ${MegaDir}/src/crypto/sodium.cpp)
+SET(Mega_DbFiles ${MegaDir}/src/db/sqlite.cpp ${MegaDir}/src/db/sqlite.cpp )
+SET(Mega_GfxFiles ${MegaDir}/src/gfx/external.cpp ${MegaDir}/src/gfx/freeimage.cpp ) 
+
+add_library(Mega STATIC
+            ${MegaDir}/src/attrmap.cpp 
+            ${MegaDir}/src/backofftimer.cpp 
+            ${MegaDir}/src/base64.cpp 
+            ${MegaDir}/src/command.cpp 
+            ${MegaDir}/src/commands.cpp 
+            ${MegaDir}/src/db.cpp 
+            ${MegaDir}/src/file.cpp 
+            ${MegaDir}/src/fileattributefetch.cpp 
+            ${MegaDir}/src/filefingerprint.cpp 
+            ${MegaDir}/src/filesystem.cpp 
+            ${MegaDir}/src/gfx.cpp 
+            ${MegaDir}/src/http.cpp 
+            ${MegaDir}/src/json.cpp 
+            ${MegaDir}/src/logging.cpp 
+            ${MegaDir}/src/mediafileattribute.cpp 
+            ${MegaDir}/src/mega_ccronexpr.cpp
+            ${MegaDir}/src/mega_http_parser.cpp 
+            ${MegaDir}/src/mega_utf8proc.cpp 
+            ${MegaDir}/src/mega_zxcvbn.cpp 
+            ${MegaDir}/src/megaapi.cpp 
+            ${MegaDir}/src/megaapi_impl.cpp 
+            ${MegaDir}/src/megaclient.cpp 
+            ${MegaDir}/src/node.cpp 
+            ${MegaDir}/src/pendingcontactrequest.cpp 
+            ${MegaDir}/src/proxy.cpp 
+            ${MegaDir}/src/pubkeyaction.cpp 
+#            ${MegaDir}/src/raid.cpp 
+            ${MegaDir}/src/request.cpp
+            ${MegaDir}/src/serialize64.cpp 
+            ${MegaDir}/src/share.cpp 
+            ${MegaDir}/src/sharenodekeys.cpp 
+            ${MegaDir}/src/sync.cpp 
+#            ${MegaDir}/src/testhooks.cpp 
+            ${MegaDir}/src/transfer.cpp 
+            ${MegaDir}/src/transferslot.cpp 
+            ${MegaDir}/src/treeproc.cpp 
+            ${MegaDir}/src/user.cpp 
+            ${MegaDir}/src/utils.cpp 
+            ${MegaDir}/src/waiterbase.cpp 
+            ${Mega_PlatformSpecificFiles} ${Mega_CryptoFiles} ${Mega_DbFiles} ${Mega_GfxFiles}  )
+
+target_include_directories(Mega PRIVATE ${MegaDir}/include ${Mega_PlatformSpecificIncludes})
+target_include_directories(Mega PUBLIC ${MegaDir}/include ${Mega_PlatformSpecificIncludes})
+target_link_libraries(Mega PUBLIC zlib 
+                $<${USE_CRYPTOPP}:cryptopp> 
+                $<${USE_SODIUM}:sodium> 
+                $<${USE_OPENSSL}:ssl> 
+                $<${USE_CURL}:curl>  $<${USE_CURL}:cares> 
+                $<${USE_SQLITE}:sqlite3> 
+                $<${USE_MEDIAINFO}:mediainfo> $<${USE_MEDIAINFO}:zen> 
+                $<${USE_FREEIMAGE}:freeimage> 
+                ${Mega_PlatformSpecificLibs})
+target_compile_definitions(Mega PUBLIC 
+                $<${USE_MEDIAINFO}:USE_MEDIAINFO> 
+                $<${USE_FREEIMAGE}:USE_FREEIMAGE> $<${USE_FREEIMAGE}:FREEIMAGE_LIB>  
+                $<${USE_SQLITE}:USE_SQLITE> 
+                $<${USE_CRYPTOPP}:USE_CRYPTOPP> 
+                $<${USE_OPENSSL}:USE_OPENSSL> 
+                $<${USE_CURL}:USE_CURL> 
+                $<${USE_SODIUM}:USE_SODIUM>
+                $<${ENABLE_SYNC}:ENABLE_SYNC> 
+                $<${ENABLE_CHAT}:ENABLE_CHAT> 
+                $<${NO_READLINE}:NO_READLINE> )
+
+if(WIN32)
+target_link_libraries(Mega PUBLIC crypt32.lib)
+endif(WIN32)
+
+#test apps
+add_executable(test_sdk             ${MegaDir}/tests/sdk_test.cpp 
+                                    ${MegaDir}/tests/sdktests.cpp)
+add_executable(test_misc            ${MegaDir}/tests/tests.cpp 
+                                    ${MegaDir}/tests/paycrypt_test.cpp 
+                                    ${MegaDir}/tests/crypto_test.cpp)
+add_executable(test_purge_account   ${MegaDir}/tests/purge_account.cpp)
+
+target_compile_definitions(test_sdk PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+target_compile_definitions(test_misc PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+target_compile_definitions(test_purge_account PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+target_link_libraries(test_sdk gtest Mega )
+target_link_libraries(test_misc gtest Mega )
+target_link_libraries(test_purge_account gtest Mega )
+
+#test apps need this file or tests fail
+configure_file("${MegaDir}/logo.png" logo.png COPYONLY)
+
+# actual apps
+
+add_executable(megacli ${MegaDir}/examples/megacli.cpp)
+target_link_libraries(megacli Mega)
+if (NOT NO_READLINE)
+    target_link_libraries(megacli readline)
+endif (NOT NO_READLINE)
+
+add_executable(megasimplesync ${MegaDir}/examples/megasimplesync.cpp)
+target_link_libraries(megasimplesync Mega )
+
+if(WIN32)
+add_executable(testmega "${MegaDir}/examples/win32/testmega/main.cpp")
+target_link_libraries(testmega Mega )
+endif(WIN32)
+
+#enable_testing()
+#add_test(NAME SdkTestStreaming COMMAND test_sdk "--gtest_filter=\"*Streaming*\"")
+#add_test(NAME SdkTestAll COMMAND test_sdk )
+

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -5274,7 +5274,7 @@ void DemoApp::account_details(AccountDetails* ad, bool storage, bool transfer, b
 
         if (ad->transfer_hist_starttime)
         {
-            time_t t = time(NULL) - ad->transfer_hist_starttime;
+            m_time_t t = m_time() - ad->transfer_hist_starttime;
 
             cout << "\tTransfer history:\n";
 

--- a/include/mega.h
+++ b/include/mega.h
@@ -72,11 +72,11 @@
 #include "mega/thread/win32thread.h"
 #include "mega/thread/cppthread.h"
 
-#include <megawaiter.h>
-#include <meganet.h>
-#include <megafs.h>
-#include <megaconsole.h>
-#include <megaconsolewaiter.h>
+#include "megawaiter.h"
+#include "meganet.h"
+#include "megafs.h"
+#include "megaconsole.h"
+#include "megaconsolewaiter.h"
 
 #include "mega/db/sqlite.h"
 #include "mega/db/bdb.h"

--- a/include/mega.h
+++ b/include/mega.h
@@ -72,11 +72,11 @@
 #include "mega/thread/win32thread.h"
 #include "mega/thread/cppthread.h"
 
-#include "megawaiter.h"
-#include "meganet.h"
-#include "megafs.h"
-#include "megaconsole.h"
-#include "megaconsolewaiter.h"
+#include <megawaiter.h>
+#include <meganet.h>
+#include <megafs.h>
+#include <megaconsole.h>
+#include <megaconsolewaiter.h>
 
 #include "mega/db/sqlite.h"
 #include "mega/db/bdb.h"

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -195,7 +195,7 @@ public:
     string k;
 
     // timestamp of the creation of the account
-    time_t accountsince;
+    m_time_t accountsince;
 
 #ifdef ENABLE_CHAT
     // all chats

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -103,7 +103,9 @@ struct Achievement;
 
 #define EOO 0
 
-typedef int64_t m_time_t;
+// Our own version of time_t which we can be sure is 64 bit.  
+// Utils.h has functions m_time() and so on corresponding to time() which help us to use this type and avoid arithmetic overflow when working with time_t on systems where it's 32-bit
+typedef int64_t m_time_t; 
 
 // monotonously increasing time in deciseconds
 typedef uint32_t dstime;

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -124,7 +124,7 @@ public:
     static const int PWD_SHOW_AFTER_LASTSKIP_LOGOUT = 1 * 30 * 24 * 60 * 60;
 
     static bool mergePwdReminderData(int numDetails, const char *data, unsigned int size, string *newValue);
-    static time_t getPwdReminderData(int numDetail, const char *data, unsigned int size);
+    static m_time_t getPwdReminderData(int numDetail, const char *data, unsigned int size);
 
     bool setChanged(attr_t at);
 

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @file mega/utils.h
  * @brief Mega SDK various utilities and helper classes
  *
@@ -333,6 +333,10 @@ public:
 
 // for pre-c++11 where this version is not defined yet.  
 long long abs(long long n);
+
+extern m_time_t m_time(m_time_t* tt = NULL);
+extern struct tm* m_localtime(m_time_t, struct tm *dt);
+extern m_time_t m_mktime(struct tm*);
 
 } // namespace
 

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -152,7 +152,7 @@ void Base64::itoa(int64_t val, string *result)
     {
         rest = val % 64;
         val /= 64;
-        c = to64(rest);
+        c = to64(byte(rest));
         result->insert(result->begin(), (char) c);
     }
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -443,7 +443,7 @@ void CommandDirectRead::procresult()
                     break;
 
                 case MAKENAMEID2('t', 'l'):
-                    tl = client->json.getint();
+                    tl = dstime(client->json.getint());
                     break;
 
                 case EOO:
@@ -544,7 +544,7 @@ void CommandGetFile::procresult()
     dstime tl = 0;
     int d = 0;
     byte* buf;
-    time_t ts = 0, tm = 0;
+    m_time_t ts = 0, tm = 0;
 
     // credentials relevant to a non-TransferSlot scenario (node query)
     string fileattrstring;
@@ -603,7 +603,7 @@ void CommandGetFile::procresult()
                 break;
 
             case MAKENAMEID2('t', 'l'):
-                tl = client->json.getint();
+                tl = dstime(client->json.getint());
                 break;
 
             case EOO:
@@ -2111,10 +2111,10 @@ void CommandEnumerateQuotaItems::procresult()
     while (client->json.enterarray())
     {
         if (ISUNDEF((product = client->json.gethandle(8)))
-                || ((prolevel = client->json.getint()) < 0)
-                || ((gbstorage = client->json.getint()) < 0)
-                || ((gbtransfer = client->json.getint()) < 0)
-                || ((months = client->json.getint()) < 0)
+                || ((prolevel = int(client->json.getint())) < 0)
+                || ((gbstorage = int(client->json.getint())) < 0)
+                || ((gbtransfer = int(client->json.getint())) < 0)
+                || ((months = int(client->json.getint())) < 0)
                 || !(a = client->json.getvalue())
                 || !(c = client->json.getvalue())
                 || !(d = client->json.getvalue())
@@ -3188,7 +3188,7 @@ void CommandGetUserQuota::procresult()
                 td = client->json.getint();
                 if (td != -1)
                 {
-                    details->transfer_hist_starttime = time(NULL) - td;
+                    details->transfer_hist_starttime = m_time() - td;
                 }
                 break;
 
@@ -3251,8 +3251,8 @@ void CommandGetUserQuota::procresult()
                         ns = &details->storage[h];
 
                         ns->bytes = client->json.getint();
-                        ns->files = client->json.getint();
-                        ns->folders = client->json.getint();
+                        ns->files = uint32_t(client->json.getint());
+                        ns->folders = uint32_t(client->json.getint());
                         ns->version_bytes = client->json.getint();
                         ns->version_files = client->json.getint();
 
@@ -3405,7 +3405,7 @@ void CommandQueryTransferQuota::procresult()
         return client->app->querytransferquota_result(0);
     }
 
-    return client->app->querytransferquota_result(client->json.getint());
+    return client->app->querytransferquota_result(int(client->json.getint()));
 }
 
 CommandGetUserTransactions::CommandGetUserTransactions(MegaClient* client, AccountDetails* ad)
@@ -3423,7 +3423,7 @@ void CommandGetUserTransactions::procresult()
     while (client->json.enterarray())
     {
         const char* handle = client->json.getvalue();
-        time_t ts = client->json.getint();
+        m_time_t ts = client->json.getint();
         const char* delta = client->json.getvalue();
         const char* cur = client->json.getvalue();
 
@@ -3462,7 +3462,7 @@ void CommandGetUserPurchases::procresult()
     while (client->json.enterarray())
     {
         const char* handle = client->json.getvalue();
-        const time_t ts = client->json.getint();
+        const m_time_t ts = client->json.getint();
         const char* amount = client->json.getvalue();
         const char* cur = client->json.getvalue();
         int method = (int)client->json.getint();
@@ -3770,7 +3770,7 @@ void CommandWhyAmIblocked::procresult()
 {
     if (client->json.isnumeric())
     {
-        return client->app->whyamiblocked_result(client->json.getint());
+        return client->app->whyamiblocked_result(int(client->json.getint()));
     }
 
     client->json.storeobject();
@@ -4138,7 +4138,7 @@ void CommandCreditCardQuerySubscriptions::procresult()
     int number = 0;
     if (client->json.isnumeric())
     {
-        number = client->json.getint();
+        number = int(client->json.getint());
         if(number >= 0)
         {
             client->app->creditcardquerysubscriptions_result(number, API_OK);
@@ -4250,7 +4250,7 @@ void CommandGetPaymentMethods::procresult()
 
     do
     {
-        int value = client->json.getint();
+        int value = int(client->json.getint());
         if(value < 0)
         {
             client->app->getpaymentmethods_result(methods, (error)value);
@@ -4382,10 +4382,10 @@ void CommandQueryRecoveryLink::procresult()
     int type = API_EINTERNAL;
     string email;
     string ip;
-    time_t ts;
+    m_time_t ts;
     handle uh;
 
-    if (!client->json.isnumeric() || ((type = client->json.getint()) < 0))   // error
+    if (!client->json.isnumeric() || ((type = int(client->json.getint())) < 0))   // error
     {
         return client->app->queryrecoverylink_result((error)type);
     }
@@ -4419,7 +4419,7 @@ void CommandQueryRecoveryLink::procresult()
         return client->app->queryrecoverylink_result(API_EINTERNAL);
     }
 
-    return client->app->queryrecoverylink_result(type, email.c_str(), ip.c_str(), ts, uh, &emails);
+    return client->app->queryrecoverylink_result(type, email.c_str(), ip.c_str(), time_t(ts), uh, &emails);
 }
 
 CommandGetPrivateKey::CommandGetPrivateKey(MegaClient *client, const char *code)
@@ -4643,7 +4643,7 @@ void CommandGetVersion::procresult()
         switch (client->json.getnameid())
         {
             case 'c':
-                versioncode = client->json.getint();
+                versioncode = int(client->json.getint());
                 break;
 
             case 's':
@@ -4786,7 +4786,7 @@ void CommandChatCreate::procresult()
                     break;
 
                 case MAKENAMEID2('c','s'):
-                    shard = client->json.getint();
+                    shard = int(client->json.getint());
                     break;
 
                 case 'g':
@@ -5424,7 +5424,7 @@ void CommandRichLink::procresult()
         switch (client->json.getnameid())
         {
             case MAKENAMEID5('e', 'r', 'r', 'o', 'r'):
-                errCode = client->json.getint();
+                errCode = int(client->json.getint());
                 break;
 
             case MAKENAMEID6('r', 'e', 's', 'u', 'l', 't'):
@@ -5514,7 +5514,7 @@ void CommandGetMegaAchievements::procresult()
                 {
                     for (;;)
                     {
-                        achievement_class_id id = client->json.getnameid();
+                        achievement_class_id id = achievement_class_id(client->json.getnameid());
                         if (id == EOO)
                         {
                             break;
@@ -5573,10 +5573,10 @@ void CommandGetMegaAchievements::procresult()
                             switch (client->json.getnameid())
                             {
                             case 'a':
-                                award.achievement_class = client->json.getint();
+                                award.achievement_class = achievement_class_id(client->json.getint());
                                 break;
                             case 'r':
-                                award.award_id = client->json.getint();
+                                award.award_id = int(client->json.getint());
                                 break;
                             case MAKENAMEID2('t', 's'):
                                 award.ts = client->json.getint();
@@ -5633,7 +5633,7 @@ void CommandGetMegaAchievements::procresult()
                         }
 
                         Reward reward;
-                        reward.award_id = id - '0';   // convert to number
+                        reward.award_id = int(id - '0');   // convert to number
 
                         client->json.enterarray();
 

--- a/src/crypto/sodium.cpp
+++ b/src/crypto/sodium.cpp
@@ -130,7 +130,7 @@ void EdDSA::signKey(const unsigned char *key, const unsigned long long keyLength
 {
     if (!ts)
     {
-        ts = (uint64_t) time(NULL);
+        ts = (uint64_t) m_time();
     }
 
     string tsstr;

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -162,7 +162,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
 
         for (unsigned i = 0; i < sizeof crc / sizeof *crc; i++)
         {
-            int begin = i * size / (sizeof crc / sizeof *crc);
+            int begin = int(i * size / (sizeof crc / sizeof *crc));
             int end = (i + 1) * size / (sizeof crc / sizeof *crc);
 
             crc32.add(buf + begin, end - begin);
@@ -257,7 +257,7 @@ bool FileFingerprint::genfingerprint(InputStreamAccess *is, m_time_t cmtime, boo
         HashCRC32 crc32;
         byte buf[MAXFULL];
 
-        if (!is->read(buf, size))
+        if (!is->read(buf, int(size)))
         {
             size = -1;
             return true;
@@ -265,8 +265,8 @@ bool FileFingerprint::genfingerprint(InputStreamAccess *is, m_time_t cmtime, boo
 
         for (unsigned i = 0; i < sizeof crc / sizeof *crc; i++)
         {
-            int begin = i * size / (sizeof crc / sizeof *crc);
-            int end = (i + 1) * size / (sizeof crc / sizeof *crc);
+            int begin = int(i * size / (sizeof crc / sizeof *crc));
+            int end = int((i + 1) * size / (sizeof crc / sizeof *crc));
 
             crc32.add(buf + begin, end - begin);
             crc32.get((byte*)&crcval);
@@ -291,11 +291,17 @@ bool FileFingerprint::genfingerprint(InputStreamAccess *is, m_time_t cmtime, boo
                         / (sizeof crc / sizeof *crc * blocks - 1);
 
                 //Seek
-                if (!is->read(NULL, offset - current))
+                for (m_off_t fullstep = offset - current; fullstep > 0; )  // 500G or more and the step doesn't fit in 32 bits
                 {
-                    size = -1;
-                    return true;
+                    unsigned step = fullstep > UINT_MAX ? UINT_MAX : unsigned(fullstep);
+                    if (!is->read(NULL, step))
+                    {
+                        size = -1;
+                        return true;
+                    }
+                    fullstep -= (uint64_t)step;
                 }
+
                 current += (offset - current);
 
                 if (!is->read(block, sizeof block))

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -590,7 +590,7 @@ bool mediaInfoOpenFileWithLimits(MediaInfoLib::MediaInfo& mi, std::string filena
     size_t totalBytesRead = 0, jumps = 0;
     mi.Open_Buffer_Init(filesize, 0);
     m_off_t readpos = 0;
-    time_t startTime = 0;
+    m_time_t startTime = 0;
 
     for (;;)
     {
@@ -602,7 +602,7 @@ bool mediaInfoOpenFileWithLimits(MediaInfoLib::MediaInfo& mi, std::string filena
             break;
         }
 
-        if (totalBytesRead > maxBytesToRead || (startTime != 0 && ((time(NULL) - startTime) > maxSeconds)))
+        if (totalBytesRead > maxBytesToRead || (startTime != 0 && ((m_time() - startTime) > maxSeconds)))
         {
             LOG_warn << "could not extract mediainfo data within reasonable limits";
             mi.Open_Buffer_Finalize();
@@ -620,7 +620,7 @@ bool mediaInfoOpenFileWithLimits(MediaInfoLib::MediaInfo& mi, std::string filena
         readpos += n;
         if (startTime == 0)
         {
-            startTime = time(NULL);
+            startTime = m_time();
         }
 
         totalBytesRead += n;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -244,7 +244,7 @@ MegaNodePrivate::MegaNodePrivate(Node *node)
             {
                if (node->type == FILENODE)
                {
-                   duration = Base64::atoi(&it->second);
+                   duration = int(Base64::atoi(&it->second));
                }
             }
             else if (it->first == AttrMap::string2nameid("l"))
@@ -408,11 +408,11 @@ bool MegaNodePrivate::serialize(string *d)
     unsigned short ll;
     bool flag;
 
-    ll = name ? strlen(name) + 1 : 0;
+    ll = (unsigned short)(name ? strlen(name) + 1 : 0);
     d->append((char*)&ll, sizeof(ll));
     d->append(name, ll);
 
-    ll = fingerprint ? strlen(fingerprint) + 1 : 0;
+    ll = (unsigned short)(fingerprint ? strlen(fingerprint) + 1 : 0);
     d->append((char*)&ll, sizeof(ll));
     d->append(fingerprint, ll);
 
@@ -1747,22 +1747,22 @@ bool MegaTransferPrivate::serialize(string *d)
     d->append((const char*)&parentHandle, sizeof(parentHandle));
 
     unsigned short ll;
-    ll = path ? strlen(path) + 1 : 0;
+    ll = (unsigned short)(path ? strlen(path) + 1 : 0);
     d->append((char*)&ll, sizeof(ll));
     d->append(path, ll);
 
-    ll = parentPath ? strlen(parentPath) + 1 : 0;
+    ll = (unsigned short)(parentPath ? strlen(parentPath) + 1 : 0);
     d->append((char*)&ll, sizeof(ll));
     d->append(parentPath, ll);
 
-    ll = fileName ? strlen(fileName) + 1 : 0;
+    ll = (unsigned short)(fileName ? strlen(fileName) + 1 : 0);
     d->append((char*)&ll, sizeof(ll));
     d->append(fileName, ll);
 
     d->append((const char*)&folderTransferTag, sizeof(folderTransferTag));
     d->append("\0\0\0\0\0\0", 7);
 
-    ll = appData ? strlen(appData) + 1 : 0;
+    ll = (unsigned short)(appData ? strlen(appData) + 1 : 0);
     if (ll)
     {
         char hasAppData = 1;
@@ -2523,6 +2523,7 @@ MegaRegExp *MegaRequestPrivate::getRegExp() const
 {
     return regExp;
 }
+
 void MegaRequestPrivate::setRegExp(MegaRegExp *regExp)
 {
     if (this->regExp)
@@ -5201,16 +5202,16 @@ void MegaApiImpl::setNodeCoordinates(MegaNode *node, double latitude, double lon
         request->setNodeHandle(node->getHandle());
     }
 
-    int lat = latitude;
+    int lat = int(latitude);
     if (latitude != MegaNode::INVALID_COORDINATE)
     {
-        lat = ((latitude + 90) / 180) * 0xFFFFFF;
+        lat = int(((latitude + 90) / 180) * 0xFFFFFF);
     }
 
-    int lon = longitude;
+    int lon = int(longitude);
     if (longitude != MegaNode::INVALID_COORDINATE)
     {
-        lon = (longitude == 180) ? 0 : ((longitude + 180) / 360) * 0x01000000;
+        lon = int((longitude == 180) ? 0 : ((longitude + 180) / 360) * 0x01000000);
     }
 
     request->setParamType(MegaApi::NODE_ATTR_COORDINATES);
@@ -5937,22 +5938,22 @@ bool MegaApiImpl::setMaxUploadSpeed(m_off_t bpslimit)
 
 int MegaApiImpl::getMaxDownloadSpeed()
 {
-    return client->getmaxdownloadspeed();
+    return int(client->getmaxdownloadspeed());
 }
 
 int MegaApiImpl::getMaxUploadSpeed()
 {
-    return client->getmaxuploadspeed();
+    return int(client->getmaxuploadspeed());
 }
 
 int MegaApiImpl::getCurrentDownloadSpeed()
 {
-    return httpio->downloadSpeed;
+    return int(httpio->downloadSpeed);
 }
 
 int MegaApiImpl::getCurrentUploadSpeed()
 {
-    return httpio->uploadSpeed;
+    return int(httpio->uploadSpeed);
 }
 
 int MegaApiImpl::getCurrentSpeed(int type)
@@ -5960,9 +5961,9 @@ int MegaApiImpl::getCurrentSpeed(int type)
     switch (type)
     {
     case MegaTransfer::TYPE_DOWNLOAD:
-        return httpio->downloadSpeed;
+        return int(httpio->downloadSpeed);
     case MegaTransfer::TYPE_UPLOAD:
-        return httpio->uploadSpeed;
+        return int(httpio->uploadSpeed);
     default:
         return 0;
     }
@@ -10579,7 +10580,7 @@ void MegaApiImpl::fa_complete(handle, fatype, const char* data, uint32_t len)
         MegaRequestPrivate* request = requestMap.at(tag);
         if(!request || (request->getType() != MegaRequest::TYPE_GET_ATTR_FILE)) return;
 
-        tag = request->getNumber();
+        tag = int(request->getNumber());
 
         FileAccess *f = client->fsaccess->newfileaccess();
         string filePath(request->getFile());
@@ -10616,7 +10617,7 @@ int MegaApiImpl::fa_failed(handle, fatype, int retries, error e)
         if(!request || (request->getType() != MegaRequest::TYPE_GET_ATTR_FILE))
             return 1;
 
-        tag = request->getNumber();
+        tag = int(request->getNumber());
         if(retries >= 2)
         {
             fireOnRequestFinish(request, MegaError(e));
@@ -10732,7 +10733,7 @@ void MegaApiImpl::additem_result(error e)
     }
 
     //MegaRequest::TYPE_UPGRADE_ACCOUNT
-    int method = request->getNumber();
+    int method = int(request->getNumber());
     client->purchase_checkout(method);
 }
 
@@ -11536,7 +11537,7 @@ void MegaApiImpl::getua_result(error e)
                 return;
             }
             else if (request->getType() == MegaRequest::TYPE_GET_ATTR_USER
-                     && (time(NULL) - client->accountsince) > User::PWD_SHOW_AFTER_ACCOUNT_AGE)
+                 && (m_time() - client->accountsince) > User::PWD_SHOW_AFTER_ACCOUNT_AGE)
             {
                 request->setFlag(true); // the password reminder dialog should be shown
             }
@@ -11646,7 +11647,7 @@ void MegaApiImpl::getua_result(byte* data, unsigned len)
                 }
                 else if (attrType == MegaApi::USER_ATTR_PWD_REMINDER)
                 {
-                    time_t currenttime = time(NULL);
+                    m_time_t currenttime = m_time();
                     if (!User::getPwdReminderData(User::PWD_MK_EXPORTED, (const char*)data, len)
                             && !User::getPwdReminderData(User::PWD_DONT_SHOW, (const char*)data, len)
                             && (currenttime - client->accountsince) > User::PWD_SHOW_AFTER_ACCOUNT_AGE
@@ -12912,10 +12913,9 @@ int naturalsorting_compare (const char *i, const char *j)
                 return difference;
             }
 
-            difference = number_i - number_j;
-            if (difference)
+            if (number_i != number_j)
             {
-                return difference;
+                return number_i > number_j ? 1 : -1;
             }
 
             stringMode = true;
@@ -15165,7 +15165,7 @@ void MegaApiImpl::sendPendingRequests()
                         break;
                     }
 
-                    prevtag = req->getNumber();
+                    prevtag = int(req->getNumber());
                 }
 
                 if(req)
@@ -15460,7 +15460,7 @@ void MegaApiImpl::sendPendingRequests()
                 int type = request->getParamType();
                 if (type == MegaApi::NODE_ATTR_DURATION)
                 {
-                    int secs = request->getNumber();
+                    int secs = int(request->getNumber());
                     if (node->type != FILENODE || secs < MegaNode::INVALID_DURATION)
                     {
                         e = API_EARGS;
@@ -15669,7 +15669,7 @@ void MegaApiImpl::sendPendingRequests()
         {
             const char *email = request->getEmail();
             const char *message = request->getText();
-            int action = request->getNumber();
+            int action = int(request->getNumber());
             MegaHandle contactLink = request->getNodeHandle();
 
             if(client->loggedin() != FULLACCOUNT)
@@ -15696,7 +15696,7 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_REPLY_CONTACT_REQUEST:
         {
             handle h = request->getNodeHandle();
-            int action = request->getNumber();
+            int action = int(request->getNumber());
 
             if(h == INVALID_HANDLE || action < 0 || action > MegaContactRequest::REPLY_ACTION_IGNORE)
             {
@@ -16064,7 +16064,7 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_PAUSE_TRANSFERS:
         {
             bool pause = request->getFlag();
-            int direction = request->getNumber();
+            int direction = int(request->getNumber());
             if(direction != -1
                     && direction != MegaTransfer::TYPE_DOWNLOAD
                     && direction != MegaTransfer::TYPE_UPLOAD)
@@ -16112,7 +16112,7 @@ void MegaApiImpl::sendPendingRequests()
         {
             bool automove = request->getFlag();
             int transferTag = request->getTransferTag();
-            int number = request->getNumber();
+            int number = int(request->getNumber());
 
             if (!transferTag || !number)
             {
@@ -16192,7 +16192,7 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_SET_MAX_CONNECTIONS:
         {
             int direction = request->getParamType();
-            int connections = request->getNumber();
+            int connections = int(request->getNumber());
 
             if (connections <= 0 || (direction != -1
                     && direction != MegaTransfer::TYPE_DOWNLOAD
@@ -16487,7 +16487,7 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_GET_PAYMENT_ID:
         case MegaRequest::TYPE_UPGRADE_ACCOUNT:
         {
-            int method = request->getNumber();
+            int method = int(request->getNumber());
             if(method != MegaApi::PAYMENT_METHOD_BALANCE && method != MegaApi::PAYMENT_METHOD_CREDIT_CARD)
             {
                 e = API_EARGS;
@@ -16500,7 +16500,7 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_SUBMIT_PURCHASE_RECEIPT:
         {
             const char* receipt = request->getText();
-            int type = request->getNumber();
+            int type = int(request->getNumber());
 
             if(!receipt || (type != MegaApi::PAYMENT_METHOD_GOOGLE_WALLET
                             && type != MegaApi::PAYMENT_METHOD_ITUNES
@@ -16556,7 +16556,7 @@ void MegaApiImpl::sendPendingRequests()
         }
         case MegaRequest::TYPE_SUBMIT_FEEDBACK:
         {
-            int rating = request->getNumber();
+            int rating = int(request->getNumber());
             const char *message = request->getText();
 
             if(rating < 1 || rating > 5)
@@ -16587,7 +16587,7 @@ void MegaApiImpl::sendPendingRequests()
         }
         case MegaRequest::TYPE_SEND_EVENT:
         {
-            int number = request->getNumber();
+            int number = int(request->getNumber());
             const char *text = request->getText();
 
             if(number < 99500 || number >= 99600 || !text)
@@ -16701,7 +16701,7 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_QUERY_GELB:
         {
             const char *service = request->getName();
-            int timeoutds = request->getNumber();
+            int timeoutds = int(request->getNumber());
             int maxretries = request->getNumRetry();
             if (!service)
             {
@@ -16881,7 +16881,7 @@ void MegaApiImpl::sendPendingRequests()
         }
         case MegaRequest::TYPE_REGISTER_PUSH_NOTIFICATION:
         {
-            int deviceType = request->getNumber();
+            int deviceType = int(request->getNumber());
             const char *token = request->getText();
 
             if ((deviceType != MegaApi::PUSH_NOTIFICATION_ANDROID &&
@@ -22647,7 +22647,7 @@ int MegaAchievementsDetailsPrivate::getRewardExpire(unsigned int index)
 long long MegaAchievementsDetailsPrivate::currentStorage()
 {
     long long total = 0;
-    m_time_t ts = time(NULL);
+    m_time_t ts = m_time();
 
     for (vector<Award>::iterator it = details.awards.begin(); it != details.awards.end(); it++)
     {
@@ -22669,7 +22669,7 @@ long long MegaAchievementsDetailsPrivate::currentStorage()
 long long MegaAchievementsDetailsPrivate::currentTransfer()
 {
     long long total = 0;
-    m_time_t ts = time(NULL);
+    m_time_t ts = m_time();
 
     for (vector<Award>::iterator it = details.awards.begin(); it != details.awards.end(); it++)
     {
@@ -22691,7 +22691,7 @@ long long MegaAchievementsDetailsPrivate::currentTransfer()
 long long MegaAchievementsDetailsPrivate::currentStorageReferrals()
 {
     long long total = 0;
-    m_time_t ts = time(NULL);
+    m_time_t ts = m_time();
 
     for (vector<Award>::iterator it = details.awards.begin(); it != details.awards.end(); it++)
     {
@@ -22713,7 +22713,7 @@ long long MegaAchievementsDetailsPrivate::currentStorageReferrals()
 long long MegaAchievementsDetailsPrivate::currentTransferReferrals()
 {
     long long total = 0;
-    m_time_t ts = time(NULL);
+    m_time_t ts = m_time();
 
     for (vector<Award>::iterator it = details.awards.begin(); it != details.awards.end(); it++)
     {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1866,7 +1866,7 @@ void MegaClient::exec()
                     for (it = syncs.begin(); it != syncs.end(); )
                     {
                         Sync* sync = *it++;
-                        prevpending |= sync->dirnotify->notifyq[q].size();
+                        prevpending = prevpending || sync->dirnotify->notifyq[q].size();
                         if (prevpending)
                         {
                             break;
@@ -5010,7 +5010,7 @@ void MegaClient::sc_upc()
                 uts = jsonsc.getint();
                 break; 
             case 's':
-                s = jsonsc.getint();
+                s = int(jsonsc.getint());
                 break;
             case 'p':
                 p = jsonsc.gethandle(MegaClient::PCRHANDLE);
@@ -5188,7 +5188,7 @@ void MegaClient::sc_se()
             uh = jsonsc.gethandle(USERHANDLE);
             break;
         case 's':
-            status = jsonsc.getint();
+            status = int(jsonsc.getint());
             break;
         case EOO:
             done = true;
@@ -5268,7 +5268,7 @@ void MegaClient::sc_chatupdate()
                 break;
 
             case MAKENAMEID2('c','s'):
-                shard = jsonsc.getint();
+                shard = int(jsonsc.getint());
                 break;
 
             case 'n':   // the new user, for notification purposes (not used)
@@ -5469,7 +5469,7 @@ void MegaClient::sc_chatflags()
                 break;
 
             case 'f':
-                flags = jsonsc.getint();
+                flags = byte(jsonsc.getint());
                 break;
 
             case EOO:
@@ -6220,7 +6220,7 @@ int MegaClient::readnodes(JSON* j, int notify, putsource_t source, NewNode* nn, 
                     break;
 
                 case 'i':   // related source NewNode index
-                    nni = j->getint();
+                    nni = int(j->getint());
                     break;
 
                 case MAKENAMEID2('t', 's'):  // actual creation timestamp
@@ -6391,7 +6391,7 @@ int MegaClient::readnodes(JSON* j, int notify, putsource_t source, NewNode* nn, 
                 // fallback timestamps
                 if (!(ts + 1))
                 {
-                    ts = time(NULL);
+                    ts = m_time();
                 }
 
                 if (!(sts + 1))
@@ -8406,7 +8406,7 @@ void MegaClient::procmcf(JSON *j)
                                 break;
 
                             case MAKENAMEID2('c','s'):
-                                shard = j->getint();
+                                shard = int(j->getint());
                                 break;
 
                             case 'u':   // list of users participating in the chat (+privileges)
@@ -8494,7 +8494,7 @@ void MegaClient::procmcf(JSON *j)
                     while(j->enterobject()) // while there are more chatid/flag tuples to read...
                     {
                         handle chatid = UNDEF;
-                        int flags = 0xFF;
+                        byte flags = 0xFF;
 
                         bool readingFlags = true;
                         while (readingFlags)
@@ -8507,7 +8507,7 @@ void MegaClient::procmcf(JSON *j)
                                 break;
 
                             case 'f':
-                                flags = j->getint();
+                                flags = byte(j->getint());
                                 break;
 
                             case EOO:
@@ -9439,7 +9439,7 @@ void MegaClient::closetc(bool remove)
         {
             transfer_map::iterator it = cachedtransfers[d].begin();
             Transfer *transfer = it->second;
-            if (remove || (purgeOrphanTransfers && (time(NULL) - transfer->lastaccesstime) >= 172500))
+            if (remove || (purgeOrphanTransfers && (m_time() - transfer->lastaccesstime) >= 172500))
             {
                 LOG_warn << "Purging orphan transfer";
                 transfer->finished = true;
@@ -10137,7 +10137,7 @@ void MegaClient::queueread(handle h, bool p, SymmCipher* key, int64_t ctriv, m_o
 
         if (overquotauntil && overquotauntil > Waiter::ds)
         {
-            dstime timeleft = overquotauntil - Waiter::ds;
+            dstime timeleft = dstime(overquotauntil - Waiter::ds);
             app->pread_failure(API_EOVERQUOTA, 0, appdata, timeleft);
             it->second->schedule(timeleft);
         }
@@ -10151,7 +10151,7 @@ void MegaClient::queueread(handle h, bool p, SymmCipher* key, int64_t ctriv, m_o
         it->second->enqueue(offset, count, reqtag, appdata);
         if (overquotauntil && overquotauntil > Waiter::ds)
         {
-            dstime timeleft = overquotauntil - Waiter::ds;
+            dstime timeleft = dstime(overquotauntil - Waiter::ds);
             app->pread_failure(API_EOVERQUOTA, 0, appdata, timeleft);
             it->second->schedule(timeleft);
         }
@@ -11166,7 +11166,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                 if (currentVersion)
                 {
                     m_time_t delay = 0;
-                    m_time_t currentTime = time(NULL);
+                    m_time_t currentTime = m_time();
                     if (currentVersion->ctime > currentTime + 30)
                     {
                         // with more than 30 seconds of detecteed clock drift,
@@ -11209,7 +11209,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                         m_time_t next = currentVersion->ctime + delay;
                         if (next > currentTime)
                         {
-                            dstime backoffds = (next - currentTime) * 10;
+                            dstime backoffds = dstime((next - currentTime) * 10);
                             ll->nagleds = waiter->ds + backoffds;
                             LOG_debug << "Waiting for the version rate limit delay during " << backoffds << " ds";
 
@@ -11623,8 +11623,8 @@ void MegaClient::execmovetosyncdebris()
     Node* tn;
     node_set::iterator it;
 
-    time_t ts;
-    struct tm* ptm;
+    m_time_t ts;
+    struct tm tms;
     char buf[32];
     syncdel_t target;
 
@@ -11642,8 +11642,8 @@ void MegaClient::execmovetosyncdebris()
 
     target = SYNCDEL_BIN;
 
-    ts = time(NULL);
-    ptm = localtime(&ts);
+    ts = m_time();
+    struct tm* ptm = m_localtime(ts, &tms); 
     sprintf(buf, "%04d-%02d-%02d", ptm->tm_year + 1900, ptm->tm_mon + 1, ptm->tm_mday);
     m_time_t currentminute = ts / 60;
 
@@ -11860,7 +11860,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes)
 
             if (overquotauntil && overquotauntil > Waiter::ds)
             {
-                dstime timeleft = overquotauntil - Waiter::ds;
+                dstime timeleft = dstime(overquotauntil - Waiter::ds);
                 t->failed(API_EOVERQUOTA, timeleft);
             }
         }
@@ -11871,7 +11871,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes)
             {
                 LOG_debug << "Resumable transfer detected";
                 t = it->second;
-                if ((d == GET && !t->pos) || ((time(NULL) - t->lastaccesstime) >= 172500))
+                if ((d == GET && !t->pos) || ((m_time() - t->lastaccesstime) >= 172500))
                 {
                     LOG_warn << "Discarding temporary URL (" << t->pos << ", " << t->lastaccesstime << ")";
                     t->cachedtempurl.clear();
@@ -11941,7 +11941,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes)
                 *(FileFingerprint*)t = *(FileFingerprint*)f;
             }
 
-            t->lastaccesstime = time(NULL);
+            t->lastaccesstime = m_time();
             t->tag = reqtag;
             f->tag = reqtag;
             t->transfers_it = transfers[d].insert(pair<FileFingerprint*, Transfer*>((FileFingerprint*)t, t)).first;
@@ -11960,7 +11960,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes)
 
             if (overquotauntil && overquotauntil > Waiter::ds)
             {
-                dstime timeleft = overquotauntil - Waiter::ds;
+                dstime timeleft = dstime(overquotauntil - Waiter::ds);
                 t->failed(API_EOVERQUOTA, timeleft);
             }
         }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -444,10 +444,10 @@ bool Node::serialize(string* d)
     d->append((char*)&owner, MegaClient::USERHANDLE);
 
     // FIXME: use Serialize64
-    time_t ts = 0;
+    time_t ts = 0;  // we don't want to break backward compatibiltiy by changing the size (where m_time_t differs)
     d->append((char*)&ts, sizeof(ts));
 
-    ts = ctime;
+    ts = (time_t)ctime; 
     d->append((char*)&ts, sizeof(ts));
 
     d->append(nodekey);
@@ -917,7 +917,7 @@ bool PublicLink::isExpired()
     if (!ets)       // permanent link: ets=0
         return false;
 
-    m_time_t t = time(NULL);
+    m_time_t t = m_time();
     return ets < t;
 }
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -839,7 +839,7 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
                         // logic to detect files being updated in the local computer moving the original file
                         // to another location as a temporary backup
 
-                        m_time_t currentsecs = time(NULL);
+                        m_time_t currentsecs = m_time();
                         if (!updatedfileinitialts)
                         {
                             updatedfileinitialts = currentsecs;
@@ -1199,10 +1199,10 @@ bool Sync::movetolocaldebris(string* localpath)
 {
     size_t t = localdebris.size();
     char buf[32];
-    time_t ts = time(NULL);
-    struct tm* ptm = localtime(&ts);
+    struct tm tms;
     string day, localday;
     bool havedir = false;
+    struct tm* ptm = m_localtime(m_time(), &tms);
 
     for (int i = -3; i < 100; i++)
     {

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -380,7 +380,7 @@ void TransferSlot::doio(MegaClient* client)
                     }
 
                     lastdata = Waiter::ds;
-                    transfer->lastaccesstime = time(NULL);
+                    transfer->lastaccesstime = m_time();
 
                     LOG_debug << "Chunk finished OK (" << transfer->type << ") Pos: " << transfer->pos
                               << " Completed: " << (transfer->progresscompleted + reqs[i]->size) << " of " << transfer->size;

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -585,20 +585,20 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     bool changed = false;
 
     // Timestamp for last successful validation of password in PRD
-    long tsLastSuccess;
+    m_time_t tsLastSuccess;
     size_t len = oldValue.find(":");
     string buf = oldValue.substr(0, len) + "#"; // add character control '#' for conversion
     oldValue = oldValue.substr(len + 1);    // skip ':'
     if (lastSuccess)
     {
         changed = true;
-        tsLastSuccess = (long)m_time();
+        tsLastSuccess = m_time();
     }
     else
     {
         char *pEnd = NULL;
-        tsLastSuccess = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || tsLastSuccess == LONG_MAX || tsLastSuccess == LONG_MIN)
+        tsLastSuccess = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || tsLastSuccess == LLONG_MAX || tsLastSuccess == LLONG_MIN)
         {
             tsLastSuccess = 0;
             changed = true;
@@ -606,20 +606,20 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     }
 
     // Timestamp for last time the PRD was skipped
-    long tsLastSkipped;
+    m_time_t tsLastSkipped;
     len = oldValue.find(":");
     buf = oldValue.substr(0, len) + "#";
     oldValue = oldValue.substr(len + 1);
     if (lastSkipped)
     {
-        tsLastSkipped = (long)m_time();
+        tsLastSkipped = m_time();
         changed = true;
     }
     else
     {
         char *pEnd = NULL;
-        tsLastSkipped = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || tsLastSkipped == LONG_MAX || tsLastSkipped == LONG_MIN)
+        tsLastSkipped = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || tsLastSkipped == LLONG_MAX || tsLastSkipped == LLONG_MIN)
         {
             tsLastSkipped = 0;
             changed = true;
@@ -685,11 +685,11 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     }
 
     // Timestamp for last time user logged in
-    long tsLastLogin = 0;
+    m_time_t tsLastLogin = 0;
     len = oldValue.length();
     if (lastLogin)
     {
-        tsLastLogin = (long)m_time();
+        tsLastLogin = m_time();
         changed = true;
     }
     else
@@ -697,8 +697,8 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
         buf = oldValue.substr(0, len) + "#";
 
         char *pEnd = NULL;
-        tsLastLogin = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || tsLastLogin == LONG_MAX || tsLastLogin == LONG_MIN)
+        tsLastLogin = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || tsLastLogin == LLONG_MAX || tsLastLogin == LLONG_MIN)
         {
             tsLastLogin = 0;
             changed = true;
@@ -714,7 +714,7 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     return changed;
 }
 
-time_t User::getPwdReminderData(int numDetail, const char *data, unsigned int size)
+m_time_t User::getPwdReminderData(int numDetail, const char *data, unsigned int size)
 {
     if (!numDetail || !data || !size)
     {
@@ -739,15 +739,15 @@ time_t User::getPwdReminderData(int numDetail, const char *data, unsigned int si
     bool lastLogin = (numDetail & PWD_LAST_LOGIN) != 0;
 
     // Timestamp for last successful validation of password in PRD
-    time_t tsLastSuccess;
+    m_time_t tsLastSuccess;
     size_t len = value.find(":");
     string buf = value.substr(0, len) + "#"; // add character control '#' for conversion
     value = value.substr(len + 1);    // skip ':'
     if (lastSuccess)
     {
         char *pEnd = NULL;
-        tsLastSuccess = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || tsLastSuccess == LONG_MAX || tsLastSuccess == LONG_MIN)
+        tsLastSuccess = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || tsLastSuccess == LLONG_MAX || tsLastSuccess == LLONG_MIN)
         {
             tsLastSuccess = 0;
         }
@@ -755,15 +755,15 @@ time_t User::getPwdReminderData(int numDetail, const char *data, unsigned int si
     }
 
     // Timestamp for last time the PRD was skipped
-    time_t tsLastSkipped;
+    m_time_t tsLastSkipped;
     len = value.find(":");
     buf = value.substr(0, len) + "#";
     value = value.substr(len + 1);
     if (lastSkipped)
     {
         char *pEnd = NULL;
-        tsLastSkipped = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || tsLastSkipped == LONG_MAX || tsLastSkipped == LONG_MIN)
+        tsLastSkipped = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || tsLastSkipped == LLONG_MAX || tsLastSkipped == LLONG_MIN)
         {
             tsLastSkipped = 0;
         }
@@ -771,56 +771,45 @@ time_t User::getPwdReminderData(int numDetail, const char *data, unsigned int si
     }
 
     // Flag for Recovery Key exported
-    bool flagMkExported;
     len = value.find(":");
     buf = value.substr(0, len) + "#";
     value = value.substr(len + 1);
     if (mkExported)
     {
         char *pEnd = NULL;
-        int tmp = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || (tmp != 0 && tmp != 1))
+        m_time_t flagMkExported = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || (flagMkExported != 0 && flagMkExported != 1))
         {
-            flagMkExported = false;
+            flagMkExported = 0;
         }
-        else
-        {
-            flagMkExported = tmp;
-        }
-
         return flagMkExported;
     }
 
     // Flag for "Don't show again" the PRD
-    bool flagDontShowAgain;
     len = value.find(":");
     buf = value.substr(0, len) + "#";
     value = value.substr(len + 1);
     if (dontShowAgain)
     {
         char *pEnd = NULL;
-        int tmp = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || (tmp != 0 && tmp != 1))
+        m_time_t flagDontShowAgain = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || (flagDontShowAgain != 0 && flagDontShowAgain != 1))
         {
-            flagDontShowAgain = false;
-        }
-        else
-        {
-            flagDontShowAgain = tmp;
+            flagDontShowAgain = 0;
         }
         return flagDontShowAgain;
     }
 
     // Timestamp for last time user logged in
-    time_t tsLastLogin = 0;
+    m_time_t tsLastLogin = 0;
     len = value.length();
     if (lastLogin)
     {
         buf = value.substr(0, len) + "#";
 
         char *pEnd = NULL;
-        tsLastLogin = strtol(buf.data(), &pEnd, 10);
-        if (*pEnd != '#' || tsLastLogin == LONG_MAX || tsLastLogin == LONG_MIN)
+        tsLastLogin = strtoll(buf.data(), &pEnd, 10);
+        if (*pEnd != '#' || tsLastLogin == LLONG_MAX || tsLastLogin == LLONG_MIN)
         {
             tsLastLogin = 0;
         }

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -72,13 +72,13 @@ bool User::serialize(string* d)
     {
         d->append((char*)&it->first, sizeof it->first);
 
-        ll = it->second.size();
+        ll = (unsigned short)it->second.size();
         d->append((char*)&ll, sizeof ll);
         d->append(it->second.data(), ll);
 
         if (attrsv.find(it->first) != attrsv.end())
         {
-            ll = attrsv[it->first].size();
+            ll = (unsigned short)attrsv[it->first].size();
             d->append((char*)&ll, sizeof ll);
             d->append(attrsv[it->first].data(), ll);
         }
@@ -585,14 +585,14 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     bool changed = false;
 
     // Timestamp for last successful validation of password in PRD
-    time_t tsLastSuccess;
+    long tsLastSuccess;
     size_t len = oldValue.find(":");
     string buf = oldValue.substr(0, len) + "#"; // add character control '#' for conversion
     oldValue = oldValue.substr(len + 1);    // skip ':'
     if (lastSuccess)
     {
         changed = true;
-        tsLastSuccess = time(NULL);
+        tsLastSuccess = (long)m_time();
     }
     else
     {
@@ -606,13 +606,13 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     }
 
     // Timestamp for last time the PRD was skipped
-    time_t tsLastSkipped;
+    long tsLastSkipped;
     len = oldValue.find(":");
     buf = oldValue.substr(0, len) + "#";
     oldValue = oldValue.substr(len + 1);
     if (lastSkipped)
     {
-        tsLastSkipped = time(NULL);
+        tsLastSkipped = (long)m_time();
         changed = true;
     }
     else
@@ -685,11 +685,11 @@ bool User::mergePwdReminderData(int numDetails, const char *data, unsigned int s
     }
 
     // Timestamp for last time user logged in
-    time_t tsLastLogin = 0;
+    long tsLastLogin = 0;
     len = oldValue.length();
     if (lastLogin)
     {
-        tsLastLogin = time(NULL);
+        tsLastLogin = (long)m_time();
         changed = true;
     }
     else

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1105,24 +1105,7 @@ struct tm* m_localtime(m_time_t ttime, struct tm *dt)
         memset(dt, 0, sizeof(struct tm));
     }
 #elif _WIN32
-    static MegaMutex * mtx = new MegaMutex();
-    static bool initiated = false;
-    if (!initiated)
-    {
-        mtx->init(true);
-        initiated = true;
-    }
-    mtx->lock();
-    struct tm *newtm = localtime(&t);
-    if (newtm)
-    {
-        memcpy(dt, newtm, sizeof(struct tm));
-    }
-    else
-    {
-        memset(dt, 0, sizeof(struct tm));
-    }
-    mtx->unlock();
+#error "localtime is not thread safe in this compiler; please use a later one"
 #else //POSIX
     localtime_r(&t, dt);
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1088,5 +1088,62 @@ long long abs(long long n)
     return n >= 0 ? n : -n;
 }
 
+struct tm* m_localtime(m_time_t ttime, struct tm *dt)
+{
+    // works for 32 or 64 bit time_t
+    time_t t = time_t(ttime);
+#if (__cplusplus >= 201103L) && defined (__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)
+    localtime_s(&t, dt);
+#elif _MSC_VER >= 1400 // MSVCRT (2005+): std::localtime is threadsafe
+    struct tm *newtm = localtime(&t);
+    if (newtm)
+    {
+        memcpy(dt, newtm, sizeof(struct tm));
+    }
+    else
+    {
+        memset(dt, 0, sizeof(struct tm));
+    }
+#elif _WIN32
+    static MegaMutex * mtx = new MegaMutex();
+    static bool initiated = false;
+    if (!initiated)
+    {
+        mtx->init(true);
+        initiated = true;
+    }
+    mtx->lock();
+    struct tm *newtm = localtime(&t);
+    if (newtm)
+    {
+        memcpy(dt, newtm, sizeof(struct tm));
+    }
+    else
+    {
+        memset(dt, 0, sizeof(struct tm));
+    }
+    mtx->unlock();
+#else //POSIX
+    localtime_r(&t, dt);
+#endif
+    return dt;
+}
+
+m_time_t m_time(m_time_t* tt)
+{
+    // works for 32 or 64 bit time_t
+    time_t t = time(NULL);
+    if (tt)
+    {
+        *tt = t;
+    }
+    return t;
+}
+
+m_time_t m_mktime(struct tm* stm)
+{
+    // works for 32 or 64 bit time_t
+    return mktime(stm);
+}
 
 } // namespace

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -2190,9 +2190,7 @@ TEST_F(SdkTest, SdkTestFingerprint)
             ofs.write((char*)&value, filesizes[i] % sizeof(value));
         }
 
-        {
-            fsa.setmtimelocal(&localname, 1000000000);
-        }
+        fsa.setmtimelocal(&localname, 1000000000);
 
         string streamfp, filefp;
         {

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -21,6 +21,13 @@
 
 #include "sdk_test.h"
 
+#ifdef WIN32
+void usleep(uint64_t n)
+{
+    Sleep(n / 1000);
+}
+#endif
+
 void SdkTest::SetUp()
 {
     // do some initialization
@@ -2040,7 +2047,7 @@ TEST_F(SdkTest, SdkTestChat)
 
     // --- Check list of available chats --- (fetch is done at SetUp())
 
-    uint numChats = chats.size();      // permanent chats cannot be deleted, so they're kept forever
+    size_t numChats = chats.size();      // permanent chats cannot be deleted, so they're kept forever
 
 
     // --- Create a group chat ---
@@ -2121,5 +2128,92 @@ TEST_F(SdkTest, SdkTestChat)
             << "The peer didn't receive notification of the invitation after " << maxTimeout << " seconds";
 
 }
+
+
+class myMIS : public MegaInputStream
+{
+public:
+    int64_t size;
+    ifstream ifs;
+
+    myMIS(const char* filename)
+        : ifs(filename, ios::binary)
+    {
+        ifs.seekg(0, ios::end);
+        size = ifs.tellg();
+        ifs.seekg(0, ios::beg);
+    }
+    virtual int64_t getSize() { return size; }
+
+    virtual bool read(char *buffer, size_t size) {
+        if (buffer)
+        {
+            ifs.read(buffer, size);
+        }
+        else
+        {
+            ifs.seekg(size, ios::cur);
+        }
+        return !ifs.fail();
+    }
+};
+
+
+TEST_F(SdkTest, SdkTestFingerprint)
+{
+    megaApi[0]->log(MegaApi::LOG_LEVEL_INFO, "___TEST fingerprint stream/file___");
+
+    int filesizes[] = { 10, 100, 1000, 10000, 100000, 10000000 };
+    string expected[] = {
+        "DAQoBAMCAQQDAgEEAwAAAAAAAAQAypo7",
+        "DAWQjMO2LBXoNwH_agtF8CX73QQAypo7",
+        "EAugDFlhW_VTCMboWWFb9VMIxugQAypo7",
+        "EAhAnWCqOGBx0gGOWe7N6wznWRAQAypo7",
+        "GA6CGAQFLOwb40BGchttx22PvhZ5gQAypo7",
+        "GA4CWmAdW1TwQ-bddEIKTmSDv0b2QQAypo7",
+    };
+
+    FSACCESS_CLASS fsa;
+    string name = "testfile";
+    string localname;
+    fsa.path2local(&name, &localname);
+
+    int value = 0x01020304;
+    for (int i = sizeof filesizes / sizeof filesizes[0]; i--; )
+    {
+
+        {
+            ofstream ofs(name.c_str(), ios::binary);
+            char s[8192];
+            ofs.rdbuf()->pubsetbuf(s, sizeof s);
+            for (int j = filesizes[i] / sizeof(value); j-- ; ) ofs.write((char*)&value, sizeof(value));
+            ofs.write((char*)&value, filesizes[i] % sizeof(value));
+        }
+
+        {
+            fsa.setmtimelocal(&localname, 1000000000);
+        }
+
+        string streamfp, filefp;
+        {
+            m_time_t mtime = 0;
+            {
+                FileAccess* nfa = fsa.newfileaccess();
+                nfa->fopen(&localname);
+                mtime = nfa->mtime;
+                delete nfa;
+            }
+
+            myMIS mis(name.c_str());
+            streamfp.assign(megaApi[0]->getFingerprint(&mis, mtime));
+        }
+
+        filefp = megaApi[0]->getFingerprint(name.c_str());
+
+        ASSERT_EQ(streamfp, filefp);
+        ASSERT_EQ(streamfp, expected[i]);
+    }
+}
+
 
 #endif


### PR DESCRIPTION
- freeimage adjustment for arm_64
- cmake script that gives an easy non-cygwin way to develop and test changes with visual studio
- use m_time_t a lot more to avoid problems with time_t where it is only 32 bits
- provide m_time() m_localtime() m_mktime to use instead of time() localtime() mktime()
- address quite a few warnings about 64/32 bit lossy conversions in 32 bit builds where it was safe to do so
- fix for (probably never hit case) where streaming fingerprint calc can't jump between block with a 32 bit value
- sdk_test added to confirm fingerprint calc is still working