### PR TITLE
Path and nodehande for MegaUserAlerts

### DIFF
--- a/include/mega/useralerts.h
+++ b/include/mega/useralerts.h
@@ -154,6 +154,7 @@ namespace UserAlert
     struct DeletedShare : public Base
     {
         handle folderHandle;
+        string folderPath;
         string folderName;
         handle removerHandle;
         string removerEmail;

--- a/include/mega/useralerts.h
+++ b/include/mega/useralerts.h
@@ -101,6 +101,8 @@ namespace UserAlert
 
         // look up the userEmail again in case it wasn't available before (or was changed)
         virtual void updateEmail(MegaClient* mc);
+
+        virtual bool checkprovisional(handle ou, MegaClient* mc);
     };
 
     struct IncomingPendingContact : public Base
@@ -122,6 +124,7 @@ namespace UserAlert
         ContactChange(UserAlertRaw& un, unsigned int id);
         ContactChange(int c, handle uh, const string& email, m_time_t timestamp, unsigned int id);
         virtual void text(string& header, string& title, MegaClient* mc);
+        virtual bool checkprovisional(handle ou, MegaClient* mc);
     };
 
     struct UpdatedPendingContactIncoming : public Base
@@ -255,6 +258,8 @@ private:
     handle lsn, fsn;
     m_time_t lastTimeDelta;
     UserAlertFlags flags;
+    bool provisionalmode;
+    std::vector<UserAlert::Base*> provisionals;
 
     struct ff {
         int files; 
@@ -289,6 +294,10 @@ public:
     void noteSharedNode(handle user, int type, m_time_t timestamp, Node* n);
     void convertNotedSharedNodes(bool added);
     void ignoreNextSharedNodesUnder(handle h);
+
+    // enter provisional mode, added items will be checked for suitability before actually adding 
+    void startprovisional();
+    void evalprovisional(handle originatinguser);
 
     // marks all as seen, and notifies the API also
     void acknowledgeAll();

--- a/include/mega/useralerts.h
+++ b/include/mega/useralerts.h
@@ -169,9 +169,10 @@ namespace UserAlert
     struct NewSharedNodes : public Base
     {
         unsigned fileCount, folderCount;
+        handle parentHandle;
 
         NewSharedNodes(UserAlertRaw& un, unsigned int id);
-        NewSharedNodes(int nfolders, int nfiles, handle uh, m_time_t timestamp, unsigned int id);
+        NewSharedNodes(int nfolders, int nfiles, handle uh, handle ph, m_time_t timestamp, unsigned int id);
         virtual void text(string& header, string& title, MegaClient* mc);
     };
 
@@ -261,8 +262,9 @@ private:
         m_time_t timestamp;
         ff() : files(0), folders(0), timestamp(0) {}
     };
-    map<handle, ff> notedSharedNodes;
+    map<pair<handle, handle>, ff> notedSharedNodes;
     bool notingSharedNodes;
+    handle ignoreNodesUnderShare;
 
     bool isUnwantedAlert(nameid type, int action);
 
@@ -284,8 +286,9 @@ public:
 
     // keep track of incoming nodes in shares, and convert to a notification
     void beginNotingSharedNodes();
-    void noteSharedNode(handle user, int type, m_time_t timestamp);
+    void noteSharedNode(handle user, int type, m_time_t timestamp, Node* n);
     void convertNotedSharedNodes(bool added);
