### PR TITLE
Prevent 'contact accepted' to match webclient

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5534,7 +5534,7 @@ void MegaClient::sc_upc(bool incoming)
                     pcr->uts = uts;
                 }
 
-                if (statecurrent && ou != me)
+                if (statecurrent && ou != me && (incoming || s != 2))
                 {
                     string email;
                     Node::copystring(&email, m);


### PR DESCRIPTION
In this case the 'contact established' alert is sufficient, and that is
all the webclient shows, and all that the condenseactions provides.