### PR TITLE
Reconnect if the lock request returns an unexpected response

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1973,12 +1973,12 @@ void MegaClient::exec()
                 else if (workinglockcs->in == "0")
                 {
                     sendevent(99425, "Timeout (server busy)", 0);
-
                     pendingcs->lastdata = Waiter::ds;
                 }
                 else
                 {
                     LOG_err << "Error in lock request: " << workinglockcs->in;
+                    disconnecttimestamp = Waiter::ds + HttpIO::CONNECTTIMEOUT;
                 }
 
                 delete workinglockcs;


### PR DESCRIPTION
instead of repeating the lock request in a loop without any backoff