### PR TITLE
Simplified the tempurl variables, using only the one in the transfer

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -34,9 +34,9 @@ set (build_64_bit 1 CACHE TYPE BOOL)
 
 #indicate which dependent libraries to use in the build
 set (USE_CRYPTOPP 1 CACHE TYPE BOOL)
-set (USE_OPENSSL 0 CACHE TYPE BOOL)
+set (USE_OPENSSL 1 CACHE TYPE BOOL)
 set (OPENSSL_IS_BORINGSSL 0 CACHE TYPE BOOL)
-set (USE_CURL 0 CACHE TYPE BOOL)
+set (USE_CURL 1 CACHE TYPE BOOL)
 set (USE_SQLITE 1 CACHE TYPE BOOL)
 set (USE_MEDIAINFO 1 CACHE TYPE BOOL)
 set (USE_FREEIMAGE 1 CACHE TYPE BOOL)
@@ -67,9 +67,9 @@ ENDIF(WIN32)
 
 IF(WIN32)
     if(build_64_bit)
-        set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x64-windows-static")
+        set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x64-windows-static-uncheckediterators")
     else(build_64_bit)
-        set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x86-windows-static")
+        set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x86-windows-static-uncheckediterators")
     endif(build_64_bit)
 ENDIF(WIN32)
 
@@ -82,6 +82,11 @@ endif(NOT CMAKE_BUILD_TYPE)
 #windows projects usually need _DEBUG and/or DEBUG set rather than NDEBUG not set
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
+
+# node deletion in debug under VC++ is pretty slow without this.  However libraries we depend on need to be built with the same setting or linking fails 
+# (hence the build3rdParty script using the xNN-windows-static-uncheckediterators triplets)
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_ITERATOR_DEBUG_LEVEL=0" )
+
 
 # accurate __cplusplus macro for vc++, selecting c++17 here for windows builds though the MEGA SDK library must build for older c++ standards also
 if(WIN32)
@@ -133,15 +138,7 @@ IF(WIN32)
     ENDIF(USE_CRYPTOPP)
 
     IF(USE_SODIUM)
-        if (build_64_bit)
-            ImportVcpkgLibrary(sodium          "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/libsodium.lib"  "${vcpkg_dir}/lib/libsodium.lib")
-        else()
-            ImportStaticLibrary(sodium          "${Mega3rdPartyDir}/libsodium-1.0.15/src/libsodium/include"
-                                                "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Debug/Win32/libsodium.lib" 
-                                                "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Release/Win32/libsodium.lib" 
-                                                "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Debug/x64/libsodium.lib" 
-                                                "${Mega3rdPartyDir}/libsodium-1.0.15/Build/Release/x64/libsodium.lib")
-        endif()
+        ImportVcpkgLibrary(sodium          "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/libsodium.lib"  "${vcpkg_dir}/lib/libsodium.lib")
     ENDIF(USE_SODIUM)
 
     IF(USE_CURL)
@@ -156,11 +153,7 @@ IF(WIN32)
     
     ImportVcpkgLibrary(zlib            "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/zlibd.lib" "${vcpkg_dir}/lib/zlib.lib") 
 
