### PR TITLE
Minor fixes in documentation comments.

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -6053,7 +6053,7 @@ typedef NS_ENUM(NSUInteger, StorageState) {
  * Even if files are allowed to be served by this function, restrictions related to
  * other configuration options ([MEGASdk httpServerSetRestrictedMode]) are still applied.
  *
- * @param YES to allow to server files, NO to forbid it
+ * @param enable YES to allow to server files, NO to forbid it
  */
 - (void)httpServerEnableFileServer:(BOOL)enable;
 
@@ -6077,7 +6077,7 @@ typedef NS_ENUM(NSUInteger, StorageState) {
  * Even if folders are allowed to be served by this function, restrictions related to
  * other configuration options ([MEGASdk httpServerSetRestrictedMode]) are still applied.
  *
- * @param YES to allow to server folders, NO to forbid it
+ * @param enable YES to allow to server folders, NO to forbid it
  */
 - (void)httpServerEnableFolderServer:(BOOL)enable;
 
@@ -6125,7 +6125,7 @@ typedef NS_ENUM(NSUInteger, StorageState) {
  * other configuration options ([MEGASdk httpServerEnableFileServer],
  * [MEGASdk httpServerEnableFolderServer]) are still applied.
  *
- * @param Required state for the restricted mode of the HTTP proxy server
+ * @param mode Required state for the restricted mode of the HTTP proxy server
  */
 - (void)httpServerSetRestrictedMode:(NSInteger)mode;
 

--- a/include/mega/mega_ccronexpr.h
+++ b/include/mega/mega_ccronexpr.h
@@ -71,7 +71,7 @@ typedef struct {
  * 
  * @param expression cron expression as nul-terminated string,
  *        should be no longer that 256 bytes
- * @param pointer to cron expression structure, it's client code responsibility
+ * @param target to cron expression structure, it's client code responsibility
  *        to free/destroy it afterwards
  * @param error output error message, will be set to string literal
  *        error message in case of error. Will be set to NULL on success.

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -25994,8 +25994,8 @@ void MegaHTTPContext::onRequestFinish(MegaApi *, MegaRequest *request, MegaError
 
 /**
  * Gets permissions string: e.g: 777 -> rwxrwxrwx
- * @param perm numeric permissions
- * @param str_perm out permission string buffer
+ * @param permissions permissions
+ * @param permsString permission string buffer
  */
 void MegaFTPServer::getPermissionsString(int permissions, char *permsString)
 {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -8522,11 +8522,11 @@ error MegaClient::removecontact(const char* email, visibility_t show)
  * "+" - Public and plain text, accessible by anyone knowing userhandle
  * "^" - Private and non-encrypted.
  *
- * @param an Attribute name.
+ * @param at Attribute name.
  * @param av Attribute value.
  * @param avl Attribute value length.
  * @param ctag Tag to identify the request at intermediate layer
- * @return Void.
+
  */
 void MegaClient::putua(attr_t at, const byte* av, unsigned avl, int ctag)
 {
@@ -8614,9 +8614,8 @@ void MegaClient::putua(userattr_map *attrs, int ctag)
  * @brief Queue a user attribute retrieval.
  *
  * @param u User.
- * @param an Attribute name.
+ * @param at Attribute name.
  * @param ctag Tag to identify the request at intermediate layer
- * @return Void.
  */
 void MegaClient::getua(User* u, const attr_t at, int ctag)
 {


### PR DESCRIPTION
Parameter 'xxxx' not found in the function declaration

'@return' command used in a comment that is attached to a function returning void