### PR TITLE
Made any std::cout text output in the console stay left aligned inste…

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -466,7 +466,7 @@ bool DemoApp::sync_syncable(Sync *, const char *name, string *)
 #endif
 
 AppFileGet::AppFileGet(Node* n, handle ch, byte* cfilekey, m_off_t csize, m_time_t cmtime, string* cfilename,
-                       string* cfingerprint)
+                       string* cfingerprint, const string& targetfolder)
 {
     if (n)
     {
@@ -495,6 +495,12 @@ AppFileGet::AppFileGet(Node* n, handle ch, byte* cfilekey, m_off_t csize, m_time
 
     localname = name;
     client->fsaccess->name2local(&localname);
+    if (!targetfolder.empty())
+    {
+        string ltf, tf = targetfolder;
+        client->fsaccess->path2local(&tf, &ltf);
+        localname = ltf + client->fsaccess->localseparator + localname;
+    }
 }
 
 AppFilePut::AppFilePut(string* clocalname, handle ch, const char* ctargetuser)
@@ -1935,7 +1941,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(sequence(text("open"), param("exportedfolderlink#key")));
     p->Add(sequence(text("put"), localFSPath("localpattern"), opt(either(remoteFSPath(client, &cwd, "dst"),param("dstemail")))));
     p->Add(sequence(text("putq"), opt(param("cancelslot"))));
-    p->Add(sequence(text("get"), remoteFSPath(client , &cwd), opt(sequence(param("offset"), opt(param("length"))))));
+    p->Add(sequence(text("get"), opt(flag("-r")), remoteFSPath(client , &cwd), opt(sequence(param("offset"), opt(param("length"))))));
     p->Add(sequence(text("get"), param("exportedfilelink#key"), opt(sequence(param("offset"), opt(param("length"))))));
     p->Add(sequence(text("getq"), opt(param("cancelslot"))));
     p->Add(sequence(text("pause"), opt(either(text("get"), text("put"))), opt(text("hard")), opt(text("status"))));
@@ -2001,6 +2007,60 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(sequence(text("quit")));
 
     return autocompleteTemplate = std::move(p);
+}
+#endif
+
+bool extractparam(const std::string& p, vector<string>& words)
+{
+    for (unsigned i = 0; i < words.size(); ++i)
+    {
+        if (!words[i].empty() && words[i][0] == '-' && !words[i].compare(1, string::npos, p))
+        {
+            words.erase(words.begin() + i);
+            return true;
+        }
+    }
+    return false;
+}
+
+#ifdef USE_FILESYSTEM
+bool recursiveget(fs::path& localpath, Node* n, bool folders, unsigned& queued)
+{
+    if (n->type == FILENODE)
+    {
+        if (!folders)
+        {
+            auto f = new AppFileGet(n, UNDEF, NULL, -1, 0, NULL, NULL, WinConsole::toUtf8String(localpath.native()));
+            f->appxfer_it = appxferq[GET].insert(appxferq[GET].end(), f);
+            client->startxfer(GET, f);
+            queued += 1;
+        }
+    }
+    else if (n->type == FOLDERNODE || n->type == ROOTNODE)
+    {
+        fs::path newpath = localpath / n->displayname();
+        if (folders)
+        {
+            std::error_code ec; 
+            if (fs::create_directory(newpath, ec) || !ec)
+            {
+                cout << newpath << endl;
+            }
+            else
+            {
+                cout << "Failed trying to create " << newpath << ": " << ec.message() << endl;
+                return false;
+            }
+        }
+        for (node_list::iterator it = n->children.begin(); it != n->children.end(); it++)
+        {
+            if (!recursiveget(newpath, *it, folders, queued))
+            {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 #endif
 
@@ -2086,7 +2146,7 @@ static void process_line(char* l)
                 }
                 else if (recoveryemail.size() && recoverycode.size())
                 {
-                    cout << endl << "Reseting password..." << endl;
+                    cout << endl << "Resetting password..." << endl;
 
                     if (hasMasterKey)
                     {
@@ -2725,7 +2785,44 @@ static void process_line(char* l)
                 case 3:
                     if (words[0] == "get")
                     {
-                        if (words.size() > 1)
+                        bool reportsyntax = false;
+                        if (extractparam("r", words))
+                        {
+#ifdef USE_FILESYSTEM
+                            // recursive get.  create local folder structure first, then queue transfer of all files 
+                            bool foldersonly = extractparam("foldersonly", words);
+
+                            if (words.size() == 2)
+                            {
+                                if (!(n = nodebypath(words[1].c_str())))
+                                {
+                                    cout << words[1] << ": No such folder (or file)" << endl;
+                                }
+                                else if (n->type != FOLDERNODE && n->type != ROOTNODE)
+                                {
+                                    cout << words[1] << ": not a folder" << endl;
+                                }
+                                else
+                                {
+                                    unsigned queued = 0;
+                                    cout << "creating folders: " << endl;
+                                    if (recursiveget(fs::current_path(), n, true, queued))
+                                    {
+                                        cout << "queueing files..." << endl;
+                                        bool alldone = recursiveget(fs::current_path(), n, false, queued);
+                                        cout << "queued " << queued << " files for download" << (!alldone ? " before failure" : "") << endl;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                reportsyntax = true;
+                            }
+#else
+                            cout << "Sorry, -r not supported yet" << endl;
+#endif
+                        }
+                        else if (words.size() > 1)
                         {
                             if (client->openfilelink(words[1].c_str(), 0) == API_OK)
                             {
@@ -2737,6 +2834,10 @@ static void process_line(char* l)
 
                             if (n)
                             {
+                                if (words.size() > 4)
+                                {
+                                    reportsyntax = true;
+                                }
                                 if (words.size() > 2)
                                 {
                                     // read file slice
@@ -2789,9 +2890,12 @@ static void process_line(char* l)
                         }
                         else
                         {
-                            cout << "      get remotepath [offset [length]]" << endl << "      get exportedfilelink#key [offset [length]]" << endl;
+                            reportsyntax = true;
                         }
-
+                        if (reportsyntax)
+                        {
+                            cout << "      get [-r] remotepath [offset [length]]" << endl << "      get exportedfilelink#key [offset [length]]" << endl;
+                        }
                         return;
                     }
                     else if (words[0] == "put")

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -55,7 +55,7 @@ struct AppFileGet : public AppFile
     void update();
     void completed(Transfer*, LocalNode*);
 
-    AppFileGet(Node*, handle = UNDEF, byte* = NULL, m_off_t = -1, m_time_t = 0, string* = NULL, string* = NULL);
+    AppFileGet(Node*, handle = UNDEF, byte* = NULL, m_off_t = -1, m_time_t = 0, string* = NULL, string* = NULL, const string& targetfolder = "");
     ~AppFileGet();
 };
 

--- a/include/mega/win32/autocomplete.h
+++ b/include/mega/win32/autocomplete.h
@@ -203,6 +203,8 @@ namespace autocomplete {
         bool active = false;
         bool firstPressDone = false;
         size_t unixListCount = 0;
+        unsigned calcUnixColumnWidth(int col, int rows);
+        const string& unixColumnEntry(int row, int col, int rows);
     };
 
     // helper function - useful in megacli for now
@@ -212,10 +214,10 @@ namespace autocomplete {
     CompletionState autoComplete(const std::string line, size_t insertPos, ACN syntax, bool unixStyle);
     
     // put the next possible string or unambiguous portion thereof at the cursor position, or indicate options to the user 
-    void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth);
+    void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth, string& consoleOutput);
 
     // execute the function attached to the matching syntax
-    void autoExec(const std::string line, size_t insertPos, ACN syntax, bool unixStyle);
+    void autoExec(const std::string line, size_t insertPos, ACN syntax, bool unixStyle, string& consoleOutput);
 
     // functions to bulid command descriptions
     ACN either(ACN n1 = nullptr, ACN n2 = nullptr, ACN n3 = nullptr, ACN n4 = nullptr);

--- a/include/mega/win32/autocomplete.h
+++ b/include/mega/win32/autocomplete.h
@@ -203,7 +203,7 @@ namespace autocomplete {
         bool active = false;
         bool firstPressDone = false;
         size_t unixListCount = 0;
-        unsigned calcUnixColumnWidth(int col, int rows);
+        unsigned calcUnixColumnWidthInGlyphs(int col, int rows);
         const string& unixColumnEntry(int row, int col, int rows);
     };
 
@@ -214,7 +214,8 @@ namespace autocomplete {
     CompletionState autoComplete(const std::string line, size_t insertPos, ACN syntax, bool unixStyle);
     
     // put the next possible string or unambiguous portion thereof at the cursor position, or indicate options to the user 
-    void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth, string& consoleOutput);
+    struct CompletionTextOut { vector<vector<string>> stringgrid; vector<int> columnwidths; };
+    void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth, CompletionTextOut& consoleOutput);
 
     // execute the function attached to the matching syntax
     void autoExec(const std::string line, size_t insertPos, ACN syntax, bool unixStyle, string& consoleOutput);

--- a/include/mega/win32/megaconsole.h
+++ b/include/mega/win32/megaconsole.h
@@ -83,7 +83,7 @@ struct MEGA_API ConsoleModel
 #endif
 
     // flags to indicate to the real console if redraws etc need to occur
-    string redrawInputLineConsoleFeedback;
+    ::mega::autocomplete::CompletionTextOut redrawInputLineConsoleFeedback;
     bool redrawInputLineNeeded = false;
     bool consoleNewlineNeeded = false;
 
@@ -157,7 +157,7 @@ private:
     size_t inputLineOffset = 0;
 
     void redrawPromptIfLoggingOccurred();
-    void redrawInputLine(const string& autocompleteFeedback = "");
+    void redrawInputLine(::mega::autocomplete::CompletionTextOut* autocompleteFeedback);
     ConsoleModel::lineEditAction interpretLineEditingKeystroke(INPUT_RECORD &ir);
 #endif
 };

--- a/include/mega/win32/megaconsole.h
+++ b/include/mega/win32/megaconsole.h
@@ -83,6 +83,7 @@ struct MEGA_API ConsoleModel
 #endif
 
     // flags to indicate to the real console if redraws etc need to occur
+    string redrawInputLineConsoleFeedback;
     bool redrawInputLineNeeded = false;
     bool consoleNewlineNeeded = false;
 
@@ -134,6 +135,7 @@ struct MEGA_API WinConsole : public Console
     char* checkForCompletedInputLine();
     void clearScreen();
     void outputHistory();
+    void retractPrompt();
     
     enum logstyle { no_log, utf8_log, utf16_log, codepage_log };
     bool log(const std::string& filename, logstyle logstyle);
@@ -145,7 +147,7 @@ struct MEGA_API WinConsole : public Console
 private:
     HANDLE hInput;
     HANDLE hOutput;
-    COORD knownCursorPos;  // if this has moved then something logged and we should redraw the prompt and input so far on a new line.
+    bool promptRetracted = false;
     ConsoleModel model;
     Utf8Rdbuf *rdbuf = nullptr;
     streambuf *oldrb1 = nullptr, *oldrb2 = nullptr;
@@ -154,9 +156,8 @@ private:
     std::string currentPrompt;
     size_t inputLineOffset = 0;
 
-    void prepareDetectLogging();
     void redrawPromptIfLoggingOccurred();
-    void redrawInputLine();
+    void redrawInputLine(const string& autocompleteFeedback = "");
     ConsoleModel::lineEditAction interpretLineEditingKeystroke(INPUT_RECORD &ir);
 #endif
 };

--- a/src/win32/console.cpp
+++ b/src/win32/console.cpp
@@ -83,6 +83,7 @@ struct Utf8Rdbuf : public streambuf
     UINT failover_codepage = CP_UTF8;
     std::ofstream logfile;
     WinConsole::logstyle logstyle = WinConsole::no_log;
+    WinConsole* wc;
 
     bool log(const string& localfile, WinConsole::logstyle ls)
     {
@@ -104,7 +105,7 @@ struct Utf8Rdbuf : public streambuf
         return true;
     }
 
-    Utf8Rdbuf(HANDLE ch) : h(ch) {}
+    Utf8Rdbuf(HANDLE ch, WinConsole* w) : h(ch), wc(w) {}
 
     streamsize xsputn(const char* s, streamsize n)
     {
@@ -127,6 +128,11 @@ struct Utf8Rdbuf : public streambuf
         else if (logstyle == WinConsole::codepage_log)
         {
             logfile << WinConsole::toUtf8String(ws, codepage);
+        }
+
+        if (wc)
+        {
+            wc->retractPrompt();
         }
 
         BOOL b = WriteConsoleW(h, ws.data(), DWORD(ws.size()), &written, NULL);
@@ -156,6 +162,7 @@ struct Utf8Rdbuf : public streambuf
                 }
             }
         }
+
         return n;
     }
 
@@ -278,7 +285,7 @@ void ConsoleModel::redrawInputLine(int p)
 
 void ConsoleModel::autoComplete(bool forwards, unsigned consoleWidth)
 {   
-    if (autocompleteSyntax) 
+    if (autocompleteSyntax)
     {
         if (!autocompleteState.active)
         {
@@ -287,7 +294,8 @@ void ConsoleModel::autoComplete(bool forwards, unsigned consoleWidth)
             autocompleteState = autocomplete::autoComplete(u8line, u8InsertPos, autocompleteSyntax, unixCompletions);
             autocompleteState.active = true;
         }
-        autocomplete::applyCompletion(autocompleteState, forwards, consoleWidth);
+
+        autocomplete::applyCompletion(autocompleteState, forwards, consoleWidth, redrawInputLineConsoleFeedback);
         buffer = WinConsole::toUtf16String(autocompleteState.line);
         size_t u16InsertPos = WinConsole::toUtf16String(autocompleteState.line.substr(0, autocompleteState.wordPos.second)).size();
         insertPos = clamp<size_t>(u16InsertPos, 0, buffer.size());
@@ -479,7 +487,7 @@ bool WinConsole::setShellConsole(UINT codepage, UINT failover_codepage)
     // skip the historic complexities of output modes etc, our own rdbuf can write direct to console
     if (!rdbuf)
     {
-        rdbuf = new Utf8Rdbuf(hOutput);
+        rdbuf = new Utf8Rdbuf(hOutput, this);
         oldrb1 = std::cout.rdbuf(rdbuf);
         oldrb2 = std::cerr.rdbuf(rdbuf);
     }
@@ -572,15 +580,14 @@ bool WinConsole::consolePeek()
     }
     if (model.redrawInputLineNeeded && model.echoOn)
     {
-        redrawInputLine();
+        redrawInputLine(model.redrawInputLineConsoleFeedback);
     }
+    model.redrawInputLineConsoleFeedback.clear();
     if (model.consoleNewlineNeeded)
     {
-        std::cout << '\n' << std::flush;
-    }
-    if (model.redrawInputLineNeeded || model.consoleNewlineNeeded)
-    {
-        prepareDetectLogging();
+        DWORD written = 0;
+        BOOL b = WriteConsoleW(hOutput, L"\n", 1, &written, NULL);
+        assert(b && written == 1);
     }
     model.redrawInputLineNeeded = false;
     model.consoleNewlineNeeded = false;
@@ -626,8 +633,14 @@ ConsoleModel::lineEditAction WinConsole::interpretLineEditingKeystroke(INPUT_REC
     return ConsoleModel::nullAction;
 }
 
-void WinConsole::redrawInputLine()
+void WinConsole::redrawInputLine(const string& autocompleteFeedback)
 {
+    if (!autocompleteFeedback.empty())
+    {
+        promptRetracted = true;
+        cout << "\n" << autocompleteFeedback << std::flush;
+    }
+
     CONSOLE_SCREEN_BUFFER_INFO sbi;
     BOOL ok = GetConsoleScreenBufferInfo(hOutput, &sbi);
     assert(ok);
@@ -692,9 +705,41 @@ void WinConsole::redrawInputLine()
         ok = SetConsoleCursorPosition(hOutput, cpos);
         assert(ok);
 
-        prepareDetectLogging();
+        promptRetracted = false;
     }
 }
+
+void WinConsole::retractPrompt()
+{
+    if (currentPrompt.size() && !promptRetracted)
+    {
+        CONSOLE_SCREEN_BUFFER_INFO sbi;
+        BOOL ok = GetConsoleScreenBufferInfo(hOutput, &sbi);
+        assert(ok);
+        //if (0 == memcmp(&knownCursorPos, &sbi.dwCursorPosition, sizeof(COORD)))
+        {
+            size_t width = std::max<size_t>(currentPrompt.size() + model.buffer.size() + 1 + inputLineOffset, sbi.dwSize.X); // +1 to show character under cursor 
+            std::unique_ptr<CHAR_INFO[]> line(new CHAR_INFO[width]);
+
+            for (size_t i = width; i--; )
+            {
+                line[i].Attributes = sbi.wAttributes;
+                line[i].Char.UnicodeChar = ' ';
+            }
+
+            SMALL_RECT screenarea2{ 0, sbi.dwCursorPosition.Y, sbi.dwSize.X, sbi.dwCursorPosition.Y };
+            ok = WriteConsoleOutputW(hOutput, line.get(), COORD{ SHORT(width), 1 }, COORD{ SHORT(inputLineOffset), 0 }, &screenarea2);
+            assert(ok);
+
+            COORD cpos{ 0, sbi.dwCursorPosition.Y };
+            ok = SetConsoleCursorPosition(hOutput, cpos);
+            assert(ok);
+
+            promptRetracted = true;
+        }
+    }
+}
+
 
 bool WinConsole::consoleGetch(wchar_t& c)
 {
@@ -782,30 +827,11 @@ static bool operator==(COORD& a, COORD& b)
     return a.X == b.X && a.Y == b.Y; 
 }
 
-void WinConsole::prepareDetectLogging()
-{
-    CONSOLE_SCREEN_BUFFER_INFO sbi;
-    BOOL ok = GetConsoleScreenBufferInfo(hOutput, &sbi);
-    assert(ok);
-    knownCursorPos = sbi.dwCursorPosition;
-}
-
 void WinConsole::redrawPromptIfLoggingOccurred()
 {
-    CONSOLE_SCREEN_BUFFER_INFO sbi;
-    BOOL ok = GetConsoleScreenBufferInfo(hOutput, &sbi);
-    assert(ok);
-    if (ok && !currentPrompt.empty())
+    if (promptRetracted)
     {
-        if (!(knownCursorPos == sbi.dwCursorPosition))
-        {
-            if (sbi.dwCursorPosition.X != 0)
-            {
-                std::cout << endl;
-            }
-            redrawInputLine();
-            prepareDetectLogging();
-        }
+        redrawInputLine();
     }
 }
 

--- a/src/win32/net.cpp
+++ b/src/win32/net.cpp
@@ -287,8 +287,9 @@ VOID CALLBACK WinHttpIO::asynccallback(HINTERNET hInternet, DWORD_PTR dwContext,
                 }
                 else
                 {
-                    // data was copied direct to req->in.
-                    assert((char*)lpvStatusInformation >= req->in.data() && (char*)lpvStatusInformation + dwStatusInformationLength <= req->in.data() + req->in.size());
+                    // data was copied direct to buf or to req->in.
+                    assert(req->buf && (byte*)lpvStatusInformation >= req->buf && (byte*)lpvStatusInformation + dwStatusInformationLength <= req->buf + req->buflen ||
+                           !req->buf && (char*)lpvStatusInformation >= req->in.data() && (char*)lpvStatusInformation + dwStatusInformationLength <= req->in.data() + req->in.size());
                 }
 
                 if (!WinHttpQueryDataAvailable(httpctx->hRequest, NULL))

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1088,12 +1088,12 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     n1 = megaApi[0]->getNodeByHandle(h);
 
     // do same conversions to lose the same precision
-    int buf = ((lat + 90) / 180) * 0xFFFFFF;
+    int buf = int(((lat + 90) / 180) * 0xFFFFFF);
     double res = -90 + 180 * (double) buf / 0xFFFFFF;
 
     ASSERT_EQ(res, n1->getLatitude()) << "Latitude value does not match";
 
-    buf = (lon == 180) ? 0 : (lon + 180) / 360 * 0x01000000;
+    buf = int((lon == 180) ? 0 : (lon + 180) / 360 * 0x01000000);
     res = -180 + 360 * (double) buf / 0x01000000;
 
     ASSERT_EQ(res, n1->getLongitude()) << "Longitude value does not match";
@@ -1113,7 +1113,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     n1 = megaApi[0]->getNodeByHandle(h);
 
     // do same conversions to lose the same precision
-    buf = ((lat + 90) / 180) * 0xFFFFFF;
+    buf = int(((lat + 90) / 180) * 0xFFFFFF);
     res = -90 + 180 * (double) buf / 0xFFFFFF;
 
     ASSERT_EQ(res, n1->getLatitude()) << "Latitude value does not match";
@@ -1415,8 +1415,8 @@ TEST_F(SdkTest, SdkTestTransfers)
 
     // --- Get the size of a file ---
 
-    int filesize = getFilesize(filename1);
-    int nodesize = megaApi[0]->getSize(n2);
+    size_t filesize = getFilesize(filename1);
+    long long nodesize = megaApi[0]->getSize(n2);
     EXPECT_EQ(filesize, nodesize) << "Wrong size of uploaded file";
 
 
@@ -1698,7 +1698,7 @@ TEST_F(SdkTest, SdkTestContacts)
 
     ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_PWD_REMINDER, maxTimeout, 0));
     string pwdReminder = attributeValue;
-    int offset = pwdReminder.find(':');
+    size_t offset = pwdReminder.find(':');
     offset += pwdReminder.find(':', offset+1);
     ASSERT_EQ( pwdReminder.at(offset), '1' ) << "Password reminder attribute not updated";
 
@@ -1740,8 +1740,8 @@ TEST_F(SdkTest, SdkTestContacts)
     ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_AVATAR));
     ASSERT_STREQ( "Avatar changed", attributeValue.data()) << "Failed to change avatar";
 