-    ImportStaticLibrary(gtest           "${Mega3rdPartyDir}/googletest/googletest/include"
-                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/Win32-Debug/gtestd.lib" 
-                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/Win32-Release/gtest.lib"
-                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/x64-Debug/gtestd.lib" 
-                                        "${Mega3rdPartyDir}/googletest/googletest/msvc/2010/gtest/x64-Release/gtest.lib")
+    ImportVcpkgLibrary(gtest           "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/manual-link/gtestd.lib" "${vcpkg_dir}/lib/manual-link/gtest.lib") 
 
     IF(USE_MEDIAINFO)
         ImportStaticLibrary(mediainfo   "${Mega3rdPartyDir}/MediaInfoLib-mw/Source"
@@ -188,16 +181,12 @@ IF(WIN32)
 
     IF(USE_SQLITE)
         ImportVcpkgLibrary(sqlite3          "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/sqlite3.lib" "${vcpkg_dir}/lib/sqlite3.lib")
-
- #       add_library(sqlite3 INTERFACE IMPORTED)
- #       set_property(TARGET sqlite3 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${Mega3rdPartyDir}/sqlite-3.20.1")
     ENDIF(USE_SQLITE)
 
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -DCURL_STATICLIB -DCARES_STATICLIB -DWIN32_LEAN_AND_MEAN -DUNICODE -DSODIUM_STATIC -DPCRE_STATICWIN32 -D_CONSOLE)
     SET(Mega_PlatformSpecificIncludes ${MegaDir}/include/mega/$<IF:${USE_CURL},wincurl,win32>)
     SET(Mega_PlatformSpecificLibs ws2_32 winhttp Shlwapi)
 
-    #get_target_property(sqlite3dir sqlite3 INTERFACE_INCLUDE_DIRECTORIES)
     SET(Mega_PlatformSpecificFiles ${MegaDir}/src/win32/console.cpp 
     ${MegaDir}/src/win32/autocomplete.cpp 
     ${MegaDir}/src/win32/consolewaiter.cpp 
@@ -205,7 +194,6 @@ IF(WIN32)
     $<IF:${USE_CURL},${MegaDir}/src/posix/net.cpp,${MegaDir}/src/win32/net.cpp>
     ${MegaDir}/src/win32/waiter.cpp 
     ${MegaDir}/src/thread/win32thread.cpp  
-    #${sqlite3dir}/sqlite3.c 
     )
 
 

--- a/contrib/cmake/build3rdparty.cmd
+++ b/contrib/cmake/build3rdparty.cmd
@@ -1,0 +1,61 @@
+REM best to use this script outside of the MEGA repo.  Once the libraries are built, the CMakeLists.txt can be adjusted to refer to them.
+mkdir 3rdParty
+cd 3rdParty
+
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+CALL .\bootstrap-vcpkg.bat
+
+REM we use a lot of map iterators, and the checking is linear, causing big delays in node deletion for example
+copy .\triplets\x86-windows-static.cmake .\triplets\x86-windows-static-uncheckediterators.cmake
+copy .\triplets\x64-windows-static.cmake .\triplets\x64-windows-static-uncheckediterators.cmake
+echo #comment >> .\triplets\x86-windows-static-uncheckediterators.cmake
+echo #comment >> .\triplets\x64-windows-static-uncheckediterators.cmake
+echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
+echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
+echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
+echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
+
+REM for libsodium for x86, currently some adjustments are needed:
+REM add this to its portfile.cmake's vcpkg_build_msbuild call (having moved that definition before it):  PLATFORM ${BUILD_ARCH}
+REM also edit its vcproj file to set Configuration->AllOptions->TargetMachine to x86 for the Win32 configurations.
+REM you can build everything first then make those adjustments and manually call vcpkg for libsodium x86.
+
+CALL :build_one zlib
+CALL :build_one cryptopp
+CALL :build_one libsodium
+CALL :build_one openssl
+CALL :build_one curl
+CALL :build_one c-ares
+CALL :build_one sqlite3
+CALL :build_one libevent
+CALL :build_one gtest
+
+REM for megachat:
+REM CALL :build_one libuv
+REM CALL :build_one libwebsockets
+
+REM currently for libwebsockets a few changes are needed (mainly get 2.4.2, turn off ipv6, turn on libuv features)
+REM modify these attributes in its portfile: 
+REM     REF v2.4.2
+REM     SHA512 
+REM     7bee49f6763ff3ab7861fcda25af8d80f6757c56e197ea42be53e0b2480969eee73de3aee5198f5ff06fd1cb8ab2be4c6495243e83cd0acc235b0da83b2353d1
+REM     HEAD_REF v2.4-stable
+REM and add libuv dependency (this might not be strictly necessary)
+REM     Feature: libuv
+REM     Build-Depends: libuv
+REM     Description: turns on LWS_WITH_LIBUU
+REM then use remove and install again.
+REM also find libwebsocket's CMakeLists.txt file and modify the libuv find_library, adding 'libuv' as that's what the libuv vcpkg produces:
+REM     find_library(LIBUV_LIBRARIES NAMES uv libuv)
+
+
+
+exit /b 0
+
+:build_one 
+.\vcpkg.exe install --triplet x64-windows-static-uncheckediterators %1%
+echo %errorlevel% %1% x64-windows-static-uncheckediterators >> buildlog
+.\vcpkg.exe install --triplet x86-windows-static-uncheckediterators %1%
+echo %errorlevel% %1% x86-windows-static-uncheckediterators >> buildlog
+exit /b 0