+    void ignoreNextSharedNodesUnder(handle h);
 
     // marks all as seen, and notifies the API also
     void acknowledgeAll();

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1445,6 +1445,20 @@ public:
     virtual const char* getPath() const;
 
     /**
+     * @brief Returns the name of a file, folder, or node related to the alert
+     *
+     * The SDK retains the ownership of the returned value. It will be valid until
+     * the MegaUserAlert object is deleted.
+     *
+     * This value is valid for those alerts that relate to a single name, provided
+     * it could be looked up from the cached nodes at the time the alert arrived.
+     * Otherwise, it may be obtainable via the nodeHandle.
+     *
+     * @return the name string if relevant and available, otherwise NULL
+     */
+    virtual const char* getName() const;
+
+    /**
     * @brief Returns the heading related to this alert
     *
     * The SDK retains the ownership of the returned value. They will be valid until

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -549,6 +549,7 @@ public:
     virtual MegaHandle getNodeHandle() const;
     virtual const char* getEmail() const;
     virtual const char* getPath() const;
+    virtual const char* getName() const;
     virtual const char* getHeading() const;
     virtual const char* getTitle() const;
     virtual int64_t getNumber(unsigned index) const;
@@ -566,6 +567,7 @@ protected:
     string email;
     handle nodeHandle;
     string nodePath;
+    string nodeName;
     vector<int64_t> numbers;
     vector<int64_t> timestamps;
     vector<string> extraStrings;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -586,6 +586,11 @@ const char* MegaUserAlert::getPath() const
     return NULL;
 }
 
+const char *MegaUserAlert::getName() const
+{
+    return NULL;
+}
+
 const char *MegaUserAlert::getHeading() const
 {
     return NULL;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -1648,6 +1648,11 @@ MegaUserAlertPrivate::MegaUserAlertPrivate(UserAlert::Base *b, MegaClient* mc)
         type = TYPE_NEWSHARE;
         userHandle = p->userHandle;
         email = p->userEmail;
+        nodeHandle = p->folderhandle;
+        if (Node* node = mc->nodebyhandle(p->folderhandle))
+        {
+            nodePath = node->displaypath();
+        }
     }
     break;
     case UserAlert::type_dshare:
@@ -1656,6 +1661,8 @@ MegaUserAlertPrivate::MegaUserAlertPrivate(UserAlert::Base *b, MegaClient* mc)
         type = TYPE_DELETEDSHARE;
         userHandle = p->userHandle;
         email = p->userEmail;
+        nodePath = p->folderName;
+        nodeHandle = p->folderHandle;
     }
     break;
     case UserAlert::type_put:

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -1673,6 +1673,7 @@ MegaUserAlertPrivate::MegaUserAlertPrivate(UserAlert::Base *b, MegaClient* mc)
         type = TYPE_NEWSHAREDNODES;
         userHandle = p->userHandle;
         email = p->userEmail;
+        nodeHandle = p->parentHandle;
         numbers.push_back(p->folderCount);
         numbers.push_back(p->fileCount);
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -1652,6 +1652,7 @@ MegaUserAlertPrivate::MegaUserAlertPrivate(UserAlert::Base *b, MegaClient* mc)
         if (Node* node = mc->nodebyhandle(p->folderhandle))
         {
             nodePath = node->displaypath();
+            nodeName = node->displayname();
         }
     }
     break;
@@ -1661,7 +1662,8 @@ MegaUserAlertPrivate::MegaUserAlertPrivate(UserAlert::Base *b, MegaClient* mc)
         type = TYPE_DELETEDSHARE;
         userHandle = p->userHandle;
         email = p->userEmail;
-        nodePath = p->folderName;
+        nodePath = p->folderPath;
+        nodeName = p->folderName;
         nodeHandle = p->folderHandle;
     }
     break;
@@ -1714,6 +1716,7 @@ MegaUserAlertPrivate::MegaUserAlertPrivate(UserAlert::Base *b, MegaClient* mc)
         if (node)
         {
             nodePath = node->displaypath();
+            nodeName = node->displayname();
         }
     }
     break;
@@ -1792,6 +1795,11 @@ const char* MegaUserAlertPrivate::getEmail() const
 const char*MegaUserAlertPrivate::getPath() const
 {
     return  nodePath.empty() ? NULL : nodePath.c_str();
+}
+
+const char *MegaUserAlertPrivate::getName() const
+{
+    return  nodeName.empty() ? NULL : nodeName.c_str();
 }
 
 const char *MegaUserAlertPrivate::getHeading() const

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4905,15 +4905,23 @@ void MegaClient::sc_paymentreminder()
 // u:[{c/m/ts}*] - Add/modify user/contact
 void MegaClient::sc_contacts()
 {
+    handle ou = UNDEF;
+
     for (;;)
     {
         switch (jsonsc.getnameid())
         {
             case 'u':
+                useralerts.startprovisional();
                 readusers(&jsonsc, true);
                 break;
 
+            case MAKENAMEID2('o', 'u'):
+                ou = jsonsc.gethandle(MegaClient::USERHANDLE);
+                break;
+
             case EOO:
+                useralerts.evalprovisional(ou);
                 return;
 
             default:

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3843,7 +3843,10 @@ bool MegaClient::procsc()
 
                         // now that we have loaded cached state, and caught up actionpackets since that state 
                         // (or just fetched everything if there was no cache), our next sc request can be for useralerts
-                        useralerts.begincatchup = true;
+                        if (!ISUNDEF(me))
+                        {
+                            useralerts.begincatchup = true;
+                        }
                     }
                     return true;
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4786,13 +4786,14 @@ bool MegaClient::sc_shares()
                         {
                             User* u = finduser(oh);
                             useralerts.add(new UserAlert::NewShare(h, oh, u ? u->email : "", ts, useralerts.nextId()));
+                            useralerts.ignoreNextSharedNodesUnder(h);  // no need to alert on nodes already in the new share, which are delivered next
                         }
 
                         // new share - can be inbound or outbound
                         newshares.push_back(new NewShare(h, outbound,
                                                          outbound ? uh : oh,
                                                          r, ts, sharekey,
-                                                         have_ha ? ha : NULL, 
+                                                         have_ha ? ha : NULL,
                                                          p, upgrade_pending_to_full));
 
                         //Returns false because as this is a new share, the node
@@ -6885,7 +6886,7 @@ int MegaClient::readnodes(JSON* j, int notify, putsource_t source, NewNode* nn, 
 
                 if (u != me && !ISUNDEF(u) && !fetchingnodes)
                 {
-                    useralerts.noteSharedNode(u, t, ts);
+                    useralerts.noteSharedNode(u, t, ts, n);
                 }
 
                 if (nn && nni >= 0 && nni < nnsize)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5368,7 +5368,7 @@ void MegaClient::sc_upc(bool incoming)
     m_time_t uts = 0;
     int s = 0;
     const char *m = NULL;
-    handle p = UNDEF;
+    handle p = UNDEF, ou = UNDEF;
     PendingContactRequest *pcr;
 
     bool done = false;
@@ -5387,6 +5387,9 @@ void MegaClient::sc_upc(bool incoming)
                 break;
             case 'p':
                 p = jsonsc.gethandle(MegaClient::PCRHANDLE);
+                break;
+            case MAKENAMEID2('o', 'u'):
+                ou = jsonsc.gethandle(MegaClient::PCRHANDLE);
                 break;
             case EOO:
                 done = true;
@@ -5440,7 +5443,7 @@ void MegaClient::sc_upc(bool incoming)
                     pcr->uts = uts;
                 }
 
-                if (statecurrent)
+                if (statecurrent && ou != me)
                 {
                     string email;
                     Node::copystring(&email, m);

--- a/src/treeproc.cpp
+++ b/src/treeproc.cpp
@@ -79,7 +79,7 @@ void TreeProcDel::proc(MegaClient* client, Node* n)
     client->notifynode(n);
     if (n->owner != client->me)
     {
-        client->useralerts.noteSharedNode(n->owner, n->type, 0);
+        client->useralerts.noteSharedNode(n->owner, n->type, 0, NULL);
     }
 }
 

--- a/src/useralerts.cpp
+++ b/src/useralerts.cpp
@@ -388,7 +388,8 @@ void UserAlert::DeletedShare::updateEmail(MegaClient* mc)
 
     if (Node* n = mc->nodebyhandle(folderHandle))
     {
-        folderName = n->displaypath();
+        folderPath = n->displaypath();
+        folderName = n->displayname();
     }
 }
 

--- a/src/useralerts.cpp
+++ b/src/useralerts.cpp
@@ -808,6 +808,7 @@ void UserAlerts::add(UserAlert::Base* unb)
         }
     }
 
+    unb->updateEmail(&mc);
     alerts.push_back(unb);
     if (catchupdone)
     {

--- a/src/useralerts.cpp
+++ b/src/useralerts.cpp
@@ -93,16 +93,23 @@ bool UserAlertRaw::gethandletypearray(nameid nid, vector<handletype>& v) const
                 handletype ht;
                 ht.h = UNDEF;
                 ht.t = -1;
-                switch (j.getnameid())
+                bool fields = true;
+                while (fields)
                 {
-                case 'h':
-                    ht.h = j.gethandle(MegaClient::NODEHANDLE);
-                    break;
-                case 't':
-                    ht.t = int(j.getint());
-                    break;
-                default:
-                    j.storeobject(NULL);
+                    switch (j.getnameid())
+                    {
+                    case 'h':
+                        ht.h = j.gethandle(MegaClient::NODEHANDLE);
+                        break;
+                    case 't':
+                        ht.t = int(j.getint());
+                        break;
+                    case EOO:
+                        fields = false;
+                        break;
+                    default:
+                        j.storeobject(NULL);
+                    }
                 }
                 v.push_back(ht);
                 j.leaveobject();

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1946,6 +1946,16 @@ TEST_F(SdkTest, SdkTestShares)
 
     delete nl;
 
+    // check the corresponding user alert
+    {
+        MegaUserAlertList* list = megaApi[1]->getUserAlerts();
+        ASSERT_TRUE(list->size() > 1);
+        MegaUserAlert* a = list->get(list->size() - 2);  // back past the 'added 2 folders and 1 file'
+        ASSERT_STREQ(a->getTitle(), ("New shared folder from " + email[0]).c_str());
+        ASSERT_STREQ(a->getPath(), (email[0] + ":Shared-folder").c_str());
+        ASSERT_NE(a->getNodeHandle(), UNDEF);
+        delete list;
+    }
 
     // --- Modify the access level of an outgoing share ---
 
@@ -1982,6 +1992,16 @@ TEST_F(SdkTest, SdkTestShares)
     ASSERT_EQ(0, nl->size()) << "Incoming share revocation failed";
     delete nl;
 
+    // check the corresponding user alert
+    {
+        MegaUserAlertList* list = megaApi[1]->getUserAlerts();
+        ASSERT_TRUE(list->size() > 0);
+        MegaUserAlert* a = list->get(list->size() - 1);
+        ASSERT_STREQ(a->getTitle(), ("Access to folders shared by " + email[0] + " was removed").c_str());
+        ASSERT_STREQ(a->getPath(), (email[0] + ":Shared-folder").c_str());
+        ASSERT_NE(a->getNodeHandle(), UNDEF);
+        delete list;
+    }
 
     // --- Get pending outgoing shares ---
 

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1958,8 +1958,10 @@ TEST_F(SdkTest, SdkTestShares)
     }
 
     // add a folder under the share
-    ASSERT_NO_FATAL_FAILURE(createFolder(0, "dummyname1", megaApi[0]->getNodeByHandle(hfolder2)));
-    ASSERT_NO_FATAL_FAILURE(createFolder(0, "dummyname2", megaApi[0]->getNodeByHandle(hfolder2)));
+    char foldernameA[64] = "dummyname1";
+    char foldernameB[64] = "dummyname2";
+    ASSERT_NO_FATAL_FAILURE(createFolder(0, foldernameA, megaApi[0]->getNodeByHandle(hfolder2)));
+    ASSERT_NO_FATAL_FAILURE(createFolder(0, foldernameB, megaApi[0]->getNodeByHandle(hfolder2)));
 
     // check the corresponding user alert
     {

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -102,6 +102,8 @@ void WaitMillisec(unsigned n)
 #endif
 }
 
+enum { USERALERT_ARRIVAL_MILLISEC = 1000 };
+
 #ifdef WIN32
 #include "mega/win32/autocomplete.h"
 #include <filesystem>
@@ -1948,11 +1950,12 @@ TEST_F(SdkTest, SdkTestShares)
 
     // check the corresponding user alert
     {
+        WaitMillisec(USERALERT_ARRIVAL_MILLISEC);
         MegaUserAlertList* list = megaApi[1]->getUserAlerts();
         ASSERT_TRUE(list->size() > 0);
         MegaUserAlert* a = list->get(list->size() - 1);
-        ASSERT_STREQ(a->getTitle(), ("New shared folder from " + email[0]).c_str());
-        ASSERT_STREQ(a->getPath(), (email[0] + ":Shared-folder").c_str());
+        ASSERT_STREQ(("New shared folder from " + email[0]).c_str(), a->getTitle());
+        ASSERT_STREQ((email[0] + ":Shared-folder").c_str(), a->getPath());
         ASSERT_NE(a->getNodeHandle(), UNDEF);
         delete list;
     }
@@ -1965,7 +1968,7 @@ TEST_F(SdkTest, SdkTestShares)
 
     // check the corresponding user alert
     {
-        WaitMillisec(2000);
+        WaitMillisec(USERALERT_ARRIVAL_MILLISEC);
         MegaUserAlertList* list = megaApi[1]->getUserAlerts();
         ASSERT_TRUE(list->size() > 1);
         MegaUserAlert* a = list->get(list->size()-1);

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1971,6 +1971,7 @@ TEST_F(SdkTest, SdkTestShares)
         MegaUserAlert* a = list->get(list->size()-1);
         ASSERT_STREQ(a->getTitle(), (email[0] + " added 2 folders").c_str());
         ASSERT_EQ(a->getNodeHandle(), megaApi[0]->getNodeByHandle(hfolder2)->getHandle());
+        ASSERT_EQ(a->getNumber(0), 2); // 0 for number of folders
         delete list;
     }
 

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -1949,13 +1949,29 @@ TEST_F(SdkTest, SdkTestShares)
     // check the corresponding user alert
     {
         MegaUserAlertList* list = megaApi[1]->getUserAlerts();
-        ASSERT_TRUE(list->size() > 1);
-        MegaUserAlert* a = list->get(list->size() - 2);  // back past the 'added 2 folders and 1 file'
+        ASSERT_TRUE(list->size() > 0);
+        MegaUserAlert* a = list->get(list->size() - 1);
         ASSERT_STREQ(a->getTitle(), ("New shared folder from " + email[0]).c_str());
         ASSERT_STREQ(a->getPath(), (email[0] + ":Shared-folder").c_str());
         ASSERT_NE(a->getNodeHandle(), UNDEF);
         delete list;
     }
+
+    // add a folder under the share
+    ASSERT_NO_FATAL_FAILURE(createFolder(0, "dummyname1", megaApi[0]->getNodeByHandle(hfolder2)));
+    ASSERT_NO_FATAL_FAILURE(createFolder(0, "dummyname2", megaApi[0]->getNodeByHandle(hfolder2)));
+
+    // check the corresponding user alert
+    {
+        WaitMillisec(2000);
+        MegaUserAlertList* list = megaApi[1]->getUserAlerts();
+        ASSERT_TRUE(list->size() > 1);
+        MegaUserAlert* a = list->get(list->size()-1);
+        ASSERT_STREQ(a->getTitle(), (email[0] + " added 2 folders").c_str());
+        ASSERT_EQ(a->getNodeHandle(), megaApi[0]->getNodeByHandle(hfolder2)->getHandle());
+        delete list;
+    }
+
 
     // --- Modify the access level of an outgoing share ---
 


### PR DESCRIPTION
looked up at the earliest opportunity,
and copied from the core alert to the client object.