### PR TITLE
Support for MEGAcmd to not use `readline` on WIN32

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -50,6 +50,10 @@ else(WIN32)
     set(NO_READLINE 0)
 endif(WIN32)
 
+if (ENABLE_CHAT AND NOT USE_SODUIM)
+    message(FATAL_ERROR "ENABLE_CHAT requires USE_SODIUM")
+endif()
+
 if(build_64_bit)
     project (MegaSDK64 LANGUAGES CXX C)
 else(build_64_bit)

--- a/include/mega/thread.h
+++ b/include/mega/thread.h
@@ -41,6 +41,15 @@ public:
     virtual void unlock() = 0;
 };
 
+class MutexGuard
+{
+    Mutex& m;
+public:
+    MutexGuard(Mutex& cm) : m(cm) { m.lock(); }
+    ~MutexGuard() { m.unlock(); }
+};
+
+
 class Semaphore
 {
 public:

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -45,6 +45,10 @@ typedef char __static_check_01__[sizeof(bool) == sizeof(char) ? 1 : -1];
 #include "mega/posix/megasys.h"
 #endif
 
+#if USE_CRYPTOPP
+#include <cryptopp/config.h> // so we can test CRYPTO_VERSION below
+#endif
+
 // signed 64-bit generic offset
 typedef int64_t m_off_t;
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -45,7 +45,7 @@ typedef char __static_check_01__[sizeof(bool) == sizeof(char) ? 1 : -1];
 #include "mega/posix/megasys.h"
 #endif
 
-#if USE_CRYPTOPP
+#ifdef USE_CRYPTOPP
 #include <cryptopp/config.h> // so we can test CRYPTO_VERSION below
 #endif
 
@@ -57,7 +57,7 @@ typedef uint64_t fsfp_t;
 
 namespace mega {
 // within ::mega namespace, byte is unsigned char (avoids ambiguity when std::byte from c++17 and perhaps other defined ::byte are available)
-#if USE_CRYPTOPP && (CRYPTOPP_VERSION >= 600) && (__cplusplus >= 201103L)
+#if defined(USE_CRYPTOPP) && (CRYPTOPP_VERSION >= 600) && (__cplusplus >= 201103L)
 using byte = CryptoPP::byte;
 #elif __RPCNDR_H_VERSION__ != 500
 typedef unsigned char byte;

--- a/include/mega/win32/autocomplete.h
+++ b/include/mega/win32/autocomplete.h
@@ -65,6 +65,7 @@ namespace autocomplete {
             quoted_word(const std::string &, const quoting&);
             std::string s;
             quoting q;
+            string getQuoted();
         };
 
         std::vector<quoted_word> words;
@@ -205,10 +206,11 @@ namespace autocomplete {
         size_t unixListCount = 0;
         unsigned calcUnixColumnWidthInGlyphs(int col, int rows);
         const string& unixColumnEntry(int row, int col, int rows);
+        void tidyCompletions();
     };
 
     // helper function - useful in megacli for now
-    ACState prepACState(const std::string line, size_t insertPos, ACN syntax, bool unixStyle);
+    ACState prepACState(const std::string line, size_t insertPos, bool unixStyle);
 
     // get a list of possible strings at the current cursor position
     CompletionState autoComplete(const std::string line, size_t insertPos, ACN syntax, bool unixStyle);
@@ -218,7 +220,7 @@ namespace autocomplete {
     void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth, CompletionTextOut& consoleOutput);
 
     // execute the function attached to the matching syntax
-    void autoExec(const std::string line, size_t insertPos, ACN syntax, bool unixStyle, string& consoleOutput);
+    bool autoExec(const std::string line, size_t insertPos, ACN syntax, bool unixStyle, string& consoleOutput, bool reportNoMatch);
 
     // functions to bulid command descriptions
     ACN either(ACN n1 = nullptr, ACN n2 = nullptr, ACN n3 = nullptr, ACN n4 = nullptr);

--- a/include/mega/win32/megaconsole.h
+++ b/include/mega/win32/megaconsole.h
@@ -49,6 +49,9 @@ struct MEGA_API ConsoleModel
 
     // If using autocomplete, client to specify the syntax of commands here so we know what.  Assign to this directly
     ::mega::autocomplete::ACN autocompleteSyntax;
+    
+    // If supplied, autocomplete will try to get additional completions from this function (eg for consulting MEGAcmd's server)
+    std::function<vector<autocomplete::ACState::Completion>(string)> autocompleteFunction;
 
     // a buffer to store characters received from keypresses.  After a newline is received, we 
     // don't check for keypresses anymore until that line is consumed.
@@ -95,6 +98,7 @@ struct MEGA_API ConsoleModel
 
     // client can check this after adding characters or performing actions to see if the user submitted the line for processing 
     bool checkForCompletedInputLine(std::wstring& ws);
+    std::wstring getInputLineToCursor(); 
 
 private:
     autocomplete::CompletionState autocompleteState;
@@ -127,6 +131,7 @@ struct MEGA_API WinConsole : public Console
     bool setShellConsole(UINT codepage = CP_UTF8, UINT failover_codepage = CP_UTF8);
     void getShellCodepages(UINT& codepage, UINT& failover_codepage);
     void setAutocompleteSyntax(autocomplete::ACN);
+    void setAutocompleteFunction(std::function<vector<autocomplete::ACState::Completion>(string)>);
     void setAutocompleteStyle(bool unix);
     bool getAutocompleteStyle() const;
     bool consolePeek();

--- a/src/win32/autocomplete.cpp
+++ b/src/win32/autocomplete.cpp
@@ -907,6 +907,11 @@ void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth, C
             s.line.replace(s.wordPos.first, s.wordPos.second - s.wordPos.first, w);
             s.wordPos.second = int(w.size() + s.wordPos.first);
             s.lastAppliedIndex = index;
+
+            if (s.completions.size()==1 && c.s.size() && c.s.at(c.s.size()-1) == '=')
+            {
+                s.active = false;
+            }
         }
         else
         {

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -21,6 +21,7 @@
 
 #include "sdk_test.h"
 #include "megaapi_impl.h"
+#include <algorithm>
 
 #ifdef _WIN32
 #include <filesystem>
@@ -2105,7 +2106,7 @@ TEST_F(SdkTest, SdkTestShares)
 */
 #ifdef WIN32
 
-bool cmp(const autocomplete::CompletionState& c, const std::vector<std::string>& s)
+bool cmp(const autocomplete::CompletionState& c, std::vector<std::string>& s)
 {
     bool result = true;
     if (c.completions.size() != s.size())
@@ -2114,6 +2115,7 @@ bool cmp(const autocomplete::CompletionState& c, const std::vector<std::string>&
     }
     else
     {
+        std::sort(s.begin(), s.end());
         for (size_t i = c.completions.size(); i--; )
         {
             if (c.completions[i].s != s[i])


### PR DESCRIPTION
Instead it can use our unicode-friendly WinConsole
Added MutexGuard, a very simple RAII way to lock one of our mutexes on
construction, and unlock automatically on exit from the scope
Added an option to specify a function to fetch additional completion
options for a command line, and merge them in our autocomplete code.