-    int filesizeSrc = getFilesize(AVATARSRC);
-    int filesizeDst = getFilesize(AVATARDST);
+    size_t filesizeSrc = getFilesize(AVATARSRC);
+    size_t filesizeDst = getFilesize(AVATARDST);
     ASSERT_EQ(filesizeDst, filesizeSrc) << "Received avatar differs from uploaded avatar";
 
     delete u;
@@ -1985,7 +1985,7 @@ TEST_F(SdkTest, SdkTestShares)
     // --- Get pending outgoing shares ---
 
     char emailfake[64];
-    srand(time(NULL));
+    srand(unsigned(time(NULL)));
     sprintf(emailfake, "%d@nonexistingdomain.com", rand()%1000000);
     // carefull, antispam rejects too many tries without response for the same address
 
@@ -2114,7 +2114,7 @@ bool cmp(const autocomplete::CompletionState& c, const std::vector<std::string>&
     }
     else
     {
-        for (int i = c.completions.size(); i--; )
+        for (size_t i = c.completions.size(); i--; )
         {
             if (c.completions[i].s != s[i])
             {
@@ -2125,7 +2125,7 @@ bool cmp(const autocomplete::CompletionState& c, const std::vector<std::string>&
     }
     if (!result)
     {
-        for (int i = 0; i < c.completions.size() || i < s.size(); ++i)
+        for (size_t i = 0; i < c.completions.size() || i < s.size(); ++i)
         {
             cout << (i < s.size() ? s[i] : "") << "/" << (i < c.completions.size() ? c.completions[i].s : "") << endl;
         }
@@ -2229,12 +2229,13 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
     }
 
     // dos style file completion, local fs
+    string s;
 
     {
         auto r = autoComplete("lls ", 4, syntax, false);
         std::vector<std::string> e{ "dir1", "dir2", "dir2a" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir1");
     }
 
@@ -2290,55 +2291,55 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2\\..\\", 12, syntax, false);
         std::vector<std::string> e{ "dir2\\..\\dir1", "dir2\\..\\dir2", "dir2\\..\\dir2a" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir1");
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir2");
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir2a");
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir1");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir2a");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir2");
     }
 
     {
         auto r = autoComplete("lls dir2a\\", 10, syntax, false);
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "lls dir2a\\nospace");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "lls \"dir2a\\dir space2\"");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "lls \"dir2a\\dir space\"");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "lls dir2a\\nospace");
     }
 
     {
         auto r = autoComplete("lls \"dir\"1\\", 11, syntax, false);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"dir1\\sub11\"");
     }
 
     {
         auto r = autoComplete("lls dir1\\\"..\\dir2\\\"", std::string::npos, syntax, false);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"dir1\\..\\dir2\\sub21\"");
     }
 
     {
         auto r = autoComplete("lls c:\\prog", std::string::npos, syntax, false);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"c:\\Program Files\"");
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"c:\\Program Files (x86)\"");
     }
 
     {
         auto r = autoComplete("lls \"c:\\program files \"", std::string::npos, syntax, false);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"c:\\Program Files (x86)\"");
     }
 
