### PR TITLE
Ability for `MegaNode::getOwner()`

### DIFF
--- a/bindings/ios/MEGANode.h
+++ b/bindings/ios/MEGANode.h
@@ -245,6 +245,11 @@ typedef NS_ENUM(NSUInteger, MEGANodeChangeType) {
 @property (readonly, nonatomic) NSString *publicLink;
 
 /**
+ * @brief The handle of the owner of the node.
+ */
+@property (readonly, nonatomic) uint64_t owner;
+
+/**
  * @brief Creates a copy of this MEGANode object.
  *
  * The resulting object is fully independent of the source MEGANode,

--- a/bindings/ios/MEGANode.mm
+++ b/bindings/ios/MEGANode.mm
@@ -157,6 +157,10 @@ using namespace mega;
     return self.megaNode ? [[MEGANode alloc] initWithMegaNode:self.megaNode->getPublicNode() cMemoryOwn:YES] : nil;
 }
 
+- (uint64_t)owner {
+    return self.megaNode ? self.megaNode->getOwner() : ::mega::INVALID_HANDLE;
+}
+
 - (BOOL)isFile {
     return self.megaNode ? self.megaNode->isFile() : NO;
 }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -1031,6 +1031,8 @@ class MegaNode
         virtual std::string getLocalPath();
 #endif
 
+        virtual MegaHandle getOwner() const;
+
         /**
          * @brief Provides a serialization of the MegaNode object
          *

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -392,7 +392,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
     public:
         MegaNodePrivate(const char *name, int type, int64_t size, int64_t ctime, int64_t mtime,
                         MegaHandle nodeMegaHandle, std::string *nodekey, std::string *attrstring, std::string *fileattrstring,
-                        const char *fingerprint, MegaHandle parentHandle = INVALID_HANDLE,
+                        const char *fingerprint, MegaHandle owner, MegaHandle parentHandle = INVALID_HANDLE,
                         const char *privateauth = NULL, const char *publicauth = NULL, bool isPublic = true,
                         bool isForeign = false, const char *chatauth = NULL);
 
@@ -453,7 +453,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
         virtual bool isOutShare();
         virtual bool isInShare();
         std::string* getSharekey();
-
+        virtual MegaHandle getOwner() const;
 
 #ifdef ENABLE_SYNC
         virtual bool isSyncDeleted();
@@ -505,6 +505,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
         double latitude;
         double longitude;
         MegaNodeList *children;
+        MegaHandle owner;
 
 #ifdef ENABLE_SYNC
         bool syncdeleted;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -466,6 +466,11 @@ MegaNodeList *MegaNode::getChildren()
     return NULL;
 }
 
+MegaHandle MegaNode::getOwner() const
+{
+    return INVALID_HANDLE;
+}
+
 char *MegaNode::serialize()
 {
     return NULL;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -631,7 +631,7 @@ MegaNodePrivate *MegaNodePrivate::unserialize(string *d)
         LOG_err << "MegaNodePrivate unserialization failed - invalid version";
         return NULL;
     }
-    ptr += 7;
+    ptr += 6;
 
     string chatauth;
     if (hasChatAuth)
@@ -660,8 +660,16 @@ MegaNodePrivate *MegaNodePrivate::unserialize(string *d)
     handle owner = INVALID_HANDLE;
     if (hasOwner)
     {
-        owner = MemAccess::get<handle>(ptr);
-        ptr += sizeof(handle);
+        if (ptr + sizeof(handle) <= end)
+        {
+            owner = MemAccess::get<handle>(ptr);
+            ptr += sizeof(handle);
+        }
+        else
+        {
+            LOG_err << "MegaNodePrivate unserialization failed - owner not found";
+            return NULL;
+        }
     }
 
     d->erase(0, ptr - d->data());

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -70,7 +70,7 @@
 namespace mega {
 
 MegaNodePrivate::MegaNodePrivate(const char *name, int type, int64_t size, int64_t ctime, int64_t mtime, uint64_t nodehandle,
-                                 string *nodekey, string *attrstring, string *fileattrstring, const char *fingerprint, MegaHandle parentHandle,
+                                 string *nodekey, string *attrstring, string *fileattrstring, const char *fingerprint, MegaHandle owner, MegaHandle parentHandle,
                                  const char *privateauth, const char *publicauth, bool ispublic, bool isForeign, const char *chatauth)
 : MegaNode()
 {
@@ -104,6 +104,7 @@ MegaNodePrivate::MegaNodePrivate(const char *name, int type, int64_t size, int64
     this->sharekey = NULL;
     this->foreign = isForeign;
     this->children = NULL;
+    this->owner = owner;
 
     if (privateauth)
     {
@@ -179,6 +180,7 @@ MegaNodePrivate::MegaNodePrivate(MegaNode *node)
     this->foreign = node->isForeign();
     this->sharekey = NULL;
     this->children = NULL;
+    this->owner = node->getOwner();
 
     if (node->isExported())
     {
@@ -336,6 +338,7 @@ MegaNodePrivate::MegaNodePrivate(Node *node)
     this->mtime = node->mtime;
     this->nodehandle = node->nodehandle;
     this->parenthandle = node->parent ? node->parent->nodehandle : INVALID_HANDLE;
+    this->owner = node->owner;
 
     if(node->attrstring)
     {
@@ -490,7 +493,10 @@ bool MegaNodePrivate::serialize(string *d)
     char hasChatAuth = (chatAuth && chatAuth[0]) ? 1 : 0;
     d->append((char *)&hasChatAuth, 1);
 
-    d->append("\0\0\0\0\0\0", 7);
+    char hasOwner = 1;
+    d->append((char *)&hasOwner, 1);
+
+    d->append("\0\0\0\0\0", 6);
 
     if (hasChatAuth)
     {
@@ -498,6 +504,8 @@ bool MegaNodePrivate::serialize(string *d)
         d->append((char*)&ll, sizeof(ll));
         d->append(chatAuth, ll);
     }
+
+    d->append((char *)&owner, sizeof(handle));
 
     return true;
 }
@@ -615,7 +623,10 @@ MegaNodePrivate *MegaNodePrivate::unserialize(string *d)
     char hasChatAuth = MemAccess::get<char>(ptr);
     ptr += sizeof(char);
 
-    if (memcmp(ptr, "\0\0\0\0\0\0", 7))
+    char hasOwner = MemAccess::get<handle>(ptr);
+    ptr += sizeof(char);
+
+    if (memcmp(ptr, "\0\0\0\0\0", 6))
     {
         LOG_err << "MegaNodePrivate unserialization failed - invalid version";
         return NULL;
@@ -646,11 +657,18 @@ MegaNodePrivate *MegaNodePrivate::unserialize(string *d)
         }
     }
 
+    handle owner = INVALID_HANDLE;
+    if (hasOwner)
+    {
+        owner = MemAccess::get<handle>(ptr);
+        ptr += sizeof(handle);
+    }
+
     d->erase(0, ptr - d->data());
 
     return new MegaNodePrivate(namelen ? name.c_str() : NULL, FILENODE, size, ctime,
                                mtime, nodehandle, &nodekey, &attrstring, &fileattrstring,
-                               fingerprintlen ? fingerprint.c_str() : NULL,
+                               fingerprintlen ? fingerprint.c_str() : NULL, owner,
                                parenthandle, privauth.c_str(), pubauth.c_str(),
                                isPublicNode, foreign, hasChatAuth ? chatauth.c_str() : NULL);
 }
@@ -1007,6 +1025,10 @@ int MegaNodePrivate::getChanges()
     return changed;
 }
 
+MegaHandle MegaNodePrivate::getOwner() const
+{
+    return owner;
+}
 
 const unsigned int MegaApiImpl::MAX_SESSION_LENGTH = 64;
 
@@ -9589,8 +9611,8 @@ MegaNode *MegaApiImpl::createForeignFileNode(MegaHandle handle, const char *key,
     string fileattrsting;
     nodekey.resize(strlen(key) * 3 / 4 + 3);
     nodekey.resize(Base64::atob(key, (byte *)nodekey.data(), int(nodekey.size())));
-    return new MegaNodePrivate(name, FILENODE, size, mtime, mtime, handle, &nodekey, &attrstring, &fileattrsting, NULL, parentHandle,
-                               privateauth, publicauth, false, true);
+    return new MegaNodePrivate(name, FILENODE, size, mtime, mtime, handle, &nodekey, &attrstring, &fileattrsting, NULL, INVALID_HANDLE,
+                               parentHandle, privateauth, publicauth, false, true);
 }
 
 MegaNode *MegaApiImpl::createForeignFolderNode(MegaHandle handle, const char *name, MegaHandle parentHandle, const char *privateauth, const char *publicauth)
@@ -9598,7 +9620,7 @@ MegaNode *MegaApiImpl::createForeignFolderNode(MegaHandle handle, const char *na
     string nodekey;
     string attrstring;
     string fileattrsting;
-    return new MegaNodePrivate(name, FOLDERNODE, 0, 0, 0, handle, &nodekey, &attrstring, &fileattrsting, NULL, parentHandle,
+    return new MegaNodePrivate(name, FOLDERNODE, 0, 0, 0, handle, &nodekey, &attrstring, &fileattrsting, NULL, INVALID_HANDLE, parentHandle,
                                privateauth, publicauth, false, true);
 }
 
@@ -29378,3 +29400,4 @@ int MegaTimeZoneDetailsPrivate::getDefault() const
 }
 
 }
+


### PR DESCRIPTION
Not always the owner of the node is the own user, even for nodes in the
own cloud (ie. files/folders created by another user in an outgoing
folder).