### PR TITLE
discard returned value in Win32Thread::run to avoid invalid (void *) …

### DIFF
--- a/src/thread/win32thread.cpp
+++ b/src/thread/win32thread.cpp
@@ -39,8 +39,9 @@ Win32Thread::Win32Thread()
 
 DWORD WINAPI Win32Thread::run(LPVOID lpParameter)
 {
-	Win32Thread *object = (Win32Thread *)lpParameter;
-	return (DWORD)object->start_routine(object->pointer);
+    Win32Thread *object = (Win32Thread *)lpParameter;
+    object->start_routine(object->pointer);
+    return 0;
 }
 
 void Win32Thread::start(void *(*start_routine)(void*), void *parameter)


### PR DESCRIPTION
…-> DWORD cast