@@ -2348,7 +2349,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls ", 4, syntax, true);
         std::vector<std::string> e{ "dir1\\", "dir2\\", "dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir");
     }
 
@@ -2356,7 +2357,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls di", 6, syntax, true);
         std::vector<std::string> e{ "dir1\\", "dir2\\", "dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir");
     }
 
@@ -2364,7 +2365,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2", 8, syntax, true);
         std::vector<std::string> e{ "dir2\\", "dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2");
     }
 
@@ -2372,7 +2373,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2a", 9, syntax, true);
         std::vector<std::string> e{ "dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2a\\");
     }
 
@@ -2380,7 +2381,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2 something after", 8, syntax, true);
         std::vector<std::string> e{ "dir2\\", "dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2 something after");
     }
 
@@ -2388,7 +2389,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2asomething immediately after", 9, syntax, true);
         std::vector<std::string> e{ "dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2a\\something immediately after");
     }
 
@@ -2396,10 +2397,10 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2\\", 9, syntax, true);
         std::vector<std::string> e{ "dir2\\sub21\\", "dir2\\sub22\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\sub2");
         auto rr = autoComplete("lls dir2\\sub22", 14, syntax, true);
-        applyCompletion(rr, true, 100);
+        applyCompletion(rr, true, 100, s);
         ASSERT_EQ(rr.line, "lls dir2\\sub22\\");
     }
 
