### PR TITLE
MEGAchat has clashing enums #defined in winhttp.h

### DIFF
--- a/contrib/cmake/build3rdparty.cmd
+++ b/contrib/cmake/build3rdparty.cmd
@@ -45,13 +45,17 @@ REM     REF v2.4.2
 REM     SHA512 
 REM     7bee49f6763ff3ab7861fcda25af8d80f6757c56e197ea42be53e0b2480969eee73de3aee5198f5ff06fd1cb8ab2be4c6495243e83cd0acc235b0da83b2353d1
 REM     HEAD_REF v2.4-stable
-REM and add libuv dependency (this might not be strictly necessary)
-REM     Feature: libuv
-REM     Build-Depends: libuv
-REM     Description: turns on LWS_WITH_LIBUU
-REM then use remove and install again.
 REM also find libwebsocket's CMakeLists.txt file and modify the libuv find_library, adding 'libuv' as that's what the libuv vcpkg produces:
 REM     find_library(LIBUV_LIBRARIES NAMES uv libuv)
+REM and add thse lines in the vcpkg_configure_cmake in its portfile:
+REM     -DLWS_WITH_LIBUV=ON
+REM     -DLIBUV_LIBRARIES=${CURRENT_PACKAGES_DIR}/lib
+REM     -DLIBUV_INCLUDE_DIR=${CURRENT_PACKAGES_DIR}/include
+REM possibly add libuv dependency (might not be necessary?)
+REM     Feature: libuv
+REM     Build-Depends: libuv
+REM     Description: turns on LWS_WITH_LIBUV
+REM then use remove and install again, building build libwebsockets[libuv].
 
 
 

--- a/contrib/cmake/build3rdparty.cmd
+++ b/contrib/cmake/build3rdparty.cmd
@@ -47,14 +47,11 @@ REM     7bee49f6763ff3ab7861fcda25af8d80f6757c56e197ea42be53e0b2480969eee73de3ae
 REM     HEAD_REF v2.4-stable
 REM also find libwebsocket's CMakeLists.txt file and modify the libuv find_library, adding 'libuv' as that's what the libuv vcpkg produces:
 REM     find_library(LIBUV_LIBRARIES NAMES uv libuv)
-REM and add thse lines in the vcpkg_configure_cmake in its portfile:
+REM and add these lines in the vcpkg_configure_cmake in its portfile (LWS_IPV6 replaces an existing line):
+REM     -DLWS_IPV6=OFF
 REM     -DLWS_WITH_LIBUV=ON
 REM     -DLIBUV_LIBRARIES=${CURRENT_PACKAGES_DIR}/lib
 REM     -DLIBUV_INCLUDE_DIR=${CURRENT_PACKAGES_DIR}/include
-REM possibly add libuv dependency (might not be necessary?)
-REM     Feature: libuv
-REM     Build-Depends: libuv
-REM     Description: turns on LWS_WITH_LIBUV
 REM then use remove and install again, building build libwebsockets[libuv].
 
 

--- a/include/mega/win32/meganet.h
+++ b/include/mega/win32/meganet.h
@@ -26,6 +26,8 @@
 #include "zlib.h"
 #include "mega.h"
 
+typedef LPVOID HINTERNET;   // from <winhttp.h>
+
 // MinGW shipped winhttp.h does not have these two flags
 #ifdef __MINGW32__
 #ifndef WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_1

--- a/include/mega/win32/megasys.h
+++ b/include/mega/win32/megasys.h
@@ -81,7 +81,6 @@
 
 #ifndef WINDOWS_PHONE
  #include <wincrypt.h>
- //#include <winhttp.h>  // #defines in here clash with enum http_status's HTTP_STATUS_CONTINUE in Karere lib's libwebsockets.h
  #include <shlwapi.h>
 #endif
 
@@ -89,11 +88,14 @@
 
 #define atoll _atoi64
 #define snprintf mega_snprintf
-#define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #define strtoull _strtoui64
 #if _MSC_VER <= 1800 && !defined (__MINGW32__)// Visual Studio 2013
 #define strtoll _strtoi64
+#endif
+
+#ifndef strcasecmp
+#define strcasecmp _stricmp
 #endif
 
 #ifndef _CRT_SECURE_NO_WARNINGS

--- a/include/mega/win32/megasys.h
+++ b/include/mega/win32/megasys.h
@@ -81,7 +81,7 @@
 
 #ifndef WINDOWS_PHONE
  #include <wincrypt.h>
- #include <winhttp.h>
+ //#include <winhttp.h>  // #defines in here clash with enum http_status's HTTP_STATUS_CONTINUE in Karere lib's libwebsockets.h
  #include <shlwapi.h>
 #endif
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -25,6 +25,10 @@
 #include "mega/proxy.h"
 #include "mega/base64.h"
 
+#if defined(WIN32) && !defined(WINDOWS_PHONE)
+#include <winhttp.h>
+#endif
+
 #if defined(__APPLE__) && !(TARGET_OS_IPHONE)
 #include "mega/osx/osxutils.h"
 #endif

--- a/src/win32/net.cpp
+++ b/src/win32/net.cpp
@@ -23,6 +23,7 @@
 // after having read from the HTTP connection
 
 #include "meganet.h"
+#include <winhttp.h>
 
 namespace mega {
 


### PR DESCRIPTION
avoid #including winhttp.h until it's really needed as it #defines some symbols that are then used in an enum declaration in MEGAchat.