### PR TITLE
Useralert notification for payment reminders

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -5244,6 +5244,14 @@ static void process_line(char* l)
                             {
                                 shownew = true;
                             }
+                            else if (words[1] == "test_reminder")
+                            {
+                                client->useralerts.add(new UserAlert::PaymentReminder(time(NULL) - 86000*3 /2, client->useralerts.nextId()));
+                            }
+                            else if (words[1] == "test_payment")
+                            {
+                                client->useralerts.add(new UserAlert::Payment(true, 1, time(NULL) + 86000 * 1, client->useralerts.nextId()));
+                            }
                             else if (atoi(words[1].c_str()) > 0)
                             {
                                 showN = atoi(words[1].c_str());


### PR DESCRIPTION
When a payment is made, the SDK will notify the app with any payment reminders that should no longer be shown.
The payment reminder useralert's getRelevant() function will return false to indicate it should be hidden.