### PR TITLE
auto-test app for sync functionality

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -86,6 +86,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
 # accurate __cplusplus macro for vc++, selecting c++17 here for windows builds though the MEGA SDK library must build for older c++ standards also
 if(WIN32)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus /std:c++17")
+add_definitions( -DNOMINMAX )  # also don't allow min and max macros from windows.h, use the std functions like on linux/g++
 endif()
 
 IF(WIN32)

--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -83,6 +83,11 @@ endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
 
+# accurate __cplusplus macro for vc++, selecting c++17 here for windows builds though the MEGA SDK library must build for older c++ standards also
+if(WIN32)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus /std:c++17")
+endif()
+
 IF(WIN32)
     #Link against the static C/C++ libraries on windows
     foreach(flag_var
@@ -291,13 +296,16 @@ add_executable(test_misc            ${MegaDir}/tests/tests.cpp
                                     ${MegaDir}/tests/paycrypt_test.cpp 
                                     ${MegaDir}/tests/crypto_test.cpp)
 add_executable(test_purge_account   ${MegaDir}/tests/purge_account.cpp)
+add_executable(test_sync            ${MegaDir}/tests/synctests.cpp)
 
 target_compile_definitions(test_sdk PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
 target_compile_definitions(test_misc PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
 target_compile_definitions(test_purge_account PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+target_compile_definitions(test_sync PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
 target_link_libraries(test_sdk gtest Mega )
 target_link_libraries(test_misc gtest Mega )
 target_link_libraries(test_purge_account gtest Mega )
+target_link_libraries(test_sync gtest Mega )
 
 #test apps need this file or tests fail
 configure_file("${MegaDir}/logo.png" logo.png COPYONLY)

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -48,6 +48,15 @@ namespace fs = std::experimental::filesystem;
 #include <iomanip>
 
 using namespace mega;
+using std::cout;
+using std::cerr;
+using std::endl;
+using std::flush;
+using std::ifstream;
+using std::ofstream;
+using std::setw;
+using std::hex;
+using std::dec;
 
 MegaClient* client;
 MegaClient* clientFolder;

--- a/examples/megasimplesync.cpp
+++ b/examples/megasimplesync.cpp
@@ -26,6 +26,9 @@
 #endif
 
 using namespace mega;
+using std::cout;
+using std::cerr;
+using std::endl;
 
 class SyncApp : public MegaApp, public Logger
 {

--- a/include/mega/crypto/cryptopp.h
+++ b/include/mega/crypto/cryptopp.h
@@ -39,7 +39,7 @@
 #include <cryptopp/pwdbased.h>
 
 namespace mega {
-using namespace std;
+using std::string;
 
 /**
  * @brief A generic pseudo-random number generator.

--- a/include/mega/crypto/sodium.h
+++ b/include/mega/crypto/sodium.h
@@ -27,7 +27,6 @@
 #include <sodium.h>
 
 namespace mega {
-using namespace std;
 
 /**
  * @brief Asymmetric cryptographic signature using EdDSA with Edwards 25519.

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1346,4 +1346,12 @@ public:
 };
 } // namespace
 
+#if __cplusplus < 201100L
+#define char_is_not_digit std::not1(std::ptr_fun(static_cast<int(*)(int)>(std::isdigit)))
+#define char_is_not_space std::not1(std::ptr_fun<int, int>(std::isspace))
+#else
+#define char_is_not_digit [](char c) { return !std::isdigit(c); }
+#define char_is_not_space [](char c) { return !std::isspace(c); }
+#endif
+
 #endif

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -34,7 +34,11 @@ public:
     MegaClient* client;
 
     // sync-wide directory notification provider
+#if __cplusplus >= 201100L
+    std::unique_ptr<DirNotify> dirnotify;
+#else
     std::auto_ptr<DirNotify> dirnotify;
+#endif
 
     // root of local filesystem tree, holding the sync's root folder
     LocalNode localroot;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -51,12 +51,6 @@ typedef int64_t m_off_t;
 // opaque filesystem fingerprint
 typedef uint64_t fsfp_t;
 
-#if USE_CRYPTOPP && (CRYPTOPP_VERSION >= 600) && (__cplusplus >= 201103L)
-    using byte = CryptoPP::byte;
-#else
-    typedef unsigned char byte;
-#endif
-
 #ifdef USE_CRYPTOPP
 #include "mega/crypto/cryptopp.h"
 #else
@@ -65,8 +59,31 @@ typedef uint64_t fsfp_t;
 
 #include "mega/crypto/sodium.h"
 
+#include <string>
+
 namespace mega {
-using namespace std;
+
+// import these select types into the namespace directly, to avoid adding std::byte from c++17
+using std::string;
+using std::map;
+using std::set;
+using std::list;
+using std::vector;
+using std::pair;
+using std::multimap;
+using std::deque;
+using std::multiset;
+using std::queue;
+using std::streambuf;
+using std::ostringstream;
+
+// within ::mega namespace, byte is unsigned char (avoids ambiguity when std::byte from c++17 and perhaps other defined ::byte are available)
+#if USE_CRYPTOPP && (CRYPTOPP_VERSION >= 600) && (__cplusplus >= 201103L)
+using byte = CryptoPP::byte;
+#else
+typedef unsigned char byte;
+#endif
+
 
 // forward declaration
 struct AttrMap;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -23,7 +23,7 @@
 #include "megaapi.h"
 #include "megaapi_impl.h"
 
-using namespace mega;
+namespace mega {
 
 MegaProxy::MegaProxy()
 {
@@ -5353,4 +5353,6 @@ long long MegaFolderInfo::getCurrentSize() const
 long long MegaFolderInfo::getVersionsSize() const
 {
     return 0;
+}
+
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -20420,7 +20420,7 @@ int64_t MegaBackupController::getLastBackupTime()
                     if (timeofbackup)
                     {
                         backupTimesPaths[timeofbackup]=childNode;
-                        latesttime = max(latesttime, timeofbackup);
+                        latesttime = std::max(latesttime, timeofbackup);
                     }
                     else
                     {
@@ -20689,7 +20689,7 @@ void MegaBackupController::start(bool skip)
     string backupname = ossremotename.str();
     currentName = backupname;
 
-    lastbackuptime = max(lastbackuptime,offsetds+startTime);
+    lastbackuptime = std::max(lastbackuptime,offsetds+startTime);
 
     megaApi->fireOnBackupStart(this);
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -5536,8 +5536,7 @@ void MegaApiImpl::creditCardStore(const char* address1, const char* address2, co
         if (creditcard)
         {
             screditcard = creditcard;
-            screditcard.erase(remove_if(screditcard.begin(), screditcard.end(),
-                                     not1(ptr_fun(static_cast<int(*)(int)>(isdigit)))), screditcard.end());
+            screditcard.erase(std::remove_if(screditcard.begin(), screditcard.end(), char_is_not_digit), screditcard.end());
         }
 
         if (expire_month)
@@ -15515,8 +15514,8 @@ void MegaApiImpl::sendPendingRequests()
             if(login)
             {
                 slogin = login;
-                slogin.erase(slogin.begin(), std::find_if(slogin.begin(), slogin.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-                slogin.erase(std::find_if(slogin.rbegin(), slogin.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), slogin.end());
+                slogin.erase(slogin.begin(), std::find_if(slogin.begin(), slogin.end(), char_is_not_space));
+                slogin.erase(std::find_if(slogin.rbegin(), slogin.rend(), char_is_not_space).base(), slogin.end());
             }
 
             requestMap.erase(request->getTag());
@@ -18989,7 +18988,7 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
 
     if (logToConsole)
     {
-        cout << "[" << time << "][" << SimpleLogger::toStr((LogLevel)loglevel) << "] " << message << endl;
+        std::cout << "[" << time << "][" << SimpleLogger::toStr((LogLevel)loglevel) << "] " << message << std::endl;
     }
     mutex.unlock();
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -67,7 +67,7 @@
 
 #include "mega/mega_zxcvbn.h"
 
-using namespace mega;
+namespace mega {
 
 MegaNodePrivate::MegaNodePrivate(const char *name, int type, int64_t size, int64_t ctime, int64_t mtime, uint64_t nodehandle,
                                  string *nodekey, string *attrstring, string *fileattrstring, const char *fingerprint, MegaHandle parentHandle,
@@ -20470,7 +20470,7 @@ int64_t MegaBackupController::getLastBackupTime()
                     if (timeofbackup)
                     {
                         backupTimesPaths[timeofbackup]=childNode;
-                        latesttime = std::max(latesttime, timeofbackup);
+                        latesttime = (std::max)(latesttime, timeofbackup);
                     }
                     else
                     {
@@ -20739,7 +20739,7 @@ void MegaBackupController::start(bool skip)
     string backupname = ossremotename.str();
     currentName = backupname;
 
-    lastbackuptime = std::max(lastbackuptime,offsetds+startTime);
+    lastbackuptime = (std::max)(lastbackuptime,offsetds+startTime);
 
     megaApi->fireOnBackupStart(this);
 
@@ -27928,4 +27928,6 @@ void TreeProcFolderInfo::proc(MegaClient *, Node *node)
 MegaFolderInfo *TreeProcFolderInfo::getResult()
 {
     return new MegaFolderInfoPrivate(numFiles, numFolders - 1, numVersions, currentSize, versionsSize);
+}
+
 }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -21,6 +21,7 @@
 
 #include "mega.h"
 #include "mega/mediafileattribute.h"
+#include <cctype>
 
 namespace mega {
 
@@ -7998,25 +7999,25 @@ error MegaClient::creditcardstore(const char *ccplain)
         return API_EARGS;
     }
 
-    string::iterator it = find_if(ccnumber.begin(), ccnumber.end(), not1(ptr_fun(static_cast<int(*)(int)>(isdigit))));
+    string::iterator it = find_if(ccnumber.begin(), ccnumber.end(), char_is_not_digit);
     if (it != ccnumber.end())
     {
         return API_EARGS;
     }
 
-    it = find_if(expm.begin(), expm.end(), not1(ptr_fun(static_cast<int(*)(int)>(isdigit))));
+    it = find_if(expm.begin(), expm.end(), char_is_not_digit);
     if (it != expm.end() || atol(expm.c_str()) > 12)
     {
         return API_EARGS;
     }
 
-    it = find_if(expy.begin(), expy.end(), not1(ptr_fun(static_cast<int(*)(int)>(isdigit))));
+    it = find_if(expy.begin(), expy.end(), char_is_not_digit);
     if (it != expy.end() || atol(expy.c_str()) < 2015)
     {
         return API_EARGS;
     }
 
-    it = find_if(cv2.begin(), cv2.end(), not1(ptr_fun(static_cast<int(*)(int)>(isdigit))));
+    it = find_if(cv2.begin(), cv2.end(), char_is_not_digit);
     if (it != cv2.end())
     {
         return API_EARGS;

--- a/src/posix/console.cpp
+++ b/src/posix/console.cpp
@@ -22,6 +22,8 @@
 #include "mega.h"
 
 namespace mega {
+using namespace std;
+
 PosixConsole::PosixConsole()
 {
     // set up the console

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -40,7 +40,8 @@ extern JavaVM *MEGAjvm;
 #endif
 
 namespace mega {
-    
+using namespace std;
+
 #ifdef USE_IOS
     char* PosixFileSystemAccess::appbasepath = NULL;
 #endif

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -21,8 +21,9 @@
 
 #include "mega/proxy.h"
 
-using namespace mega;
 using namespace std;
+
+namespace mega {
 
 Proxy::Proxy()
 {
@@ -68,4 +69,6 @@ string Proxy::getUsername()
 string Proxy::getPassword()
 {
     return password;
+}
+
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -68,7 +68,7 @@ Sync::Sync(MegaClient* cclient, string* crootpath, const char* cdebris,
         debris = cdebris;
         client->fsaccess->path2local(&debris, &localdebris);
 
-        dirnotify = auto_ptr<DirNotify>(client->fsaccess->newdirnotify(crootpath, &localdebris));
+        dirnotify.reset(client->fsaccess->newdirnotify(crootpath, &localdebris));
 
         localdebris.insert(0, client->fsaccess->localseparator);
         localdebris.insert(0, *crootpath);
@@ -78,7 +78,7 @@ Sync::Sync(MegaClient* cclient, string* crootpath, const char* cdebris,
         localdebris = *clocaldebris;
 
         // FIXME: pass last segment of localdebris
-        dirnotify = auto_ptr<DirNotify>(client->fsaccess->newdirnotify(crootpath, &localdebris));
+        dirnotify.reset(client->fsaccess->newdirnotify(crootpath, &localdebris));
     }
     dirnotify->sync = this;
 

--- a/src/win32/autocomplete.cpp
+++ b/src/win32/autocomplete.cpp
@@ -31,6 +31,7 @@ namespace fs = std::experimental::filesystem;
 
 namespace mega {
 namespace autocomplete {
+using namespace std;
 
 template<class T>
 static T clamp(T v, T lo, T hi)

--- a/src/win32/console.cpp
+++ b/src/win32/console.cpp
@@ -34,6 +34,8 @@
 
 namespace mega {
 
+using namespace std;
+
 #ifdef NO_READLINE
 template<class T>
 static T clamp(T v, T lo, T hi)

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -205,7 +205,7 @@ TEST(Crypto, Ed25519_Signing)
 
     // Initialize variables
 
-    int keySeedLen = EdDSA::SEED_KEY_LENGTH;
+    const int keySeedLen = EdDSA::SEED_KEY_LENGTH;
     unsigned char keySeed[keySeedLen];
     ASSERT_EQ(keySeedLen, Base64::atob(prEd255str.data(), keySeed, keySeedLen))
             << "Failed to convert Ed25519 private key to binary";
@@ -306,7 +306,7 @@ TEST(Crypto, Ed25519_Signing)
 
     // ____ Create and verify signatures of random messages ____
 
-    unsigned keylen = SymmCipher::KEYLENGTH;
+    const unsigned keylen = SymmCipher::KEYLENGTH;
     byte key[keylen];
     string sig;
     for (int i = 0; i < 100; i++)

--- a/tests/purge_account.cpp
+++ b/tests/purge_account.cpp
@@ -28,6 +28,16 @@ static const string APP_KEY = "V8ZGDDBA";
 static const unsigned int pollingT      = 500000;   // (microseconds) to check if response from server is received
 static const unsigned int maxTimeout    = 300;      // Maximum time (seconds) to wait for response from server
 
+
+void WaitMillisec(unsigned n)
+{
+#ifdef _WIN32
+    Sleep(n);
+#else
+    usleep(n * 1000);
+#endif
+}
+
 class PurgeAcc: public MegaListener, MegaRequestListener {
 
 public:
@@ -183,7 +193,7 @@ void PurgeAcc::waitForResponse(bool *responseReceived, int timeout)
     int tWaited = 0;    // microseconds
     while(!(*responseReceived))
     {
-        usleep(pollingT);
+        WaitMillisec(pollingT/1000);
 
         if (timeout)
         {

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -26,7 +26,7 @@
 #include <filesystem>
 #endif
 
-
+using namespace std;
 
 MegaFileSystemAccess fileSystemAccess;
 

--- a/tests/sdk_test.h
+++ b/tests/sdk_test.h
@@ -57,7 +57,7 @@ public:
     ~MegaLoggerSDK();
 
 private:
-    ofstream sdklog;
+    std::ofstream sdklog;
 
 protected:
     void log(const char *time, int loglevel, const char *source, const char *message);

--- a/tests/synctests.cpp
+++ b/tests/synctests.cpp
@@ -1,0 +1,1605 @@
+/**
+ * @file tests/synctests.cpp
+ * @brief Mega SDK test file
+ *
+ * (c) 2018 by Mega Limited, Wellsford, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+// Many of these tests are still being worked on.
+// The file uses some C++17 mainly for the very convenient std::filesystem library, though the main SDK must still build with C++11 (and prior)
+
+#include <mega.h>
+#include "gtest/gtest.h"
+#include <stdio.h>
+#include <filesystem>
+#include <map>
+#include <future>
+//#include <mega/testhooks.h>
+
+using namespace ::mega;
+using namespace ::std;
+namespace fs = ::std::filesystem;
+namespace {
+
+typedef ::mega::byte byte;
+
+WinConsole* wc = NULL;
+
+void WaitMillisec(unsigned n)
+{
+#ifdef _WIN32
+    Sleep(n);
+#else
+    usleep(n * 1000);
+#endif
+}
+struct Model
+{
+    // records what we think the tree should look like after sync so we can confirm it
+
+    struct ModelNode
+    {
+        string name;
+        vector<unique_ptr<ModelNode>> kids;
+        ModelNode* parent = nullptr;
+        string path() 
+        {
+            string s;
+            for (auto p = this; p; p = p->parent) 
+                s = "/" + p->name + s;
+            return s;
+        }
+        void addkid(unique_ptr<ModelNode>&& p)
+        {
+            p->parent = this;
+            kids.emplace_back(move(p));
+        }
+    };
+
+    unique_ptr<ModelNode> makeModelSubfolder(const string& utf8Name)
+    {
+        unique_ptr<ModelNode> n(new ModelNode);
+        n->name = utf8Name;
+        return n;
+    }
+
+    unique_ptr<ModelNode> buildModelSubdirs(const string& prefix, int n, int recurselevel)
+    {
+        unique_ptr<ModelNode> nn = makeModelSubfolder(prefix);
+        if (recurselevel > 0)
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                unique_ptr<ModelNode> sn = buildModelSubdirs(prefix + "_" + to_string(i), n, recurselevel - 1);
+                sn->parent = nn.get();
+                nn->addkid(move(sn));
+            }
+        }
+        return nn;
+    }
+
+    ModelNode* childnodebyname(ModelNode* n, const std::string& s)
+    {
+        for (auto& m : n->kids)
+        {
+            if (m->name == s)
+            {
+                return m.get();
+            }
+        }
+        return nullptr;
+    }
+
+    ModelNode* findnode(string path)
+    {
+        ModelNode* n = root.get();
+        while (n && !path.empty())
+        {
+            auto pos = path.find("/");
+            n = childnodebyname(n, path.substr(0, pos));
+            path.erase(0, pos == string::npos ? path.size() : pos + 1);
+        }
+        return n;
+    }
+
+    unique_ptr<ModelNode> removenode(const string& path)
+    {
+        ModelNode* n = findnode(path);
+        if (n && n->parent)
+        {
+            unique_ptr<ModelNode> extracted;
+            ModelNode* parent = n->parent;
+            auto newend = std::remove_if(parent->kids.begin(), parent->kids.end(), [&extracted, n](unique_ptr<ModelNode>& v) { if (v.get() == n) return extracted = move(v), true; else return false; });
+            parent->kids.erase(newend, parent->kids.end());
+            return std::move(extracted);
+        }
+        return false;
+    }
+
+    bool movenode(const string& sourcepath, const string& destpath)
+    {
+        ModelNode* source = findnode(sourcepath);
+        ModelNode* dest = findnode(destpath);
+        if (source && source && source->parent && dest)
+        {
+            unique_ptr<ModelNode> n;
+            ModelNode* parent = source->parent;
+            auto newend = std::remove_if(parent->kids.begin(), parent->kids.end(), [&n, source](unique_ptr<ModelNode>& v) { if (v.get() == source) return n = move(v), true; else return false; });
+            parent->kids.erase(newend, parent->kids.end());
+            if (n)
+            {
+                dest->addkid(move(n));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Model() : root(makeModelSubfolder("root"))
+    {
+    }
+
+    unique_ptr<ModelNode> root;
+};
+
+
+bool waitonresults(future<bool>* r1 = nullptr, future<bool>* r2 = nullptr, future<bool>* r3 = nullptr, future<bool>* r4 = nullptr)
+{
+    if (r1) r1->wait();
+    if (r2) r2->wait();
+    if (r3) r3->wait();
+    if (r4) r4->wait();
+    return (!r1 || r1->get()) && (!r2 || r2->get()) && (!r3 || r3->get()) && (!r4 || r4->get());
+}
+
+struct StandardClient : public MegaApp
+{
+    HANDLE functionEventMC, functionEventSC;
+    WAIT_CLASS waiter;
+#ifdef GFX_CLASS
+    GFX_CLASS gfx;
+#endif
+
+    MegaClient client;
+    bool clientthreadexit = false;
+    bool fatalerror = false;
+    string clientname;
+    std::function<void(MegaClient&, promise<bool>&)> nextfunctionMC;
+    std::promise<bool> nextfunctionMCpromise;
+    std::function<void(StandardClient&, promise<bool>&)> nextfunctionSC;
+    std::promise<bool> nextfunctionSCpromise;
+    std::condition_variable functionDone;
+    std::mutex functionDoneMutex;
+
+
+    fs::path fsBasePath;
+
+    handle basefolderhandle = UNDEF;
+
+    // thread as last member so everything else is initialised before we start it
+    std::thread clientthread;
+
+    fs::path ensureDir(const fs::path& p)
+    {
+        fs::create_directories(p);
+        return p;
+    }
+
+    StandardClient(const fs::path& basepath, const string& name)
+        : functionEventMC(CreateEvent(NULL, TRUE, FALSE, NULL))
+        , functionEventSC(CreateEvent(NULL, TRUE, FALSE, NULL))
+        , client(this, &waiter, new HTTPIO_CLASS, new FSACCESS_CLASS,
+#ifdef DBACCESS_CLASS
+            new DBACCESS_CLASS(&(ensureDir(basepath / name).u8string() + "\\")),   // client takes ownership of this one
+#else
+            NULL,
+#endif
+#ifdef GFX_CLASS
+            &gfx,
+#else
+            NULL,
+#endif
+            "N9tSBJDC", "synctests")
+        , clientname(name)
+        , fsBasePath(basepath / name)
+        , clientthread([this]() { threadloop(); })
+    {
+        //client.clientname = " " + clientname;
+    }
+
+    ~StandardClient()
+    {
+        // shut down any syncs on the same thread, or they stall the client destruction (CancelIo instead of CancelIoEx on the WinDirNotify)
+        thread_do([](MegaClient& mc, promise<bool>&) { mc.purgenodesusersabortsc(); });
+
+        clientthreadexit = true;
+        SetEvent(functionEventMC);
+        clientthread.join();
+    }
+
+    static mutex om;
+    bool logcb = false;
+    chrono::steady_clock::time_point lastcb = std::chrono::steady_clock::now();
+    string lp(LocalNode* ln) { string lp;  ln->getlocalpath(&lp); client.fsaccess->local2name(&lp); return lp; }
+    void syncupdate_state(Sync*, syncstate_t state) override { if (logcb) { lock_guard g(om);  cout << clientname << " syncupdate_state() " << state << endl; } }
+    void syncupdate_scanning(bool b) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_scanning()" << b << endl; } }
+    //void syncupdate_local_folder_addition(Sync* s, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_local_folder_addition() " << lp(ln) << " " << cp << endl; }}
+    //void syncupdate_local_folder_deletion(Sync*, LocalNode* ln) override { if (logcb) { lock_guard g(om);  cout << clientname << " syncupdate_local_folder_deletion() " << lp(ln) << endl; }}
+    void syncupdate_local_folder_addition(Sync*, LocalNode* ln, const char* cp) override { lastcb = chrono::steady_clock::now(); }
+    void syncupdate_local_folder_deletion(Sync*, LocalNode* ln) override { lastcb = chrono::steady_clock::now(); }
+    void syncupdate_local_file_addition(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_local_file_addition() " << lp(ln) << " " << cp << endl; }}
+    void syncupdate_local_file_deletion(Sync*, LocalNode* ln) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_local_file_deletion() " << lp(ln) << endl; }}
+    void syncupdate_local_file_change(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_local_file_change() " << lp(ln) << " " << cp << endl; }}
+    void syncupdate_local_move(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_local_move() " << lp(ln) << " " << cp << endl; }}
+    void syncupdate_local_lockretry(bool b) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_local_lockretry() " << b << endl; }}
+    //void syncupdate_get(Sync*, Node* n, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_get()" << n->displaypath() << " " << cp << endl; }}
+    void syncupdate_put(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_put()" << lp(ln) << " " << cp << endl; }}
+    //void syncupdate_remote_file_addition(Sync*, Node* n) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_remote_file_addition() " << n->displaypath() << endl; }}
+    //void syncupdate_remote_file_deletion(Sync*, Node* n) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_remote_file_deletion() " << n->displaypath() << endl; }}
+    //void syncupdate_remote_folder_addition(Sync*, Node* n) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_remote_folder_addition() " << n->displaypath() << endl; }}
+    //void syncupdate_remote_folder_deletion(Sync*, Node* n) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_remote_folder_deletion() " << n->displaypath() << endl; }}
+    void syncupdate_remote_folder_addition(Sync*, Node* n) override { lastcb = chrono::steady_clock::now(); }
+    void syncupdate_remote_folder_deletion(Sync*, Node* n) override { lastcb = chrono::steady_clock::now(); }
+    void syncupdate_remote_copy(Sync*, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_remote_copy() " << cp << endl; }}
+    //void syncupdate_remote_move(Sync*, Node* n1, Node* n2) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_remote_move() " << n1->displaypath() << " " << n2->displaypath() << endl; }}
+    //void syncupdate_remote_rename(Sync*, Node* n, const char* cp) override { if (logcb) { lock_guard g(om); cout << clientname << " syncupdate_remote_rename() " << n->displaypath() << " " << cp << endl; }}
+    void syncupdate_treestate(LocalNode* ln) override { if (logcb) { lock_guard g(om);   cout << clientname << " syncupdate_treestate() " << ln->ts << " " << ln->dts << " " << lp(ln) << endl; }}
+
+
+
+    void threadloop()
+        try
+    {
+        while (!clientthreadexit)
+        {
+            waiter.addhandle(functionEventMC, Waiter::HAVESTDIN);
+            waiter.addhandle(functionEventSC, Waiter::HAVESTDIN);
+            int r = client.wait();
+            if (WAIT_OBJECT_0 == WaitForSingleObject(functionEventMC, 0))
+            {
+                nextfunctionMC(client, nextfunctionMCpromise);
+                unique_lock<mutex> guard(functionDoneMutex);
+                ResetEvent(functionEventMC);
+                functionDone.notify_all();
+                r = Waiter::NEEDEXEC;
+            }
+            if (WAIT_OBJECT_0 == WaitForSingleObject(functionEventSC, 0))
+            {
+                nextfunctionSC(*this, nextfunctionSCpromise);
+                unique_lock<mutex> guard(functionDoneMutex);
+                ResetEvent(functionEventSC);
+                functionDone.notify_all();
+                r = Waiter::NEEDEXEC;
+            }
+            if (r & Waiter::NEEDEXEC)
+            {
+                client.exec();
+            }
+        }
+        cout << clientname << " thread exiting naturally" << endl;
+    }
+    catch (std::exception& e)
+    {
+        cout << clientname << " thread exception, StandardClient " << clientname << " terminated: " << e.what() << endl;
+    }
+    catch (...)
+    {
+        cout << clientname << " thread exception, StandardClient " << clientname << " terminated" << endl;
+    }
+
+    static bool debugging;  // turn this on to prevent the main thread timing out when stepping in the MegaClient
+
+    future<bool> thread_do(std::function<void(MegaClient&, promise<bool>&)>&& f)
+    {
+        nextfunctionMCpromise = promise<bool>();
+        nextfunctionMC = std::move(f);
+        SetEvent(functionEventMC);
+        std::mutex functionDoneMutex;
+        unique_lock<mutex> guard(functionDoneMutex);
+        while (!functionDone.wait_until(guard, chrono::steady_clock::now() + 50s, [this]() { return WAIT_TIMEOUT == WaitForSingleObject(functionEventMC, 0); }))
+        {
+            if (!debugging)
+            {
+                nextfunctionMCpromise.set_value(false);
+                break;
+            }
+        }
+        return nextfunctionMCpromise.get_future();
+    }
+
+    future<bool> thread_do(std::function<void(StandardClient&, promise<bool>&)>&& f)
+    {
+        nextfunctionSCpromise = promise<bool>();
+        nextfunctionSC = std::move(f);
+        SetEvent(functionEventSC);
+        unique_lock<mutex> guard(functionDoneMutex);
+        while (!functionDone.wait_until(guard, chrono::steady_clock::now() + 50s, [this]() { return WAIT_TIMEOUT == WaitForSingleObject(functionEventSC, 0); }))
+        {
+            if (!debugging)
+            {
+                nextfunctionSCpromise.set_value(false);
+                break;
+            }
+        }
+        return nextfunctionSCpromise.get_future();
+    }
+
+    enum resultprocenum { LOGIN, FETCHNODES, PUTNODES, UNLINK };
+
+    void loginFromEnv(const string& userenv, const string& pwdenv, promise<bool>& pb)
+    {
+        string user = getenv(userenv.c_str());
+        string pwd = getenv(pwdenv.c_str());
+
+        ASSERT_FALSE(user.empty());
+        ASSERT_FALSE(pwd.empty());
+
+        byte pwkey[SymmCipher::KEYLENGTH];
+        ASSERT_TRUE(API_OK == client.pw_key(pwd.c_str(), pwkey));
+
+        resultproc.prepresult(LOGIN, [this, &pb](error e) { pb.set_value(!e); });
+        client.login(user.c_str(), pwkey);
+    }
+
+    void fetchnodes(promise<bool>& pb)
+    {
+        resultproc.prepresult(FETCHNODES, [this, &pb](error e) { pb.set_value(!e); });
+        client.fetchnodes();
+    }
+
+    NewNode* makeSubfolder(const string& utf8Name)
+    {
+        SymmCipher key;
+        string attrstring;
+        byte buf[FOLDERNODEKEYLENGTH];
+        NewNode* newnode = new NewNode[1];
+
+        // set up new node as folder node
+        newnode->source = NEW_NODE;
+        newnode->type = FOLDERNODE;
+        newnode->nodehandle = 0;
+        newnode->parenthandle = UNDEF;
+
+        // generate fresh random key for this folder node
+        PrnGen::genblock(buf, FOLDERNODEKEYLENGTH);
+        newnode->nodekey.assign((char*)buf, FOLDERNODEKEYLENGTH);
+        key.setkey(buf);
+
+        // generate fresh attribute object with the folder name
+        AttrMap attrs;
+        string& n = attrs.map['n'];
+        client.fsaccess->normalize(&(n = utf8Name));
+
+        // JSON-encode object and encrypt attribute string
+        attrs.getjson(&attrstring);
+        newnode->attrstring = new string;
+        client.makeattr(&key, newnode->attrstring, attrstring.c_str());
+
+        return newnode;
+    }
+
+
+    struct ResultProc
+    {
+        map<resultprocenum, deque<std::function<void(error)>>> m;
+
+        void prepresult(resultprocenum rpe, std::function<void(error)>&& f)
+        {
+            auto& entry = m[rpe];
+            entry.emplace_back(move(f));
+        }
+
+        void processresult(resultprocenum rpe, error e)
+        {
+            auto& entry = m[rpe];
+            if (!entry.empty())
+            {
+                entry.front()(e);
+                entry.pop_front();
+            }
+            else
+            {
+                assert(!entry.empty());
+            }
+        }
+    } resultproc;
+
+    void deleteTestBaseFolder(bool mayneeddeleting, promise<bool>& pb)
+    {
+        if (Node* root = client.nodebyhandle(client.rootnodes[0]))
+        {
+            if (Node* basenode = client.childnodebyname(root, "mega_test_sync", false))
+            {
+                if (mayneeddeleting)
+                {
+                    resultproc.prepresult(UNLINK, [this, &pb](error e) {
+                        deleteTestBaseFolder(false, pb);
+                    });
+                    client.unlink(basenode);
+                    return;
+                }
+            }
+            else
+            {
+                pb.set_value(true);
+                return;
+            }
+        }
+        pb.set_value(false);
+    }
+
+    void ensureTestBaseFolder(bool mayneedmaking, promise<bool>& pb)
+    {
+        if (Node* root = client.nodebyhandle(client.rootnodes[0]))
+        {
+            if (Node* basenode = client.childnodebyname(root, "mega_test_sync", false))
+            {
+                if (basenode->type == FOLDERNODE)
+                {
+                    basefolderhandle = basenode->nodehandle;
+                    pb.set_value(true);
+                    return;
+                }
+            }
+            else if (mayneedmaking)
+            {
+                resultproc.prepresult(PUTNODES, [this, &pb](error e) {
+                    ensureTestBaseFolder(false, pb);
+                });
+                client.putnodes(root->nodehandle, makeSubfolder("mega_test_sync"), 1);
+                return;
+            }
+        }
+        pb.set_value(false);
+    }
+
+    NewNode* buildSubdirs(vector<NewNode*>& nodes, const string& prefix, int n, int recurselevel)
+    {
+        NewNode* nn = makeSubfolder(prefix);
+        nodes.push_back(nn);
+        nn->nodehandle = nodes.size();
+
+        if (recurselevel > 0)
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                buildSubdirs(nodes, prefix + "_" + to_string(i), n, recurselevel - 1)->parenthandle = nn->nodehandle;
+            }
+        }
+
+        return nn;
+    }
+
+    void makeTestSubdirs(int depth, int fanout, promise<bool>& pb)
+    {
+        assert(basefolderhandle != UNDEF);
+
+        vector<NewNode*> nodes;
+        NewNode* nn = buildSubdirs(nodes, "f", fanout, depth);
+        nn->parenthandle = UNDEF;
+        nn->ovhandle = UNDEF;
+
+        NewNode* nodearray = new NewNode[nodes.size()];
+        for (size_t i = 0; i < nodes.size(); ++i)
+        {
+            nodearray[i] = *nodes[i]; // todo:  need move semantics
+            //delete nodes[i];
+        }
+
+        resultproc.prepresult(PUTNODES, [this, &pb](error e) { 
+            pb.set_value(!e); 
+        });
+        client.putnodes(basefolderhandle, nodearray, nodes.size());
+    }
+
+    struct SyncInfo { handle h; fs::path localpath; };
+    map<int, SyncInfo> syncSet;
+
+    Node* drillchildnodebyname(Node* n, const string& path)
+    {
+        for (size_t p = 0; n && p < path.size(); )
+        {
+            auto pos = path.find("/", p);
+            n = client.childnodebyname(n, path.substr(p, pos).c_str(), false);
+            p = pos == string::npos ? path.size() : pos + 1;
+        }
+        return n;
+    }
+
+    bool setupSync_inthread(int syncid, const string& subfoldername, const fs::path& localpath)
+    {
+        if (Node* n = client.nodebyhandle(basefolderhandle))
+        {
+            if (Node* m = drillchildnodebyname(n, subfoldername))
+            {
+                string local, orig = localpath.u8string();
+                client.fsaccess->path2local(&orig, &local);
+                error e = client.addsync(&local, DEBRISFOLDER, NULL, m, 0, syncid);  // use syncid as tag
+                if (!e)
+                {
+                    syncSet[syncid] = SyncInfo{ m->nodehandle, localpath };
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    bool recursiveConfirm(Model::ModelNode* mn, Node* n, int& descendants, const string& identifier)
+    {
+        if (!mn || !n) return false;
+        // top level names can differ so we don't check those
+
+        multimap<string, Model::ModelNode*> ms;
+        multimap<string, Node*> ns;
+        for (auto& m : mn->kids) ms.emplace(m->name, m.get());
+        for (auto& n : n->children) ns.emplace(n->displayname(), n);
+
+        int matched = 0;
+        for (auto m_iter = ms.begin(); m_iter != ms.end(); )
+        {
+            auto er = ns.equal_range(m_iter->first);
+            auto next_m = m_iter;
+            ++next_m;
+            bool any_equal_matched = false;
+            for (auto i = er.first; i != er.second; ++i)
+            {
+                int rdescendants = 0;
+                if (recursiveConfirm(m_iter->second, i->second, rdescendants, identifier))
+                {
+                    ns.erase(i);
+                    ms.erase(m_iter);
+                    ++matched;
+                    descendants += rdescendants;
+                    any_equal_matched = true;
+                    break;
+                }
+            }
+            if (!any_equal_matched)
+            {
+                break;
+            }
+            m_iter = next_m;
+        }
+        if (ns.empty() && ms.empty())
+        {
+            descendants += matched;
+            return true;
+        }
+        else
+        {
+            cout << identifier << " after matching " << matched << " child nodes (with " << descendants << " descendants) in " << mn->path() << ", ended up with unmatched model nodes:";
+            for (auto& m : ms) cout << " " << m.first;
+            cout << " and unmatched remote nodes:";
+            for (auto& n : ns) cout << " " << n.first;
+            cout << endl;
+            return false;
+        };
+    }
+
+    bool recursiveConfirm(Model::ModelNode* mn, LocalNode* n, int& descendants, const string& identifier)
+    {
+        // top level names can differ so we don't check those
+        if (!mn || !n) return false;
+
+        multimap<string, Model::ModelNode*> ms;
+        multimap<string, LocalNode*> ns;
+        for (auto& m : mn->kids) ms.emplace(m->name, m.get());
+        for (auto& n : n->children) if (!n.second->deleted) ns.emplace(n.second->name, n.second); // todo: should LocalNodes marked as deleted actually have been removed by now?
+
+        int matched = 0;
+        for (auto m_iter = ms.begin(); m_iter != ms.end(); )
+        {
+            auto er = ns.equal_range(m_iter->first);
+            auto next_m = m_iter;
+            ++next_m;
+            bool any_equal_matched = false;
+            for (auto i = er.first; i != er.second; ++i)
+            {
+                int rdescendants = 0; 
+                if (recursiveConfirm(m_iter->second, i->second, rdescendants, identifier))
+                {
+                    ns.erase(i);
+                    ms.erase(m_iter);
+                    ++matched;
+                    descendants += rdescendants;
+                    any_equal_matched = true;
+                    break;
+                }
+            }
+            if (!any_equal_matched)
+            {
+                break;
+            }
+            m_iter = next_m;
+        }
+        if (ns.empty() && ms.empty())
+        {
+            return true;
+        }
+        else
+        {
+            cout << identifier << " after matching " << matched << " child nodes (with " << descendants << " descendants) in " << mn->path() << ", ended up with unmatched model nodes:";
+            for (auto& m : ms) cout << " " << m.first;
+            cout << " and unmatched LocalNodes:";
+            for (auto& n : ns) cout << " " << n.first;
+            cout << endl;
+            return false;
+        };
+    }
+
+
+    bool recursiveConfirm(Model::ModelNode* mn, fs::path p, int& descendants, const string& identifier)
+    {
+        if (!mn) return false;
+
+        multimap<string, Model::ModelNode*> ms;
+        multimap<string, fs::path> ps;
+        for (auto& m : mn->kids) ms.emplace(m->name, m.get());
+        for (fs::directory_iterator pi(p); pi != fs::directory_iterator(); ++pi) ps.emplace(pi->path().filename().u8string(), pi->path());
+
+        int matched = 0;
+        for (auto m_iter = ms.begin(); m_iter != ms.end(); )
+        {
+            auto er = ps.equal_range(m_iter->first);
+            auto next_m = m_iter;
+            ++next_m;
+            bool any_equal_matched = false;
+            for (auto i = er.first; i != er.second; ++i)
+            {
+                int rdescendants = 0; 
+                if (recursiveConfirm(m_iter->second, i->second, rdescendants, identifier))
+                {
+                    ps.erase(i);
+                    ms.erase(m_iter);
+                    ++matched;
+                    descendants += rdescendants;
+                    any_equal_matched = true;
+                    break;
+                }
+            }
+            if (!any_equal_matched)
+            {
+                break;
+            }
+            m_iter = next_m;
+        }
+        if (ps.size() == 1 && !mn->parent && ps.begin()->first == DEBRISFOLDER)
+        {
+            ps.clear();
+        }
+        if (ps.empty() && ms.empty())
+        {
+            return true;
+        }
+        else
+        {
+            cout << identifier << " after matching " << matched << " child nodes (with " << descendants << " descendants) in " << mn->path() << ", ended up with unmatched model nodes:";
+            for (auto& m : ms) cout << " " << m.first;
+            cout << " and unmatched filesystem paths:";
+            for (auto& p : ps) cout << " " << p.second;
+            cout << endl;
+            return false;
+        };
+    }
+
+    Node* getBaseNode()
+    {
+        if (Node* root = client.nodebyhandle(client.rootnodes[0]))
+        {
+            return client.childnodebyname(root, "mega_test_sync", false);
+        }
+        return nullptr;
+    }
+
+    Sync* syncByTag(int tag)
+    {
+        for (Sync* s : client.syncs)
+        {
+            if (s->tag == tag)
+                return s;
+        }
+        return nullptr;
+    }
+
+    bool confirmModel(int syncid, Model::ModelNode* mnode)
+    {
+        auto si = syncSet.find(syncid);
+        if (si == syncSet.end())
+        {
+            cout << "syncid " << syncid << " not found " << endl;
+            return false;
+        }
+
+        // compare model aganst nodes representing remote state
+        int descendants = 0;
+        if (!recursiveConfirm(mnode, client.nodebyhandle(si->second.h), descendants, "Sync " + to_string(syncid)))
+        {
+            cout << "syncid " << syncid << " comparison against remote nodes failed" << endl;
+            return false;
+        }
+
+        // compare model against LocalNodes
+        descendants = 0; 
+        if (Sync* sync = syncByTag(syncid))
+        {
+            if (!recursiveConfirm(mnode, &sync->localroot, descendants, "Sync " + to_string(syncid)))
+            {
+                cout << "syncid " << syncid << " comparison against LocalNodes failed" << endl;
+                return false;
+            }
+        }
+
+        // compare model against local filesystem
+        descendants = 0;
+        if (!recursiveConfirm(mnode, si->second.localpath, descendants, "Sync " + to_string(syncid)))
+        {
+            cout << "syncid " << syncid << " comparison against local filesystem failed" << endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    void login_result(error e) override 
+    {
+        cout << clientname << " Login: " << e << endl;
+        resultproc.processresult(LOGIN, e);
+    }
+
+    void fetchnodes_result(error e) override
+    {
+        cout << clientname << " Fetchnodes: " << e << endl;
+        resultproc.processresult(FETCHNODES, e);
+    }
+
+    void unlink_result(handle, error e) 
+    { 
+        resultproc.processresult(UNLINK, e);
+    }
+
+    void putnodes_result(error e, targettype_t tt, NewNode* nn) override
+    {
+        if (nn)  // ignore sync based putnodes
+        {
+            resultproc.processresult(PUTNODES, e);
+        }
+    }
+
+    void deleteremote(string path, promise<bool>& pb )
+    {
+        Node* n = getBaseNode();
+        while (n && !path.empty())
+        {
+            auto pos = path.find("/");
+            n = client.childnodebyname(n, path.substr(0, pos).c_str(), false);
+            path.erase(0, pos == string::npos ? path.size() : pos + 1);
+        }
+        if (n)
+        {
+            resultproc.prepresult(UNLINK, [this, &pb](error e) { pb.set_value(!e); });
+            client.unlink(n);
+        }
+        else
+        {
+            pb.set_value(false);
+        }
+    }
+
+    void waitonsyncs(chrono::seconds d = 2s)
+    {
+        auto start = chrono::steady_clock::now();
+        for (;;)
+        {
+            bool any_add_del = false;;
+            vector<int> syncstates;
+
+            thread_do([&syncstates, &any_add_del, this](StandardClient& mc, promise<bool>&)
+            {
+                for (auto& sync : mc.client.syncs)
+                {
+                    syncstates.push_back(sync->state);
+                    if (sync->deleteq.size() || sync->insertq.size())
+                        any_add_del = true;
+                }
+                if (!(client.todebris.empty() && client.tounlink.empty() && client.synccreate.empty()))
+                {
+                    any_add_del = true;
+                }
+            });
+            bool allactive = true;
+            {
+                lock_guard g(StandardClient::om);
+                std::cout << "sync state: ";
+                for (auto n : syncstates)
+                {
+                    cout << n;
+                    if (n != SYNC_ACTIVE) allactive = false;
+                }
+                cout << endl;
+            }
+
+            if (any_add_del || debugging)
+            {
+                start = chrono::steady_clock::now();
+            }
+
+            if (allactive && ((chrono::steady_clock::now() - start) > d) && ((chrono::steady_clock::now() - lastcb) > d))
+                break;
+
+            Sleep(500);
+        }
+
+    }
+
+    bool login_reset(const string& user, const string& pw)
+    {
+        future<bool> p1;
+        p1 = thread_do([=](StandardClient& sc, promise<bool>& pb) { sc.loginFromEnv(user, pw, pb); });
+        if (!waitonresults(&p1)) return false;
+        p1 = thread_do([](StandardClient& sc, promise<bool>& pb) { sc.fetchnodes(pb); });
+        if (!waitonresults(&p1)) return false;
+        p1 = thread_do([](StandardClient& sc, promise<bool>& pb) { sc.deleteTestBaseFolder(true, pb); });
+        if (!waitonresults(&p1)) return false;
+        p1 = thread_do([](StandardClient& sc, promise<bool>& pb) { sc.ensureTestBaseFolder(true, pb); });
+        if (!waitonresults(&p1)) return false;
+        return true;
+    }
+
+    bool login_reset_makeremotenodes(const string& user, const string& pw)
+    {
+        if (!login_reset(user, pw))
+            return false;
+        future<bool> p1 = thread_do([=](StandardClient& sc, promise<bool>& pb) { sc.makeTestSubdirs(3, 3, pb); });
+        if (!waitonresults(&p1)) return false;
+        return true;
+    }
+
+    bool login_fetchnodes(const string& user, const string& pw)
+    {
+        future<bool> p2;
+        p2 = thread_do([=](StandardClient& sc, promise<bool>& pb) { sc.loginFromEnv(user, pw, pb); });
+        if (!waitonresults(&p2)) return false; 
+        p2 = thread_do([](StandardClient& sc, promise<bool>& pb) { sc.fetchnodes(pb); });
+        if (!waitonresults(&p2)) return false;
+        p2 = thread_do([](StandardClient& sc, promise<bool>& pb) { sc.ensureTestBaseFolder(false, pb); });
+        if (!waitonresults(&p2)) return false;
+        return true;
+    }
+
+    bool setupSync_mainthread(const std::string& localsyncrootfolder, const std::string& remotesyncrootfolder, int syncid)
+    {
+        fs::path syncdir = fsBasePath / localsyncrootfolder;
+        fs::create_directory(syncdir);
+        future<bool> fb = thread_do([=](StandardClient& mc, promise<bool>& pb) { pb.set_value(mc.setupSync_inthread(syncid, remotesyncrootfolder, syncdir)); });
+        return fb.get();
+    }
+
+    bool confirmModel_mainthread(Model::ModelNode* mnode, int syncid)
+    {
+        future<bool> fb;
+        fb = thread_do([syncid, mnode](StandardClient& sc, promise<bool>& pb) { pb.set_value(sc.confirmModel(syncid, mnode)); });
+        return fb.get();
+    }
+};
+
+
+void waitonsyncs(chrono::seconds d = 4s, StandardClient* c1 = nullptr, StandardClient* c2 = nullptr, StandardClient* c3 = nullptr, StandardClient* c4 = nullptr)
+{
+    auto start = chrono::steady_clock::now();
+    std::vector<StandardClient*> v{ c1, c2, c3, c4 };
+    for (;;)
+    {
+        bool any_add_del = false;;
+        vector<int> syncstates;
+
+        for (auto vn : v) if (vn)
+        {
+            vn->thread_do([&syncstates, &any_add_del](StandardClient& mc, promise<bool>&)
+            {
+                for (auto& sync : mc.client.syncs)
+                {
+                    syncstates.push_back(sync->state);
+                    if (sync->deleteq.size() || sync->insertq.size())
+                        any_add_del = true;
+                }
+                if (!(mc.client.todebris.empty() && mc.client.tounlink.empty() && mc.client.synccreate.empty()))
+                {
+                    any_add_del = true;
+                }
+            });
+        }
+
+        bool allactive = true;
+        {
+            lock_guard g(StandardClient::om);
+            std::cout << "sync state: ";
+            for (auto n : syncstates)
+            {
+                cout << n;
+                if (n != SYNC_ACTIVE) allactive = false;
+            }
+            cout << endl;
+        }
+
+        if (any_add_del || StandardClient::debugging)
+        {
+            start = chrono::steady_clock::now();
+        }
+
+        for (auto vn : v) if (vn)
+        {
+            if (allactive && ((chrono::steady_clock::now() - start) > d) && ((chrono::steady_clock::now() - vn->lastcb) > d))
+                return;
+        }
+
+        Sleep(500);
+    }
+
+}
+
+
+mutex StandardClient::om;
+bool StandardClient::debugging = false;
+
+void moveToTrash(const fs::path& p)
+{
+    fs::path trashpath = p.parent_path() / "trash";
+    fs::create_directory(trashpath);
+    fs::path newpath = trashpath / p.filename();
+    for (int i = 2; fs::exists(newpath); ++i)
+    {
+        newpath = trashpath / (p.filename().stem().u8string() + "_" + to_string(i) + p.extension().u8string());
+    }
+    fs::rename(p, newpath);
+}
+
+fs::path makeNewTestRoot(fs::path p)
+{
+    if (fs::exists(p))
+    {
+        moveToTrash(p);
+    }
+    bool b = fs::create_directory(p);
+    assert(b);
+    return p;
+}
+
+bool buildLocalFolders(fs::path targetfolder, const string& prefix, int n, int recurselevel)
+{
+    fs::path p = targetfolder / prefix;
+    if (!fs::create_directory(p))
+        return false;
+
+    if (recurselevel > 0)
+    {
+        for (int i = 0; i < n; ++i)
+        {
+            if (!buildLocalFolders(p, prefix + "_" + to_string(i), n, recurselevel - 1))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+GTEST_TEST(BasicSync, DelRemoteFolder)
+{
+    // delete a remote folder and confirm the client sending the request and another also synced both correctly update the disk
+    ASSERT_TRUE(wc->log("synctest_DelRemoteFolder", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // delete something remotely and let sync catch up
+    future<bool> fb = clientA1.thread_do([](StandardClient& sc, promise<bool>& pb) { sc.deleteremote("f/f_2/f_2_1", pb); });
+    ASSERT_TRUE(waitonresults(&fb));
+    waitonsyncs(4s, &clientA1, &clientA2);
+
+    // check everything matches in both syncs (model has expected state of remote and local)
+    ASSERT_TRUE(model.removenode("f/f_2/f_2_1"));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, DelLocalFolder)
+{
+    // confirm change is synced to remote, and also seen and applied in a second client that syncs the same folder
+    ASSERT_TRUE(wc->log("synctest_DelLocalFolder", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // delete something in the local filesystem and see if we catch up in A1 and A2 (deleter and observer syncs)
+    error_code e;
+    ASSERT_TRUE(fs::remove_all(clientA1.syncSet[1].localpath / "f_2" / "f_2_1", e) != static_cast<std::uintmax_t>(-1)) << e;
+
+    // let them catch up
+    waitonsyncs(4s, &clientA1, &clientA2);
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(model.removenode("f/f_2/f_2_1"));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, MoveLocalFolder)
+{
+    // confirm change is synced to remote, and also seen and applied in a second client that syncs the same folder
+    ASSERT_TRUE(wc->log("synctest_MoveLocalFolder", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // move something in the local filesystem and see if we catch up in A1 and A2 (deleter and observer syncs)
+    error_code rename_error;
+    fs::rename(clientA1.syncSet[1].localpath / "f_2" / "f_2_1", clientA1.syncSet[1].localpath / "f_2_1", rename_error);
+    ASSERT_TRUE(!rename_error) << rename_error;
+
+    // let them catch up
+    waitonsyncs(4s, &clientA1, &clientA2);
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(model.movenode("f/f_2/f_2_1", "f"));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, MoveLocalFolderBetweenSyncs)
+{
+    // confirm change is synced to remote, and also seen and applied in a second client that syncs the same folder
+    ASSERT_TRUE(wc->log("synctest_MoveLocalFolderBetweenSyncs", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+    StandardClient clientA3(localtestroot, "clientA3");   // user 1 client 3
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA3.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    // set up sync for A1 and A2, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f/f_0", 11));
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync2", "f/f_2", 12));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("syncA2_1", "f/f_0", 21));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("syncA2_2", "f/f_2", 22));
+    ASSERT_TRUE(clientA3.setupSync_mainthread("syncA3", "f", 31));
+    waitonsyncs(4s, &clientA1, &clientA2, &clientA3);
+    clientA1.logcb = clientA2.logcb = clientA3.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f/f_0"), 11));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f/f_2"), 12));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f/f_0"), 21));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f/f_2"), 22));
+    ASSERT_TRUE(clientA3.confirmModel_mainthread(model.findnode("f"), 31));
+
+    // move a folder form one local synced folder to another local synced folder and see if we sync correctly and catch up in A2 and A3 (mover and observer syncs)
+    error_code rename_error;
+    fs::path path1 = clientA1.syncSet[11].localpath / "f_0_1";
+    fs::path path2 = clientA1.syncSet[12].localpath / "f_2_1" / "f_2_1_0" / "f_0_1";
+    fs::rename(path1, path2, rename_error);
+    ASSERT_TRUE(!rename_error) << rename_error;
+
+    // let them catch up
+    waitonsyncs(4s, &clientA1, &clientA2, &clientA3);
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(model.movenode("f/f_0/f_0_1", "f/f_2/f_2_1/f_2_1_0"));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f/f_0"), 11));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f/f_2"), 12));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f/f_0"), 21));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f/f_2"), 22));
+    ASSERT_TRUE(clientA3.confirmModel_mainthread(model.findnode("f"), 31));
+}
+
+
+
+GTEST_TEST(BasicSync, AddLocalFolder)
+{
+    // confirm change is synced to remote, and also seen and applied in a second client that syncs the same folder
+    ASSERT_TRUE(wc->log("synctest_AddLocalFolder", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // make new folders in the local filesystem and see if we catch up in A1 and A2 (adder and observer syncs)
+    ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath / "f_2", "newkid", 2, 2));
+
+    // let them catch up
+    waitonsyncs(4s, &clientA1, &clientA2);
+
+    // check everything matches (model has expected state of remote and local)
+    model.findnode("f/f_2")->addkid(model.buildModelSubdirs("newkid", 2, 2));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, MAX_NEWNODES1)
+{
+    // create more nodes than we can upload in one putnodes.
+    // this tree is 5x5 and the algorithm ends up creating nodes one at a time so it's pretty slow (and doesn't hit MAX_NEWNODES as a result)
+    ASSERT_TRUE(wc->log("synctest_MAX_NEWNODES1", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    //StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    //ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    //ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    //ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f_3_999", 2));
+    clientA1.waitonsyncs();
+    //clientA2.waitonsyncs();
+    //clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    //ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // make new folders in the local filesystem and see if we catch up in A1 and A2 (adder and observer syncs)
+    assert(MegaClient::MAX_NEWNODES < 3125);
+    ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath, "f", 5, 5));  // 5^5=3125 leaf folders, 625 pre-leaf etc
+
+    // let them catch up
+    clientA1.waitonsyncs(30s);
+    //clientA2.waitonsyncs(30s);
+
+    // check everything matches (model has expected state of remote and local)
+    model.findnode("")->addkid(model.buildModelSubdirs("f", 5, 5));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    //ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, MAX_NEWNODES2)
+{
+    // create more nodes than we can upload in one putnodes.
+    // this tree is 5x5 and the algorithm ends up creating nodes one at a time so it's pretty slow (and doesn't hit MAX_NEWNODES as a result)
+    ASSERT_TRUE(wc->log("synctest_MAX_NEWNODES2", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+                                                          //StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    //ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    //ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    //ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
+    clientA1.waitonsyncs();
+    //clientA2.waitonsyncs();
+    //clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    //ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // make new folders in the local filesystem and see if we catch up in A1 and A2 (adder and observer syncs)
+    assert(MegaClient::MAX_NEWNODES < 3125);
+    ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath, "f", 3000, 1));  // 5^5=3125 leaf folders, 625 pre-leaf etc
+
+                                                                              // let them catch up
+    clientA1.waitonsyncs(30s);
+    //clientA2.waitonsyncs(30s);
+
+    // check everything matches (model has expected state of remote and local)
+    model.findnode("")->addkid(model.buildModelSubdirs("f", 3000, 1));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    //ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, MoveExistingIntoNewLocalFolder)
+{
+    // historic case:  in the local filesystem, create a new folder then move an existing file/folder into it
+    ASSERT_TRUE(wc->log("synctest_MoveExistingIntoNewLocalFolder", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // make new folder in the local filesystem
+    ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath, "new", 1, 0));
+    // move an already synced folder into it
+    error_code rename_error;
+    fs::path path1 = clientA1.syncSet[1].localpath / "f_2";
+    fs::path path2 = clientA1.syncSet[1].localpath / "new" / "f_2";
+    fs::rename(path1, path2, rename_error);
+    ASSERT_TRUE(!rename_error) << rename_error;
+
+    // let them catch up
+    waitonsyncs(4s, &clientA1, &clientA2);
+
+    // check everything matches (model has expected state of remote and local)
+    auto f = model.makeModelSubfolder("new");
+    f->addkid(model.removenode("f/f_2"));
+    model.findnode("f")->addkid(move(f));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+
+GTEST_TEST(BasicSync, SyncDuplicateNames)
+{
+    ASSERT_TRUE(wc->log("synctest_SyncDuplicateNames", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+
+    NewNode* nodearray = new NewNode[3];
+    nodearray[0] = *clientA1.makeSubfolder("samename");
+    nodearray[1] = *clientA1.makeSubfolder("samename");
+    nodearray[2] = *clientA1.makeSubfolder("Samename");
+    clientA1.resultproc.prepresult(StandardClient::PUTNODES, [this](error e) {
+    });
+    clientA1.client.putnodes(clientA1.basefolderhandle, nodearray, 3);
+
+    // set up syncs, they should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    Model model;
+    model.root->kids.emplace_back(model.makeModelSubfolder("root"));
+    model.root->addkid(model.makeModelSubfolder("samename"));
+    model.root->addkid(model.makeModelSubfolder("samename"));
+    model.root->addkid(model.makeModelSubfolder("Samename"));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+bool ignorePutnodesResponseHappened = false;
+bool ignorePutnodesResponse()
+{
+    ignorePutnodesResponseHappened = true;
+    return false; // false causes non-processing
+}
+
+
+GTEST_TEST(BasicSync, RemoveLocalNodeBeforeSessionResume)
+{
+    ASSERT_TRUE(wc->log("synctest_RemoveLocalNodeBeforeSessionResume", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
+    clientA1.waitonsyncs();
+    clientA2.waitonsyncs();
+    clientA1.logcb = clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    fs::path rmpath = clientA1.syncSet[1].localpath;
+
+    // save session
+    byte session[64];
+    int size = clientA1.client.dumpsession(session, sizeof session);
+
+    // logout (but keep caches)
+    future<bool> p1 = clientA1.thread_do([](StandardClient& sc, promise<bool>& pb) { sc.client.locallogout(); pb.set_value(true); });
+    ASSERT_TRUE(waitonresults(&p1));
+
+    // remove local folders
+    error_code e;
+    ASSERT_TRUE(fs::remove_all(rmpath / "f_2", e) != static_cast<std::uintmax_t>(-1)) << e;
+
+    // resume session, see if nodes and localnodes get in sync
+    ASSERT_TRUE(clientA1.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));  // todo:  use session
+    // restore sync
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+
+    clientA1.waitonsyncs();
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(model.removenode("f/f_2").get() != nullptr);
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, TieLocalNodesToRemoteAfterExitingBeforePutnodesResponseProcessed)
+{
+    ASSERT_TRUE(wc->log("synctest_TieLocalNodesToRemoteAfterExitingBeforePutnodesResponseProcessed", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    //StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset_makeremotenodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    //ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    //ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    Model model;
+    model.root->kids.emplace_back(model.buildModelSubdirs("f", 3, 3));
+
+    // set up sync for A1, it should build matching local folders
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f_3_999", 1));
+    //ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f_3_999", 2));
+    clientA1.waitonsyncs();
+    //clientA2.waitonsyncs();
+    clientA1.logcb = true;// clientA2.logcb = true;
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    //ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+
+    // make new folder in the local filesystem
+
+    //globalMegaTestHooks.onPutnodesResponse = ignorePutnodesResponse;
+    ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath, "new", 1, 0));
+
+    // let them catch up
+    clientA1.waitonsyncs();
+    //clientA2.waitonsyncs();
+    ASSERT_TRUE(ignorePutnodesResponseHappened);
+    ignorePutnodesResponseHappened = false;
+    //globalMegaTestHooks.onPutnodesResponse = NULL;
+
+    // save session
+    byte session[64];
+    int size= clientA1.client.dumpsession(session, sizeof session);
+
+    // logout (but keep caches)
+    future<bool> p1 = clientA1.thread_do([](StandardClient& sc, promise<bool>& pb) { sc.client.locallogout(); pb.set_value(true); });
+    ASSERT_TRUE(waitonresults(&p1));
+
+
+    // resume session, see if nodes and localnodes get in sync
+    ASSERT_TRUE(clientA1.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    // restore sync
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
+
+    clientA1.waitonsyncs();
+
+    // check everything matches (model has expected state of remote and local)
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    //ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+
+GTEST_TEST(BasicSync, RemoteFolderCreationRaceSamename)
+{
+    // confirm change is synced to remote, and also seen and applied in a second client that syncs the same folder
+    ASSERT_TRUE(wc->log("synctest_RemoteFolderCreationRaceSamename", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    // set up sync for both, it should build matching local folders (empty initially)
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    // now have both clients create the same remote folder structure simultaneously.  We should end up with just one copy of it on the server and in both syncs
+    future<bool> p1 = clientA1.thread_do([=](StandardClient& sc, promise<bool>& pb) { sc.makeTestSubdirs(3, 3, pb); });
+    future<bool> p2 = clientA2.thread_do([=](StandardClient& sc, promise<bool>& pb) { sc.makeTestSubdirs(3, 3, pb); });
+    ASSERT_TRUE(waitonresults(&p1, &p2));
+
+    // let them catch up
+    waitonsyncs(4s, &clientA1, &clientA2);
+
+    // check everything matches (model has expected state of remote and local)
+    Model model;
+    model.root->addkid(model.buildModelSubdirs("f", 3, 3));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+GTEST_TEST(BasicSync, LocalFolderCreationRaceSamename)
+{
+    // confirm change is synced to remote, and also seen and applied in a second client that syncs the same folder
+    ASSERT_TRUE(wc->log("synctest_LocalFolderCreationRaceSamename", WinConsole::utf8_log));
+
+    fs::path localtestroot = makeNewTestRoot("c:\\tmp\\synctests");
+    StandardClient clientA1(localtestroot, "clientA1");   // user 1 client 1
+    StandardClient clientA2(localtestroot, "clientA2");   // user 1 client 2
+
+    ASSERT_TRUE(clientA1.login_reset("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_TRUE(clientA2.login_fetchnodes("MEGAAUTOTESTUSER1", "MEGAAUTOTESTPWD1"));
+    ASSERT_EQ(clientA1.basefolderhandle, clientA2.basefolderhandle);
+
+    // set up sync for both, it should build matching local folders (empty initially)
+    ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "", 1));
+    ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "", 2));
+    waitonsyncs(4s, &clientA1, &clientA2);
+    clientA1.logcb = clientA2.logcb = true;
+
+    // now have both clients create the same folder structure simultaneously.  We should end up with just one copy of it on the server and in both syncs
+    future<bool> p1 = clientA1.thread_do([=](StandardClient& sc, promise<bool>& pb) { buildLocalFolders(sc.syncSet[1].localpath, "f", 3, 3); pb.set_value(true); });
+    future<bool> p2 = clientA2.thread_do([=](StandardClient& sc, promise<bool>& pb) { buildLocalFolders(sc.syncSet[2].localpath, "f", 3, 3); pb.set_value(true); });
+    ASSERT_TRUE(waitonresults(&p1, &p2));
+
+    // let them catch up
+    waitonsyncs(30s, &clientA1, &clientA2);
+
+    // check everything matches (model has expected state of remote and local)
+    Model model;
+    model.root->addkid(model.buildModelSubdirs("f", 3, 3));
+    ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
+    ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
+}
+
+
+
+class MegaCLILogger : public ::mega::Logger {
+public:
+    virtual void log(const char *time, int loglevel, const char *source, const char *message)
+    {
+#ifdef _WIN32
+        OutputDebugStringA(message);
+        OutputDebugStringA("\r\n");
+#endif
+
+        if (loglevel <= logWarning)
+        {
+            std::cout << message << std::endl;
+        }
+    }
+};
+
+MegaCLILogger logger;
+};  // unnamed namespace
+
+int main (int argc, char *argv[])
+{
+    remove("synctests.log");
+
+#ifdef _WIN32
+    SimpleLogger::setLogLevel(logDebug);  // warning and stronger to console; info and weaker to VS output window
+    SimpleLogger::setOutputClass(&logger);
+#else
+    SimpleLogger::setAllOutputs(&std::cout);
+#endif
+
+
+#if defined(WIN32) && defined(NO_READLINE)
+    wc = new CONSOLE_CLASS;
+    wc->setShellConsole();
+#endif
+
+    ::testing::InitGoogleTest(&argc, argv);
+    auto x = RUN_ALL_TESTS();
+    return x;
+}


### PR DESCRIPTION
Added a test app for sync.  It's not finished yet but has some useful tests and may be good to have available in other branches.  I've used some c++17 features just in that (without affecting the main SDK - mostly std::filesystem) which prompted this next one:

Resolved some issues when building with a c++17 compliant compiler, mainly that it defines std::byte which clashes with the byte we were defining, and probably with others.  The main change is removing 'using namespace std' from headers (even inside the mega namespace it still caused clashes).  Just 'using std::map' to pull the specific items we need into the mega namespace works pretty well.  