### PR TITLE
login2() for megacli, autocomplete auto space too

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -71,8 +71,6 @@ using std::dec;
 MegaClient* client;
 MegaClient* clientFolder;
 
-// login e-mail address
-static string login;
 
 // new account signup e-mail address and name
 static string signupemail, signupname;
@@ -2238,13 +2236,56 @@ bool recursiveget(fs::path&& localpath, Node* n, bool folders, unsigned& queued)
 }
 #endif
 
+
+struct Login
+{
+    string email, password, salt, pin;
+    int version;
+
+    Login() : version(0)
+    {
+    }
+
+    void reset()
+    {
+        *this = Login();
+    }
+
+    void login(MegaClient* client)
+    {
+        byte pwkey[SymmCipher::KEYLENGTH];
+
+        if (version == 1)
+        {
+            if (error e = client->pw_key(password.c_str(), pwkey))
+            {
+                cout << "Login error: " << e << endl;
+            }
+            else
+            {
+                client->login(email.c_str(), pwkey, pin.c_str());
+            }
+        }
+        else if (version == 2 && !salt.empty())
+        {
+            client->login2(email.c_str(), password.c_str(), &salt, pin.c_str());
+        }
+        else
+        {
+            cout << "Login unexpected error" << endl;
+        }
+    }
+};
+static Login login;
+
+
 // execute command
 static void process_line(char* l)
 {
     switch (prompt)
     {
         case LOGINTFA:
-                client->login(login.c_str(), pwkey, l);
+                client->login(login.email.c_str(), pwkey, l);
                 setprompt(COMMAND);
                 return;
 
@@ -2254,11 +2295,11 @@ static void process_line(char* l)
                 return;
 
         case LOGINPASSWORD:
-            client->pw_key(l, pwkey);
 
             if (signupcode.size())
             {
                 // verify correctness of supplied signup password
+                client->pw_key(l, pwkey);
                 SymmCipher pwcipher(pwkey);
                 pwcipher.ecb_decrypt(signuppwchallenge);
 
@@ -2276,15 +2317,18 @@ static void process_line(char* l)
             }
             else if (recoverycode.size())   // cancelling account --> check password
             {
+                client->pw_key(l, pwkey);
                 client->validatepwd(pwkey);
             }
             else if (changecode.size())     // changing email --> check password to avoid creating an invalid hash
             {
+                client->pw_key(l, pwkey);
                 client->validatepwd(pwkey);
             }
             else
             {
-                client->login(login.c_str(), pwkey);
+                login.password = l;
+                login.login(client);
                 cout << endl << "Logging in..." << endl;
             }
 
@@ -3493,7 +3537,7 @@ static void process_line(char* l)
                     {
                         if (words.size() == 1)
                         {
-                            client->multifactorauthcheck(login.c_str());
+                            client->multifactorauthcheck(login.email.c_str());
                         }
                         else
                         {
@@ -3542,18 +3586,20 @@ static void process_line(char* l)
                                 }
                                 else if (strchr(words[1].c_str(), '@'))
                                 {
+                                    login.reset();
+                                    login.email = words[1];
+
                                     // full account login
                                     if (words.size() > 2)
                                     {
-                                        client->pw_key(words[2].c_str(), pwkey);
-                                        client->login(words[1].c_str(), pwkey);
+                                        login.password = words[2];
                                         cout << "Initiated login attempt..." << endl;
                                     }
                                     else
                                     {
-                                        login = words[1];
                                         setprompt(LOGINPASSWORD);
                                     }
+                                    client->prelogin(login.email.c_str());
                                 }
                                 else
                                 {
@@ -4189,7 +4235,7 @@ static void process_line(char* l)
 #ifdef ENABLE_CHAT
                     else if (words[0] == "chatc")
                     {
-                        unsigned wordscount = words.size();
+                        size_t wordscount = words.size();
                         if (wordscount < 2 || wordscount == 3)
                         {
                             cout << "Invalid syntax to create chatroom" << endl;
@@ -5011,7 +5057,7 @@ static void process_line(char* l)
                     }
                     else if (words[0] == "chatcp")
                     {
-                        unsigned wordscount = words.size();
+                        size_t wordscount = words.size();
                         if (wordscount < 2 || wordscount == 3)
                         {
                             cout << "Invalid syntax to create chatroom" << endl;
@@ -5799,7 +5845,7 @@ void DemoApp::multifactorauthsetup_result(string *code, error e)
             if (++attempts >= 3)
             {
                 attempts = 0;
-                cout << "Two many attempts"<< endl;
+                cout << "Too many attempts"<< endl;
                 setprompt(COMMAND);
             }
             else
@@ -5810,11 +5856,36 @@ void DemoApp::multifactorauthsetup_result(string *code, error e)
     }
 }
 
+
+void DemoApp::prelogin_result(int version, string* email, string *salt, error e)
+{
+    if (e)
+    {
+        cout << "Login error: " << e << endl;
+        setprompt(COMMAND);
+        return;
+    }
+
+    login.version = version;
+    login.salt = (version == 2 && salt ? *salt : string());
+    
+    if (login.password.empty())
+    {
+        setprompt(LOGINPASSWORD);
+    }
+    else
+    {
+        login.login(client);
+    }
+}
+
+
 // login result
 void DemoApp::login_result(error e)
 {
     if (!e)
     {
+        login.reset();
         cout << "Login successful, retrieving account..." << endl;
         client->fetchnodes();
     }
@@ -5824,6 +5895,7 @@ void DemoApp::login_result(error e)
     }
     else
     {
+        login.reset();
         cout << "Login failed: " << errorstring(e) << endl;
     }
 }

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -90,6 +90,7 @@ struct DemoApp : public MegaApp
     
     void request_response_progress(m_off_t, m_off_t);
     
+    void prelogin_result(int version, string* email, string *salt, error e);
     void login_result(error);
     void multifactorauthdisable_result(error);
     void multifactorauthsetup_result(string *code, error e);

--- a/include/mega/autocomplete.h
+++ b/include/mega/autocomplete.h
@@ -45,11 +45,12 @@ namespace autocomplete {
         struct Completion {
             std::string s;
             bool caseInsensitive = false;
-            inline Completion(const std::string& str, bool b) : s(str), caseInsensitive(b) {}
+            bool couldExtend = false;
+            inline Completion(const std::string& str, bool b, bool b2) : s(str), caseInsensitive(b), couldExtend(b2) {}
         };
 
         std::vector<Completion> completions;
-        void addCompletion(const std::string& s, bool caseInsenstive = false);
+        void addCompletion(const std::string& s, bool caseInsenstive = false, bool couldextend = false);
         void addPathCompletion(std::string&& f, const std::string& relativeRootPath, bool isFolder, char dir_sep, bool caseInsensitive);
 
         std::vector<std::pair<int, int>> wordPos;

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -128,7 +128,7 @@ string ACState::quoted_word::getQuoted()
     return qs;
 }
 
-void ACState::addCompletion(const std::string& s, bool caseInsensitive) 
+void ACState::addCompletion(const std::string& s, bool caseInsensitive, bool couldextend) 
 {
     // add if it matches the prefix. Doing the check here keeps subclasses simple
     assert(atCursor());
@@ -151,7 +151,7 @@ void ACState::addCompletion(const std::string& s, bool caseInsensitive)
             if ((s[0] == '-' && !prefix.empty() && prefix[0] == '-') ||
                 (s[0] != '-' && (prefix.empty() || prefix[0] != '-')))
             {
-                completions.emplace_back(s, caseInsensitive);
+                completions.emplace_back(s, caseInsensitive, couldextend);
             }
         }
     }
@@ -179,7 +179,7 @@ void ACState::addPathCompletion(std::string&& f, const std::string& relativeRoot
     {
         f.push_back(dir_sep);
     }
-    addCompletion(f, caseInsensitive);
+    addCompletion(f, caseInsensitive, isFolder);
 }
 
 std::ostream& operator<<(std::ostream& s, const ACNode& n)
@@ -1068,6 +1068,7 @@ void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth, C
             auto& c = s.completions[index];
             std::string w = c.s;
             s.originalWord.q.applyQuotes(w);
+            w += (s.completions.size() == 1 && !c.couldExtend) ? " " : "";
             s.line.replace(s.wordPos.first, s.wordPos.second - s.wordPos.first, w);
             s.wordPos.second = int(w.size() + s.wordPos.first);
             s.lastAppliedIndex = index;
@@ -1098,6 +1099,7 @@ void applyCompletion(CompletionState& s, bool forwards, unsigned consoleWidth, C
                     }
                 }
                 s.originalWord.q.applyQuotes(exactChars);
+                exactChars += (s.completions.size() == 1 && !s.completions[0].couldExtend) ? " " : "";
                 s.line.replace(s.wordPos.first, s.wordPos.second - s.wordPos.first, exactChars);
                 s.wordPos.second = int(exactChars.size() + s.wordPos.first);
                 s.firstPressDone = true;


### PR DESCRIPTION
Enable logging into newly created accounts that require login2() from megacli.

Also autocomplete will now add a space when there is only one result, but not for folder autocompletion (just on windows for now - linux to follow)