### PR TITLE
WIP: 16343: do always notify in case of IN_MOVED_FROM

### DIFF
--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -118,6 +118,9 @@ public:
 
     PosixFileSystemAccess(int = -1);
     ~PosixFileSystemAccess();
+#ifdef ENABLE_SYNC
+    void notifyIfNotIgnore(int &r, std::string *ignore, unsigned int insize, const char* inname, LocalNode *localnode, bool immediate = false);
+#endif
 };
 
 #ifdef HAVE_AIO_RT

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -707,7 +707,10 @@ int PosixFileSystemAccess::checkevents(Waiter* w)
                             else
                             {
                                 lastcookie = 0;
+                            }
 
+                            //if (!(in->mask & IN_MOVED_FROM))
+                            {
                                 ignore = &it->second->sync->dirnotify->ignore;
                                 unsigned int insize = strlen(in->name);
 


### PR DESCRIPTION
prevents case when haste execution of "mv a b; rm b"
lead to unnoticed removal of a