### PR TITLE
HOTFIX: stringAtIndex must returns a NSString using the getString(index)…

### DIFF
--- a/bindings/ios/MEGAUserAlert.mm
+++ b/bindings/ios/MEGAUserAlert.mm
@@ -122,7 +122,7 @@ using namespace mega;
 - (NSString *)stringAtIndex:(NSUInteger)index {
     if (!self.megaUserAlert) return nil;
     
-    return self.megaUserAlert->getString((unsigned int)index)? [[NSString alloc] initWithUTF8String:self.megaUserAlert->getEmail()] : nil;
+    return self.megaUserAlert->getString((unsigned int)index) ? [[NSString alloc] initWithUTF8String:self.megaUserAlert->getString((unsigned int)index)] : nil;
 }
 
 @end


### PR DESCRIPTION
… of the user alert instead the email