### PR TITLE
Fix for excess CPU relating to curl timeouts

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -1846,7 +1846,7 @@ public:
             t->source = NEW_NODE;
             t->type = n->type;
             t->nodehandle = n->nodehandle;
-            t->parenthandle = n->parent->nodehandle;
+            t->parenthandle = n->parent ? n->parent->nodehandle : UNDEF;
 
             // copy key (if file) or generate new key (if folder)
             if (n->type == FILENODE)

--- a/include/mega/posix/meganet.h
+++ b/include/mega/posix/meganet.h
@@ -43,7 +43,7 @@ struct MEGA_API SockInfo
     };
 
     SockInfo();
-    int fd;
+    curl_socket_t fd;
     int mode;
 #if defined(_WIN32)
     HANDLE handle;
@@ -143,7 +143,8 @@ protected:
     void processaresevents();
     void processcurlevents(direction_t d);
     std::vector<SockInfo> aressockets;
-    std::map<int, SockInfo> curlsockets[3];
+    typedef std::map<curl_socket_t, SockInfo> SockInfoMap;
+    SockInfoMap curlsockets[3];
     m_time_t curltimeoutreset[3];
     bool arerequestspaused[3];
     int numconnections[3];

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -576,8 +576,6 @@ void CurlHttpIO::processcurlevents(direction_t d)
     m_time_t *timeout = &curltimeoutreset[d];
     bool *paused = &arerequestspaused[d];
 
-    curl_multi_socket_action(curlm[d], CURL_SOCKET_TIMEOUT, 0, &dummy);
-
     for (SockInfoMap::iterator it = socketmap->begin(); !(*paused) && it != socketmap->end();)
     {
         SockInfo &info = (it++)->second;
@@ -798,7 +796,6 @@ void CurlHttpIO::addevents(Waiter* w, int)
         if (ds <= 0)
         {
             curltimeoutms = 0;
-            curltimeoutreset[API] = -1;
         }
         else
         {
@@ -827,7 +824,6 @@ void CurlHttpIO::addevents(Waiter* w, int)
                 if (ds <= 0)
                 {
                     curltimeoutms = 0;
-                    curltimeoutreset[d] = -1;
                 }
                 else
                 {

--- a/src/win32/waiter.cpp
+++ b/src/win32/waiter.cpp
@@ -36,6 +36,7 @@ WinWaiter::WinWaiter()
 #ifndef WINDOWS_PHONE
     if (!pGTC) 
     {
+        #pragma warning(suppress:4191)
         pGTC = (PGTC)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetTickCount64");
     }
 
@@ -108,13 +109,13 @@ int WinWaiter::wait()
         EnterCriticalSection(pcsHTTP);
     }
 
-    if ((dwWaitResult == WAIT_TIMEOUT) || (dwWaitResult == WAIT_IO_COMPLETION))
+    if ((dwWaitResult == WAIT_TIMEOUT) || (dwWaitResult == WAIT_IO_COMPLETION) || maxds == 0)
     {
         r = NEEDEXEC;
     }
-    else if ((dwWaitResult >= WAIT_OBJECT_0) && (dwWaitResult < WAIT_OBJECT_0 + flags.size()))
+    if ((dwWaitResult >= WAIT_OBJECT_0) && (dwWaitResult < WAIT_OBJECT_0 + flags.size()))
     {
-        r = flags[dwWaitResult - WAIT_OBJECT_0];
+        r |= flags[dwWaitResult - WAIT_OBJECT_0];
     }
 
     handles.clear();


### PR DESCRIPTION
The main changes are making sure the NEEDEXEC flag (and any others occuring) are set on timeout,
and calling curl_multi_action_socket for timeouts.
Also addressed 32/64 bit warnings in those files.