--- a/include/mega/backofftimer.h
+++ b/include/mega/backofftimer.h
@@ -70,8 +70,8 @@ public:
 class MEGA_API TimerWithBackoff: public BackoffTimer {
 
 public:
-    long long tag;
-    TimerWithBackoff(long long tag);
+    int tag;
+    TimerWithBackoff(int tag);
 };
 
 } // namespace

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -119,7 +119,7 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     const char* displayname() const;
 
     // display path from its root in the cloud (UTF-8)
-    string Node::displaypath() const;
+    string displaypath() const;
 
     // node attributes
     AttrMap attrs;

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -118,6 +118,9 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     // display name (UTF-8)
     const char* displayname() const;
 
+    // display path from its root in the cloud (UTF-8)
+    string Node::displaypath() const;
+
     // node attributes
     AttrMap attrs;
 

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -116,8 +116,8 @@ struct MEGA_API Transfer : public FileFingerprint
     // transfer state
     bool finished;
 
-    // cached temp URL for upload/download data
-    string cachedtempurl;
+    // temp URL for upload/download data.  It can be cached.  For uploads, a new url means any previously uploaded data is abandoned.
+    string tempurl;
 
     // context of the async fopen operation
     AsyncIOContext* asyncopencontext;

--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -71,9 +71,6 @@ struct MEGA_API TransferSlot
     // file attributes mutable
     int fileattrsmutable;
 
-    // storage server access URL
-    string tempurl;
-
     // maximum number of parallel connections and connection aray
     int connections;
     HttpReqXfer** reqs;

--- a/src/backofftimer.cpp
+++ b/src/backofftimer.cpp
@@ -129,7 +129,7 @@ void BackoffTimer::update(dstime* waituntil)
     }
 }
 
