### PR TITLE
Fixed a bug generating video thumbnails for some video sizes

### DIFF
--- a/src/gfx/qt.cpp
+++ b/src/gfx/qt.cpp
@@ -853,7 +853,7 @@ QImageReader *GfxProcQT::readbitmapFfmpeg(int &w, int &h, int &orientation, QStr
     }
 
     AVPixelFormat sourcePixelFormat = codecContext.pix_fmt;
-    AVPixelFormat targetPixelFormat = AV_PIX_FMT_RGB24;
+    AVPixelFormat targetPixelFormat = AV_PIX_FMT_RGBA;
     SwsContext* swsContext = sws_getContext(width, height, sourcePixelFormat,
                                             width, height, targetPixelFormat,
                                             SWS_FAST_BILINEAR, NULL, NULL, NULL);
@@ -988,8 +988,8 @@ QImageReader *GfxProcQT::readbitmapFfmpeg(int &w, int &h, int &orientation, QStr
 
                 if (scalingResult > 0)
                 {
-                    QImage image(width, height, QImage::Format_RGB888);
-                    if (avpicture_layout((AVPicture *)targetFrame, AV_PIX_FMT_RGB24,
+                    QImage image(width, height, QImage::Format_RGBA8888);
+                    if (avpicture_layout((AVPicture *)targetFrame, AV_PIX_FMT_RGBA,
                                     width, height, image.bits(), image.byteCount()) <= 0)
                     {
                         LOG_warn << "Error copying frame";


### PR DESCRIPTION
because the start of each line of the image in image.bits() must be 32bit aligned