@@ -2407,7 +2408,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2\\.\\", 11, syntax, true);
         std::vector<std::string> e{ "dir2\\.\\sub21\\", "dir2\\.\\sub22\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\.\\sub2");
     }
 
@@ -2415,7 +2416,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2\\..", 11, syntax, true);
         std::vector<std::string> e{ "dir2\\..\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\");
     }
 
@@ -2423,7 +2424,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2\\..\\", 12, syntax, true);
         std::vector<std::string> e{ "dir2\\..\\dir1\\", "dir2\\..\\dir2\\", "dir2\\..\\dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir");
     }
 
@@ -2431,46 +2432,46 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("lls dir2\\..\\", 12, syntax, true);
         std::vector<std::string> e{ "dir2\\..\\dir1\\", "dir2\\..\\dir2\\", "dir2\\..\\dir2a\\" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls dir2\\..\\dir");
     }
 
     {
         auto r = autoComplete("lls dir2a\\d", 11, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"dir2a\\dir space\"");
         auto rr = autoComplete("lls \"dir2a\\dir space\"\\", std::string::npos, syntax, false);
-        applyCompletion(rr, true, 100);
+        applyCompletion(rr, true, 100, s);
         ASSERT_EQ(rr.line, "lls \"dir2a\\dir space\\next\"");
     }
 
     {
         auto r = autoComplete("lls \"dir\"1\\", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"dir1\\sub1\"");
     }
 
     {
         auto r = autoComplete("lls dir1\\\"..\\dir2\\\"", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"dir1\\..\\dir2\\sub2\"");
     }
 
     {
         auto r = autoComplete("lls c:\\prog", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls c:\\program");
     }
 
     {
         auto r = autoComplete("lls \"c:\\program files \"", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls \"c:\\program files (x86)\\\"");
     }
 
     {
         auto r = autoComplete("lls 'c:\\program files '", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "lls 'c:\\program files (x86)\\'");
     }
 
@@ -2507,7 +2508,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls ", std::string::npos, syntax, false);
         std::vector<std::string> e{ "dir1", "dir2", "dir2a" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir1");
     }
 
@@ -2563,47 +2564,47 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2/../", std::string::npos, syntax, false);
         std::vector<std::string> e{ "dir2/../dir1", "dir2/../dir2", "dir2/../dir2a" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir1");
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir2");
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir2a");
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir1");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir2a");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir2");
     }
 
     {
         auto r = autoComplete("ls dir2a/", std::string::npos, syntax, false);
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "ls dir2a/nospace");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "ls \"dir2a/dir space2\"");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "ls \"dir2a/dir space\"");
-        applyCompletion(r, false, 100);
+        applyCompletion(r, false, 100, s);
         ASSERT_EQ(r.line, "ls dir2a/nospace");
     }
 
     {
         auto r = autoComplete("ls \"dir\"1/", std::string::npos, syntax, false);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls \"dir1/sub11\"");
     }
 
     {
         auto r = autoComplete("ls dir1/\"../dir2/\"", std::string::npos, syntax, false);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls \"dir1/../dir2/sub21\"");
     }
 
     {
         auto r = autoComplete("ls /test_autocomplete_meg", std::string::npos, syntax, false);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls /test_autocomplete_megafs");
     }
 
