### PR TITLE
Clear peerlist upon own user's leave

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -5390,6 +5390,10 @@ void CommandChatRemove::procresult()
             if (uh == client->me)
             {
                 chat->priv = PRIV_RM;
+
+                // clear the list of peers (if re-invited, peers will be re-added)
+                delete chat->userpriv;
+                chat->userpriv = NULL;
             }
 
             chat->setTag(tag ? tag : -1);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5866,6 +5866,15 @@ void MegaClient::sc_chatupdate()
                             }
                         }
                     }
+
+                    if (chat->priv == PRIV_RM)
+                    {
+                        // clear the list of peers because API still includes peers in the
+                        // actionpacket, but not in a fresh fetchnodes
+                        delete userpriv;
+                        userpriv = NULL;
+                    }
+
                     delete chat->userpriv;  // discard any existing `userpriv`
                     chat->userpriv = userpriv;
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -9096,18 +9096,28 @@ void MegaClient::procmcf(JSON *j)
                                     // remove yourself from the list of users (only peers matter)
                                     if (userpriv)
                                     {
-                                        userpriv_vector::iterator upvit;
-                                        for (upvit = userpriv->begin(); upvit != userpriv->end(); upvit++)
+                                        if (chat->priv == PRIV_RM)
                                         {
-                                            if (upvit->first == me)
+                                            // clear the list of peers because API still includes peers in the
+                                            // actionpacket, but not in a fresh fetchnodes
+                                            delete userpriv;
+                                            userpriv = NULL;
+                                        }
+                                        else
+                                        {
+                                            userpriv_vector::iterator upvit;
+                                            for (upvit = userpriv->begin(); upvit != userpriv->end(); upvit++)
                                             {
-                                                userpriv->erase(upvit);
-                                                if (userpriv->empty())
+                                                if (upvit->first == me)
                                                 {
-                                                    delete userpriv;
-                                                    userpriv = NULL;
+                                                    userpriv->erase(upvit);
+                                                    if (userpriv->empty())
+                                                    {
+                                                        delete userpriv;
+                                                        userpriv = NULL;
+                                                    }
+                                                    break;
                                                 }
-                                                break;
                                             }
                                         }
                                     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -201,6 +201,12 @@ TextChat* TextChat::unserialize(class MegaClient *client, string *d)
 
             userpriv->push_back(userpriv_pair(uh, priv));
         }
+
+        if (priv == PRIV_RM)    // clear peerlist if removed
+        {
+            delete userpriv;
+            userpriv = NULL;
+        }
     }
 
     if (ptr + sizeof(bool) + sizeof(unsigned short) > end)


### PR DESCRIPTION
When the own user is removed/leaves a room, the API still includes the
peerlist in the actionpacket. However, the peerlist is not included in a
fresh fetchnodes. This commit aims to be consistent with API's state.
Also, it clears the peerlist if inactive chats are stored in cache.