### PR TITLE
Do not ignore IN_CREATE for files

### DIFF
--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -670,7 +670,7 @@ int PosixFileSystemAccess::checkevents(Waiter* w)
                 if (in->mask & (IN_CREATE | IN_DELETE | IN_MOVED_FROM
                               | IN_MOVED_TO | IN_CLOSE_WRITE | IN_EXCL_UNLINK))
                 {
-                    if ((in->mask & (IN_CREATE | IN_ISDIR)) != IN_CREATE)
+                    if (true || (in->mask & (IN_CREATE | IN_ISDIR)) != IN_CREATE)
                     {
                         it = wdnodes.find(in->wd);
 


### PR DESCRIPTION
given that certain ocassions (e.g: newer implementations of QFile::copy)
may not produce any other event for a file copied into a synched folder