### PR TITLE
Fix compilation for Windows Phone in VS2013

### DIFF
--- a/include/mega/win32/megasys.h
+++ b/include/mega/win32/megasys.h
@@ -91,6 +91,9 @@
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #define strtoull _strtoui64
+#if _MSC_VER <= 1800 // Visual Studio 2013
+#define strtoll _strtoi64
+#endif
 
 #ifndef _CRT_SECURE_NO_WARNINGS
   #define _CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
The `strtoll` function is not included in VS2013 and previous versions.
Microsoft provides another function, called `_strtoi64()`, which does the same thing, and has exactly the same signature. 