@@ -2613,7 +2614,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls ", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir1/", "dir2/", "dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir");
     }
 
@@ -2621,7 +2622,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls di", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir1/", "dir2/", "dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir");
     }
 
@@ -2629,7 +2630,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir2/", "dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2");
     }
 
@@ -2637,7 +2638,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2a", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2a/");
     }
 
@@ -2645,7 +2646,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2 something after", 7, syntax, true);
         std::vector<std::string> e{ "dir2/", "dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2 something after");
     }
 
@@ -2653,7 +2654,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2asomething immediately after", 8, syntax, true);
         std::vector<std::string> e{ "dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2a/something immediately after");
     }
 
@@ -2661,10 +2662,10 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2/", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir2/sub21/", "dir2/sub22/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/sub2");
         auto rr = autoComplete("ls dir2/sub22", std::string::npos, syntax, true);
-        applyCompletion(rr, true, 100);
+        applyCompletion(rr, true, 100, s);
         ASSERT_EQ(rr.line, "ls dir2/sub22/");
     }
 
@@ -2672,7 +2673,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2/./", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir2/./sub21/", "dir2/./sub22/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/./sub2");
     }
 
@@ -2680,7 +2681,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2/..", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir2/../" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../");
     }
 
@@ -2688,7 +2689,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2/../", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir2/../dir1/", "dir2/../dir2/", "dir2/../dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir");
     }
 
