### PR TITLE
Hotfix: Call notifypurge() before a possible commit to the local database.

### DIFF
--- a/include/mega/db.h
+++ b/include/mega/db.h
@@ -73,7 +73,7 @@ public:
 
 struct MEGA_API DbAccess
 {
-    static const int LEGACY_DB_VERSION = 10;
+    static const int LEGACY_DB_VERSION = 11;
     static const int DB_VERSION = LEGACY_DB_VERSION + 1;
 
     DbAccess();

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1495,6 +1495,7 @@ void MegaClient::exec()
                                 delete pendingcs;
                                 pendingcs = NULL;
 
+                                notifypurge();
                                 if (sctable && pendingsccommit && !reqs.cmdspending())
                                 {
                                     LOG_debug << "Executing postponed DB commit";


### PR DESCRIPTION
Force a reload to fix possible inconsistencies caused by this bug.