-TimerWithBackoff::TimerWithBackoff(long long tag)
+TimerWithBackoff::TimerWithBackoff(int tag)
 {
     this->tag = tag;
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -359,13 +359,13 @@ void CommandPutFile::procresult()
         switch (client->json.getnameid())
         {
             case 'p':
-                client->json.storeobject(canceled ? NULL : &tslot->tempurl);
+                client->json.storeobject(canceled ? NULL : &tslot->transfer->tempurl);
                 break;
 
             case EOO:
                 if (canceled) return;
 
-                if (tslot->tempurl.size())
+                if (tslot->transfer->tempurl.size())
                 {
                     tslot->starttime = tslot->lastdata = client->waiter->ds;
                     return tslot->progress();
@@ -567,7 +567,7 @@ void CommandGetFile::procresult()
         switch (client->json.getnameid())
         {
             case 'g':
-                client->json.storeobject(tslot ? &tslot->tempurl : NULL);
+                client->json.storeobject(tslot ? &tslot->transfer->tempurl : NULL);
                 e = API_OK;
                 break;
 
@@ -712,7 +712,7 @@ void CommandGetFile::procresult()
 
                                         tslot->starttime = tslot->lastdata = client->waiter->ds;
 
-                                        if (tslot->tempurl.size() && s >= 0)
+                                        if (tslot->transfer->tempurl.size() && s >= 0)
                                         {
                                             return tslot->progress();
                                         }
@@ -1452,7 +1452,7 @@ void CommandPrelogin::procresult()
         switch (client->json.getnameid())
         {
             case 'v':
-                v = client->json.getint();
+                v = int(client->json.getint());
                 break;
             case 's':
                 client->json.storeobject(&salt);
@@ -3977,8 +3977,8 @@ void CommandSendSignupLink::procresult()
 CommandSendSignupLink2::CommandSendSignupLink2(MegaClient* client, const char* email, const char* name)
 {
     cmd("uc2");
-    arg("n", (byte*)name, strlen(name));
-    arg("m", (byte*)email, strlen(email));
+    arg("n", (byte*)name, int(strlen(name)));
+    arg("m", (byte*)email, int(strlen(email)));
     arg("v", 2);
     tag = client->reqtag;
 }
@@ -3986,8 +3986,8 @@ CommandSendSignupLink2::CommandSendSignupLink2(MegaClient* client, const char* e
 CommandSendSignupLink2::CommandSendSignupLink2(MegaClient* client, const char* email, const char* name, byte *clientrandomvalue, byte *encmasterkey, byte *hashedauthkey)
 {
     cmd("uc2");
-    arg("n", (byte*)name, strlen(name));
-    arg("m", (byte*)email, strlen(email));
+    arg("n", (byte*)name, int(strlen(name)));
+    arg("m", (byte*)email, int(strlen(email)));
     arg("crv", clientrandomvalue, SymmCipher::KEYLENGTH);
     arg("hak", hashedauthkey, SymmCipher::KEYLENGTH);
     arg("k", encmasterkey, SymmCipher::KEYLENGTH);
@@ -4080,7 +4080,7 @@ void CommandConfirmSignupLink2::procresult()
     if (client->json.storebinary(&email) && client->json.storebinary(&name))
     {
         uh = client->json.gethandle(MegaClient::USERHANDLE);
-        version = client->json.getint();
+        version = int(client->json.getint());
     }
     while (client->json.storeobject());
 

--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -378,7 +378,7 @@ int AsymmCipher::encrypt(const byte* plain, int plainlen, byte* buf, int buflen)
         *ptr++ = t.GetByte(i);
     }
 
-    return ptr - buf;
+    return int(ptr - buf);
 }
 
 static void rsadecrypt(Integer* key, Integer* m)

--- a/src/crypto/sodium.cpp
+++ b/src/crypto/sodium.cpp
@@ -72,7 +72,7 @@ int EdDSA::sign(const unsigned char* msg, const unsigned long long msglen,
 
     int result = crypto_sign_detached(sig, NULL, msg, msglen, (const unsigned char*)privKey);
 
-    return (result == 0) ? (crypto_sign_BYTES + msglen) : 0;
+    return int( (result == 0) ? (crypto_sign_BYTES + msglen) : 0 );
 }
 
 
@@ -144,7 +144,7 @@ void EdDSA::signKey(const unsigned char *key, const unsigned long long keyLength
 
     string keyString = "keyauth";
     keyString.append(tsstr);
-    keyString.append((char*)key, keyLength);
+    keyString.append((char*)key, size_t(keyLength));
 
     byte sigBuf[crypto_sign_BYTES];
     sign((unsigned char *)keyString.data(), keyString.size(), sigBuf);
@@ -166,7 +166,7 @@ bool EdDSA::verifyKey(const unsigned char *pubk, const unsigned long long pubkLe
 
     string message = "keyauth";
     message.append(sig->data(), 8);
-    message.append((char*)pubk, pubkLen);
+    message.append((char*)pubk, size_t(pubkLen));
 
     string signature = sig->substr(8);
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -32,7 +32,7 @@ DbTable::DbTable()
 // add or update record from string
 bool DbTable::put(uint32_t index, string* data)
 {
-    return put(index, (char*)data->data(), data->size());
+    return put(index, (char*)data->data(), unsigned(data->size()));
 }
 
 // add or update record with padding and encryption

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -118,7 +118,7 @@ void GfxProc::loop()
             // (this assumes that the width of the largest dimension is max)
             if (readbitmap(NULL, &job->localfilename, dimensions[sizeof dimensions/sizeof dimensions[0]-1][0]))
             {
-                for (int i = 0; i < job->imagetypes.size(); i++)
+                for (unsigned i = 0; i < job->imagetypes.size(); i++)
                 {
                     // successively downscale the original image
                     string* jpeg = new string();
@@ -143,7 +143,7 @@ void GfxProc::loop()
             }
             else
             {
-                for (int i = 0; i < job->imagetypes.size(); i++)
+                for (unsigned i = 0; i < job->imagetypes.size(); i++)
                 {
                     job->images.push_back(NULL);
                 }
@@ -162,7 +162,7 @@ void GfxProc::loop()
 
     while (job = responses.pop())
     {
-        for (int i = 0; i < job->imagetypes.size(); i++)
+        for (unsigned i = 0; i < job->imagetypes.size(); i++)
         {
             delete job->images[i];
         }
@@ -182,7 +182,7 @@ int GfxProc::checkevents(Waiter *)
     SymmCipher key;
     while (job = responses.pop())
     {
-        for (int i = 0; i < job->images.size(); i++)
+        for (unsigned i = 0; i < job->images.size(); i++)
         {
             if (job->images[i])
             {
@@ -314,7 +314,7 @@ int GfxProc::gendimensionsputfa(FileAccess* fa, string* localfilename, handle th
 
     requests.push(job);
     waiter.notify();
-    return job->imagetypes.size();
+    return int(job->imagetypes.size());
 }
 
 bool GfxProc::savefa(string *localfilepath, int width, int height, string *localdstpath)
@@ -358,7 +358,7 @@ bool GfxProc::savefa(string *localfilepath, int width, int height, string *local
         return false;
     }
 
-    if (!f->fwrite((const byte*)jpeg.data(), jpeg.size(), 0))
+    if (!f->fwrite((const byte*)jpeg.data(), unsigned(jpeg.size()), 0))
     {
         delete f;
         return false;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -712,7 +712,7 @@ void MegaClient::confirmrecoverylink(const char *code, const char *email, const 
         string buffer = "mega.nz";
         buffer.resize(200, 'P');
         buffer.append((char *)clientkey, sizeof(clientkey));
-        hasher.add((const byte*)buffer.data(), buffer.size());
+        hasher.add((const byte*)buffer.data(), unsigned(buffer.size()));
         hasher.get(&salt);
 
         byte derivedKey[2 * SymmCipher::KEYLENGTH];
@@ -3118,7 +3118,7 @@ bool MegaClient::dispatch(direction_t d)
                 nexttransfer->pos = 0;
                 nexttransfer->progresscompleted = 0;
 
-                if (d == GET || nexttransfer->cachedtempurl.size())
+                if (d == GET || nexttransfer->tempurl.size())
                 {
                     m_off_t p = 0;
 
@@ -3207,11 +3207,9 @@ bool MegaClient::dispatch(direction_t d)
                 }
 
                 // dispatch request for temporary source/target URL
-                if (nexttransfer->cachedtempurl.size())
+                if (nexttransfer->tempurl.size())
                 {
                     app->transfer_prepare(nexttransfer);
-                    ts->tempurl =  nexttransfer->cachedtempurl;
-                    nexttransfer->cachedtempurl.clear();
                 }
                 else
                 {
@@ -9598,7 +9596,7 @@ error MegaClient::changepw(const char* password, const char *pin)
     string buffer = "mega.nz";
     buffer.resize(200, 'P');
     buffer.append((char *)clientRandomValue, sizeof(clientRandomValue));
-    hasher.add((const byte*)buffer.data(), buffer.size());
+    hasher.add((const byte*)buffer.data(), unsigned(buffer.size()));
     hasher.get(&salt);
 
     byte derivedKey[2 * SymmCipher::KEYLENGTH];
@@ -9672,7 +9670,7 @@ string MegaClient::sendsignuplink2(const char *email, const char *password, cons
     string buffer = "mega.nz";
     buffer.resize(200, 'P');
     buffer.append((char *)clientrandomvalue, sizeof(clientrandomvalue));
-    hasher.add((const byte*)buffer.data(), buffer.size());
+    hasher.add((const byte*)buffer.data(), unsigned(buffer.size()));
     hasher.get(&salt);
 
     byte derivedKey[2 * SymmCipher::KEYLENGTH];
@@ -12332,7 +12330,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes)
                 if ((d == GET && !t->pos) || ((m_time() - t->lastaccesstime) >= 172500))
                 {
                     LOG_warn << "Discarding temporary URL (" << t->pos << ", " << t->lastaccesstime << ")";
-                    t->cachedtempurl.clear();
+                    t->tempurl.clear();
 
                     if (d == PUT)
                     {
@@ -12369,7 +12367,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes)
                         if (f->genfingerprint(fa))
                         {
                             LOG_warn << "The local file has been modified";
-                            t->cachedtempurl.clear();
+                            t->tempurl.clear();
                             t->chunkmacs.clear();
                             t->progresscompleted = 0;
                             delete [] t->ultoken;
@@ -12514,7 +12512,6 @@ void MegaClient::setmaxconnections(direction_t d, int num)
                 {
                     slot->transfer->state = TRANSFERSTATE_QUEUED;
                     slot->transfer->bt.arm();
-                    slot->transfer->cachedtempurl = slot->tempurl;
                     delete slot;
                 }
             }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -697,6 +697,53 @@ const char* Node::displayname() const
     return it->second.c_str();
 }
 
+string Node::displaypath() const
+{
+    // factored from nearly identical functions in megapi_impl and megacli
+    string path;
+    const Node* n = this;
+    for (; n; n = n->parent)
+    {
+        switch (n->type)
+        {
+        case FOLDERNODE:
+            path.insert(0, n->displayname());
+
+            if (n->inshare)
+            {
+                path.insert(0, ":");
+                if (n->inshare->user)
+                {
+                    path.insert(0, n->inshare->user->email);
+                }
+                else
+                {
+                    path.insert(0, "UNKNOWN");
+                }
+                return path;
+            }
+            break;
+
+        case INCOMINGNODE:
+            path.insert(0, "//in");
+            return path;
+
+        case ROOTNODE:
+            return path.empty() ? "/" : path;
+
+        case RUBBISHNODE:
+            path.insert(0, "//bin");
+            return path;
+
+        case TYPE_UNKNOWN:
+        case FILENODE:
+            path.insert(0, n->displayname());
+        }
+        path.insert(0, "/");
+    }
+    return path;
+}
+
 // returns position of file attribute or 0 if not present
 int Node::hasfileattribute(fatype t) const
 {

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -600,7 +600,7 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
     if (initializing || fullscan)
     {
         // find corresponding LocalNode by file-/foldername
-        int lastpart = client->fsaccess->lastpartlocal(localname ? localpath : &tmppath);
+        size_t lastpart = client->fsaccess->lastpartlocal(localname ? localpath : &tmppath);
 
         string fname(localname ? *localpath : tmppath,
                      lastpart,


### PR DESCRIPTION
object.
Updated some sync tests, and made some changes to move it closer to
building on Linux.
Addressed a few warnings under vc++ 32/64 bit.
Disabled checked iterators under vc++ debug builds, as it's just too
slow when we store an iterator to each node - the implementation stores
pointers to those in a linked list.