@@ -2696,40 +2697,40 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         auto r = autoComplete("ls dir2/../", std::string::npos, syntax, true);
         std::vector<std::string> e{ "dir2/../dir1/", "dir2/../dir2/", "dir2/../dir2a/" };
         ASSERT_TRUE(cmp(r, e));
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls dir2/../dir");
     }
 
     {
         auto r = autoComplete("ls dir2a/d", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls \"dir2a/dir space\"");
         auto rr = autoComplete("ls \"dir2a/dir space\"/", std::string::npos, syntax, false);
-        applyCompletion(rr, true, 100);
+        applyCompletion(rr, true, 100, s);
         ASSERT_EQ(rr.line, "ls \"dir2a/dir space/next\"");
     }
 
     {
         auto r = autoComplete("ls \"dir\"1/", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls \"dir1/sub1\"");
     }
 
     {
         auto r = autoComplete("ls dir1/\"../dir2/\"", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls \"dir1/../dir2/sub2\"");
     }
 
     {
         auto r = autoComplete("ls /test_autocomplete_meg", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls /test_autocomplete_megafs/");
         r = autoComplete(r.line + "dir2a", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls /test_autocomplete_megafs/dir2a/");
         r = autoComplete(r.line + "d", std::string::npos, syntax, true);
-        applyCompletion(r, true, 100);
+        applyCompletion(r, true, 100, s);
         ASSERT_EQ(r.line, "ls \"/test_autocomplete_megafs/dir2a/dir space\"");
     }
 


### PR DESCRIPTION
…ad of being output to the right of the current prompt. So the current prompt floats below any cout output now.

Nicer columns for unix autocomplete, single tab press to contine if it was not all output, double press is required to repeat it after completion.
Also the console model and autocomplete module are now independent of cout.
Added megacli `get -r` option for testing mass downloads.
Added the other legit condition in the new assert in win32/net.cpp