### PR TITLE
Refactoring serialization for maintainability

### DIFF
--- a/include/mega/mediafileattribute.h
+++ b/include/mega/mediafileattribute.h
@@ -54,7 +54,6 @@ struct MEGA_API MediaProperties
     bool is_VFR;
     bool no_audio;
 
-
     MediaProperties();
     bool operator==(const MediaProperties& o) const;
 
@@ -75,6 +74,8 @@ struct MEGA_API MediaProperties
     std::string convertMediaPropertyFileAttributes(uint32_t attributekey[4], MediaFileInfo& mediaInfo);
 #endif
 
+    std::string serialize();
+    MediaProperties(const std::string& deserialize);
 };
 
 struct MEGA_API JSON;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -166,7 +166,12 @@ struct ChunkMAC
 };
 
 // file chunk macs
-typedef map<m_off_t, ChunkMAC> chunkmac_map;
+class chunkmac_map : public map<m_off_t, ChunkMAC>
+{
+public:
+    void serialize(string& d) const;
+    bool unserialize(const char*& ptr, const char* end);
+};
 
 /**
  * @brief Declaration of API error codes.

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -379,7 +379,7 @@ struct CacheableReader
     bool unserializebool(bool& s);
     bool unserializechunkmacs(chunkmac_map& m);
 
-    bool unserializeexpansionflags(unsigned char field[8]);
+    bool unserializeexpansionflags(unsigned char field[8], unsigned unusedFlagCount);
 
     void eraseused(string& d); // must be the same string, unchanged
 };

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -341,6 +341,49 @@ std::string webdavurlescape(const std::string &value);
 std::string escapewebdavchar(const char c);
 std::string webdavnameescape(const std::string &value);
 
+struct CacheableWriter
+{
+    CacheableWriter(string& d);
+    string& dest;
+
+    void serializebinary(byte* data, size_t len);
+    void serializecstr(const char* field, bool storeNull);  // may store the '\0' also for backward compatibility
+    void serializestring(const string& field);
+    void serializei64(int64_t field);
+    void serializeu32(uint32_t field);
+    void serializehandle(handle field);
+    void serializebool(bool field);
+    void serializebyte(byte field);
+    void serializechunkmacs(const chunkmac_map& m);
+
+    // Each class that might get extended should store expansion flags at the end
+    // When adding new fields to an existing class, set the next expansion flag true to indicate they are present.
+    // If you turn on the last flag, then you must also add another set of expansion flags (all false) after the new fields, for further expansion later.
+    void serializeexpansionflags(bool b1 = false, bool b2 = false, bool b3 = false, bool b4 = false, bool b5 = false, bool b6 = false, bool b7 = false, bool b8 = false);
+};
+
+struct CacheableReader
+{
+    CacheableReader(const string& d);
+    const char* ptr;
+    const char* end;
+    unsigned fieldnum;
+
+    bool unserializebinary(byte* data, size_t len);
+    bool unserializecstr(string& s, bool removeNull); // set removeNull if this field stores the terminating '\0' at the end
+    bool unserializestring(string& s);
+    bool unserializei64(int64_t& s);
+    bool unserializeu32(uint32_t& s);
+    bool unserializebyte(byte& s);
+    bool unserializehandle(handle& s);
+    bool unserializebool(bool& s);
+    bool unserializechunkmacs(chunkmac_map& m);
+
+    bool unserializeexpansionflags(unsigned char field[8]);
+
+    void eraseused(string& d); // must be the same string, unchanged
+};
+
 } // namespace
 
 #endif

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -420,6 +420,37 @@ MediaProperties::MediaProperties()
 {
 }
 
+MediaProperties::MediaProperties(const std::string& deserialize)
+{
+    CacheableReader r(deserialize);
+    r.unserializebyte(shortformat);
+    r.unserializeu32(width);
+    r.unserializeu32(height);
+    r.unserializeu32(fps);
+    r.unserializeu32(containerid);
+    r.unserializeu32(videocodecid);
+    r.unserializeu32(audiocodecid);
+    r.unserializebool(is_VFR);
+    r.unserializebool(no_audio);
+}
+
+std::string MediaProperties::serialize()
+{
+    std::string s;
+    CacheableWriter r(s);
+    r.serializebyte(shortformat);
+    r.serializeu32(width);
+    r.serializeu32(height);
+    r.serializeu32(fps);
+    r.serializeu32(containerid);
+    r.serializeu32(videocodecid);
+    r.serializeu32(audiocodecid);
+    r.serializebool(is_VFR);
+    r.serializebool(no_audio);
+    r.serializeexpansionflags();
+    return s;
+}
+
 bool MediaProperties::operator==(const MediaProperties& o) const
 { 
     return shortformat == o.shortformat && width == o.width && height == o.height && fps == o.fps && playtime == o.playtime &&

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -427,6 +427,7 @@ MediaProperties::MediaProperties(const std::string& deserialize)
     r.unserializeu32(width);
     r.unserializeu32(height);
     r.unserializeu32(fps);
+    r.unserializeu32(playtime);
     r.unserializeu32(containerid);
     r.unserializeu32(videocodecid);
     r.unserializeu32(audiocodecid);
@@ -442,6 +443,7 @@ std::string MediaProperties::serialize()
     r.serializeu32(width);
     r.serializeu32(height);
     r.serializeu32(fps);
+    r.serializeu32(playtime);
     r.serializeu32(containerid);
     r.serializeu32(videocodecid);
     r.serializeu32(audiocodecid);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -451,234 +451,75 @@ char *MegaNodePrivate::serialize()
 
 bool MegaNodePrivate::serialize(string *d)
 {
-    unsigned short ll;
-    bool flag;
+    CacheableWriter w(*d);
+    w.serializecstr(name, true);
+    w.serializecstr(fingerprint, true);
+    w.serializei64(size);
+    w.serializei64(ctime);
+    w.serializei64(mtime);
+    w.serializehandle(nodehandle);
+    w.serializehandle(parenthandle);
+    w.serializestring(attrstring);
+    w.serializestring(nodekey);
+    w.serializestring(privateAuth);
+    w.serializestring(publicAuth);
+    w.serializebool(isPublicNode);
+    w.serializebool(foreign);
 
-    ll = (unsigned short)(name ? strlen(name) + 1 : 0);
-    d->append((char*)&ll, sizeof(ll));
-    d->append(name, ll);
+    bool hasChatAuth = chatAuth && chatAuth[0];
+    bool hasOwner = true;
 
-    ll = (unsigned short)(fingerprint ? strlen(fingerprint) + 1 : 0);
-    d->append((char*)&ll, sizeof(ll));
-    d->append(fingerprint, ll);
-
-    d->append((char*)&size, sizeof(size));
-    d->append((char*)&ctime, sizeof(ctime));
-    d->append((char*)&mtime, sizeof(mtime));
-    d->append((char*)&nodehandle, sizeof(nodehandle));
-    d->append((char*)&parenthandle, sizeof(parenthandle));
-
-    ll = (unsigned short)attrstring.size();
-    d->append((char*)&ll, sizeof(ll));
-    d->append(attrstring.data(), ll);
-
-    ll = (unsigned short)nodekey.size();
-    d->append((char*)&ll, sizeof(ll));
-    d->append(nodekey.data(), ll);
-
-    ll = (unsigned short)privateAuth.size();
-    d->append((char*)&ll, sizeof(ll));
-    d->append(privateAuth.data(), ll);
-
-    ll = (unsigned short)publicAuth.size();
-    d->append((char*)&ll, sizeof(ll));
-    d->append(publicAuth.data(), ll);
-
-    flag = isPublicNode;
-    d->append((char*)&flag, sizeof(flag));
-
-    flag = foreign;
-    d->append((char*)&flag, sizeof(flag));
-
-    char hasChatAuth = (chatAuth && chatAuth[0]) ? 1 : 0;
-    d->append((char *)&hasChatAuth, 1);
-
-    char hasOwner = 1;
-    d->append((char *)&hasOwner, 1);
-
-    d->append("\0\0\0\0\0", 6);
+    w.serializeexpansionflags(hasChatAuth, hasOwner);
 
     if (hasChatAuth)
     {
-        ll = (unsigned short) strlen(chatAuth);
-        d->append((char*)&ll, sizeof(ll));
-        d->append(chatAuth, ll);
+        w.serializecstr(chatAuth, false);
     }
-
-    d->append((char *)&owner, sizeof(handle));
+    if (hasOwner)
+    {
+        w.serializehandle(owner);
+    }
 
     return true;
 }
 
 MegaNodePrivate *MegaNodePrivate::unserialize(string *d)
 {
-    const char* ptr = d->data();
-    const char* end = ptr + d->size();
-
-    if (ptr + sizeof(unsigned short) > end)
+    CacheableReader r(*d);
+    string name, fingerprint, originalfingerprint, attrstring, nodekey, privauth, pubauth, chatauth;
+    int64_t size, ctime, mtime;
+    MegaHandle nodehandle, parenthandle, owner = INVALID_HANDLE;
+    bool isPublicNode, foreign;
+    unsigned char expansions[8];
+    string fileattrstring; // fileattrstring is not serialized
+    if (!r.unserializecstr(name, true) ||
+        !r.unserializecstr(fingerprint, true) ||
+        !r.unserializei64(size) ||
+        !r.unserializei64(ctime) ||
+        !r.unserializei64(mtime) ||
+        !r.unserializehandle(nodehandle) ||
+        !r.unserializehandle(parenthandle) ||
+        !r.unserializestring(attrstring) ||
+        !r.unserializestring(nodekey) ||
+        !r.unserializestring(privauth) ||
+        !r.unserializestring(pubauth) ||
+        !r.unserializebool(isPublicNode) ||
+        !r.unserializebool(foreign) ||
+        !r.unserializeexpansionflags(expansions) ||
+        (expansions[0] && !r.unserializecstr(chatauth, false)) ||
+        (expansions[1] && !r.unserializehandle(owner)))
     {
-        LOG_err << "MegaNode unserialization failed - data too short";
+        LOG_err << "MegaNode unserialization failed at field " << r.fieldnum;
         return NULL;
     }
 
-    unsigned short namelen = MemAccess::get<unsigned short>(ptr);
-    ptr += sizeof(namelen);
-    if (ptr + namelen + sizeof(unsigned short) > end)
-    {
-        LOG_err << "MegaNode unserialization failed - name too long";
-        return NULL;
-    }
-    string name;
-    if (namelen)
-    {
-        name.assign(ptr, namelen - 1);
-    }
-    ptr += namelen;
+    r.eraseused(*d);
 
-    unsigned short fingerprintlen = MemAccess::get<unsigned short>(ptr);
-    ptr += sizeof(fingerprintlen);
-    if (ptr + fingerprintlen + sizeof(unsigned short)
-            + sizeof(int64_t) + sizeof(int64_t)
-            + sizeof(int64_t) + sizeof(MegaHandle)
-            + sizeof(MegaHandle) + sizeof(unsigned short) > end)
-    {
-        LOG_err << "MegaNode unserialization failed - fingerprint too long";
-        return NULL;
-    }
-    string fingerprint;
-    if (fingerprintlen)
-    {
-        fingerprint.assign(ptr, fingerprintlen - 1);
-    }
-    ptr += fingerprintlen;
-
-    int64_t size = MemAccess::get<int64_t>(ptr);
-    ptr += sizeof(int64_t);
-
-    int64_t ctime = MemAccess::get<int64_t>(ptr);
-    ptr += sizeof(int64_t);
-
-    int64_t mtime = MemAccess::get<int64_t>(ptr);
-    ptr += sizeof(int64_t);
-
-    MegaHandle nodehandle = MemAccess::get<MegaHandle>(ptr);
-    ptr += sizeof(MegaHandle);
-
-    MegaHandle parenthandle = MemAccess::get<MegaHandle>(ptr);
-    ptr += sizeof(MegaHandle);
-
-    unsigned short ll = MemAccess::get<unsigned short>(ptr);
-    ptr += sizeof(ll);
-    if (ptr + ll + sizeof(unsigned short) > end)
-    {
-        LOG_err << "MegaNode unserialization failed - attrstring too long";
-        return NULL;
-    }
-    string attrstring;
-    attrstring.assign(ptr, ll);
-    ptr += ll;
-
-    string fileattrstring;  // not serialized
-
-    ll = MemAccess::get<unsigned short>(ptr);
-    ptr += sizeof(ll);
-    if (ptr + ll + sizeof(unsigned short) > end)
-    {
-        LOG_err << "MegaNode unserialization failed - nodekey too long";
-        return NULL;
-    }
-    string nodekey;
-    nodekey.assign(ptr, ll);
-    ptr += ll;
-
-    ll = MemAccess::get<unsigned short>(ptr);
-    ptr += sizeof(ll);
-    if (ptr + ll + sizeof(unsigned short) > end)
-    {
-        LOG_err << "MegaNode unserialization failed - auth too long";
-        return NULL;
-    }
-    string privauth;
-    privauth.assign(ptr, ll);
-    ptr += ll;
-
-    ll = MemAccess::get<unsigned short>(ptr);
-    ptr += sizeof(ll);
-    if (ptr + ll + sizeof(bool) + sizeof(bool) + 8 > end)
-    {
-        LOG_err << "MegaNode unserialization failed - auth too long";
-        return NULL;
-    }
-
-    string pubauth;
-    pubauth.assign(ptr, ll);
-    ptr += ll;
-
-    bool isPublicNode = MemAccess::get<bool>(ptr);
-    ptr += sizeof(bool);
-
-    bool foreign = MemAccess::get<bool>(ptr);
-    ptr += sizeof(bool);
-
-    char hasChatAuth = MemAccess::get<char>(ptr);
-    ptr += sizeof(char);
-
-    char hasOwner = MemAccess::get<handle>(ptr);
-    ptr += sizeof(char);
-
-    if (memcmp(ptr, "\0\0\0\0\0", 6))
-    {
-        LOG_err << "MegaNodePrivate unserialization failed - invalid version";
-        return NULL;
-    }
-    ptr += 6;
-
-    string chatauth;
-    if (hasChatAuth)
-    {
-        if (ptr + sizeof(unsigned short) <= end)
-        {
-            unsigned short chatauthlen = MemAccess::get<unsigned short>(ptr);
-            ptr += sizeof(chatauthlen);
-
-            if (!chatauthlen || ptr + chatauthlen > end)
-            {
-                LOG_err << "MegaNodePrivate unserialization failed - incorrect size of chat auth";
-                return NULL;
-            }
-
-            chatauth.assign(ptr, chatauthlen);
-            ptr += chatauthlen;
-        }
-        else
-        {
-            LOG_err << "MegaNodePrivate unserialization failed - chat auth not found";
-            return NULL;
-        }
-    }
-
-    handle owner = INVALID_HANDLE;
-    if (hasOwner)
-    {
-        if (ptr + sizeof(handle) <= end)
-        {
-            owner = MemAccess::get<handle>(ptr);
-            ptr += sizeof(handle);
-        }
-        else
-        {
-            LOG_err << "MegaNodePrivate unserialization failed - owner not found";
-            return NULL;
-        }
-    }
-
-    d->erase(0, ptr - d->data());
-
-    return new MegaNodePrivate(namelen ? name.c_str() : NULL, FILENODE, size, ctime,
+    return new MegaNodePrivate(name.empty() ? NULL : name.c_str(), FILENODE, size, ctime,
                                mtime, nodehandle, &nodekey, &attrstring, &fileattrstring,
-                               fingerprintlen ? fingerprint.c_str() : NULL, owner,
+                               fingerprint.empty() ? NULL : fingerprint.c_str(), owner,
                                parenthandle, privauth.c_str(), pubauth.c_str(),
-                               isPublicNode, foreign, hasChatAuth ? chatauth.c_str() : NULL);
+                               isPublicNode, foreign, chatauth.empty() ? NULL : chatauth.c_str());
 }
 
 char *MegaNodePrivate::getBase64Handle()

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -505,7 +505,7 @@ MegaNodePrivate *MegaNodePrivate::unserialize(string *d)
         !r.unserializestring(pubauth) ||
         !r.unserializebool(isPublicNode) ||
         !r.unserializebool(foreign) ||
-        !r.unserializeexpansionflags(expansions) ||
+        !r.unserializeexpansionflags(expansions, 6) ||
         (expansions[0] && !r.unserializecstr(chatauth, false)) ||
         (expansions[1] && !r.unserializehandle(owner)))
     {

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -129,13 +129,7 @@ bool Transfer::serialize(string *d)
     d->append((const char*)&metamac, sizeof(metamac));
     d->append((const char*)transferkey, sizeof (transferkey));
 
-    ll = (unsigned short)chunkmacs.size();
-    d->append((char*)&ll, sizeof(ll));
-    for (chunkmac_map::iterator it = chunkmacs.begin(); it != chunkmacs.end(); it++)
-    {
-        d->append((char*)&it->first, sizeof(it->first));
-        d->append((char*)&it->second, sizeof(it->second));
-    }
+    chunkmacs.serialize(*d);
 
     if (!FileFingerprint::serialize(d))
     {
@@ -221,23 +215,11 @@ Transfer *Transfer::unserialize(MegaClient *client, string *d, transfer_map* tra
 
     t->localfilename.assign(filepath, ll);
 
-    ll = MemAccess::get<unsigned short>(ptr);
-    ptr += sizeof(ll);
-
-    if (ptr + ll * (sizeof(m_off_t) + sizeof(ChunkMAC)) + sizeof(ll) > end)
+    if (!t->chunkmacs.unserialize(ptr, end))
     {
         LOG_err << "Transfer unserialization failed - chunkmacs too long";
         delete t;
         return NULL;
-    }
-
-    for (int i = 0; i < ll; i++)
-    {
-        m_off_t pos = MemAccess::get<m_off_t>(ptr);
-        ptr += sizeof(m_off_t);
-
-        memcpy(&(t->chunkmacs[pos]), ptr, sizeof(ChunkMAC));
-        ptr += sizeof(ChunkMAC);
     }
 
     d->erase(0, ptr - d->data());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -48,6 +48,227 @@ Cachable::Cachable()
     notified = 0;
 }
 
+CacheableWriter::CacheableWriter(string& d)
+    : dest(d)
+{
+}
+
+void CacheableWriter::serializebinary(byte* data, size_t len)
+{
+    dest.append((char*)data, len);
+}
+
+void CacheableWriter::serializechunkmacs(const chunkmac_map& m)
+{
+    m.serialize(dest);
+}
+
+void CacheableWriter::serializecstr(const char* field, bool storeNull)
+{
+    unsigned short ll = (unsigned short)(field ? strlen(field) + (storeNull ? 1 : 0) : 0);
+    dest.append((char*)&ll, sizeof(ll));
+    dest.append(field, ll);
+}
+
+void CacheableWriter::serializestring(const string& field)
+{
+    unsigned short ll = (unsigned short)field.size();
+    dest.append((char*)&ll, sizeof(ll));
+    dest.append(field.data(), ll);
+}
+
+void CacheableWriter::serializei64(int64_t field)
+{
+    dest.append((char*)&field, sizeof(field));
+}
+
+void CacheableWriter::serializeu32(uint32_t field)
+{
+    dest.append((char*)&field, sizeof(field));
+}
+
+void CacheableWriter::serializehandle(handle field)
+{
+    dest.append((char*)&field, sizeof(field));
+}
+
+void CacheableWriter::serializebool(bool field)
+{
+    dest.append((char*)&field, sizeof(field));
+}
+
+void CacheableWriter::serializebyte(byte field)
+{
+    dest.append((char*)&field, sizeof(field));
+}
+
+void CacheableWriter::serializeexpansionflags(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5, bool b6, bool b7)
+{
+    unsigned char b[8];
+    b[0] = b0;
+    b[1] = b1;
+    b[2] = b2;
+    b[3] = b3;
+    b[4] = b4;
+    b[5] = b5;
+    b[6] = b6;
+    b[7] = b7;
+    dest.append((char*)b, 8);
+}
+
+
+CacheableReader::CacheableReader(const string& d)
+    : ptr(d.data())
+    , end(ptr + d.size())
+    , fieldnum(0)
+{
+}
+
+void CacheableReader::eraseused(string& d)
+{
+    assert(end == d.data() + d.size());
+    d.erase(0, ptr - d.data());
+}
+
+bool CacheableReader::unserializecstr(string& s, bool removeNull)
+{
+    if (ptr + sizeof(unsigned short) > end)
+    {
+        return false;
+    }
+
+    unsigned short len = MemAccess::get<unsigned short>(ptr);
+    ptr += sizeof(len);
+
+    if (ptr + len > end)
+    {
+        return false;
+    }
+
+    if (len)
+    {
+        s.assign(ptr, len - (removeNull ? 1 : 0));
+    }
+    ptr += len;
+    fieldnum += 1;
+    return true;
+}
+
+
+bool CacheableReader::unserializestring(string& s)
+{
+    if (ptr + sizeof(unsigned short) > end)
+    {
+        return false;
+    }
+
+    unsigned short len = MemAccess::get<unsigned short>(ptr);
+    ptr += sizeof(len);
+
+    if (ptr + len > end)
+    {
+        return false;
+    }
+
+    if (len)
+    {
+        s.assign(ptr, len);
+    }
+    ptr += len;
+    fieldnum += 1;
+    return true;
+}
+
+bool CacheableReader::unserializebinary(byte* data, size_t len)
+{
+    if (ptr + len > end)
+    {
+        return false;
+    }
+
+    memcpy(data, ptr, len);
+    ptr += len;
+    fieldnum += 1;
+    return true;
+}
+
+bool CacheableReader::unserializechunkmacs(chunkmac_map& m)
+{
+    return m.unserialize(ptr, end);   // ptr is adjusted by reference
+}
+
+bool CacheableReader::unserializei64(int64_t& field)
+{
+    if (ptr + sizeof(int64_t) > end)
+    {
+        return false;
+    }
+    field = MemAccess::get<int64_t>(ptr);
+    ptr += sizeof(int64_t);
+    fieldnum += 1;
+    return true;
+}
+
+bool CacheableReader::unserializeu32(uint32_t& field)
+{
+    if (ptr + sizeof(uint32_t) > end)
+    {
+        return false;
+    }
+    field = MemAccess::get<uint32_t>(ptr);
+    ptr += sizeof(uint32_t);
+    fieldnum += 1;
+    return true;
+}
+
+bool CacheableReader::unserializehandle(handle& field)
+{
+    if (ptr + sizeof(handle) > end)
+    {
+        return false;
+    }
+    field = MemAccess::get<handle>(ptr);
+    ptr += sizeof(handle);
+    fieldnum += 1;
+    return true;
+}
+
+bool CacheableReader::unserializebool(bool& field)
+{
+    if (ptr + sizeof(bool) > end)
+    {
+        return false;
+    }
+    field = MemAccess::get<bool>(ptr);
+    ptr += sizeof(bool);
+    fieldnum += 1;
+    return true;
+}
+
+bool CacheableReader::unserializebyte(byte& field)
+{
+    if (ptr + sizeof(byte) > end)
+    {
+        return false;
+    }
+    field = MemAccess::get<byte>(ptr);
+    ptr += sizeof(byte);
+    fieldnum += 1;
+    return true;
+}
+
+bool CacheableReader::unserializeexpansionflags(unsigned char field[8])
+{
+    if (ptr + 8 > end)
+    {
+        return false;
+    }
+    memcpy(field, ptr, 8);
+    ptr += 8;
+    fieldnum += 1;
+    return true;
+}
+
 #ifdef ENABLE_CHAT
 TextChat::TextChat()
 {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -156,7 +156,8 @@ TEST(Cacheable, CacheableReaderWriter)
     ASSERT_EQ(check_cm[777].offset, cm[777].offset);
 
     unsigned char expansions[8];
-    ASSERT_TRUE(r.unserializeexpansionflags(expansions));
+    ASSERT_FALSE(r.unserializeexpansionflags(expansions, 1));
+    ASSERT_TRUE(r.unserializeexpansionflags(expansions, 0));
     ASSERT_EQ(expansions[0], 1);
     ASSERT_EQ(expansions[1], 0);
     ASSERT_EQ(expansions[2], 1);
@@ -168,6 +169,31 @@ TEST(Cacheable, CacheableReaderWriter)
 
     r.eraseused(readstring);
     ASSERT_EQ(readstring, "abc");
+
+    MediaProperties mp;
+    mp.shortformat = 1;
+    mp.width = 2;
+    mp.height = 3;
+    mp.fps = 4;
+    mp.playtime = 5;
+    mp.containerid = 6;
+    mp.videocodecid = 7;
+    mp.audiocodecid = 8;
+    mp.is_VFR = true;
+    mp.no_audio = false;
+    string mps = mp.serialize();
+    MediaProperties mp2(mps);
+    ASSERT_EQ(mps, mp2.serialize());
+    ASSERT_EQ(mp2.shortformat, 1);
+    ASSERT_EQ(mp2.width, 2);
+    ASSERT_EQ(mp2.height, 3);
+    ASSERT_EQ(mp2.fps, 4);
+    ASSERT_EQ(mp2.playtime, 5);
+    ASSERT_EQ(mp2.containerid, 6);
+    ASSERT_EQ(mp2.videocodecid, 7);
+    ASSERT_EQ(mp2.audiocodecid, 8);
+    ASSERT_EQ(mp2.is_VFR, true);
+    ASSERT_EQ(mp2.no_audio, false);
 }
 
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -50,6 +50,127 @@ TEST(Serialize64, serialize)
     ASSERT_EQ(in, out);
 }
 
+size_t checksize(size_t& n, size_t added)
+{
+    n += added;
+    return n;
+}
+
+TEST(Cacheable, CacheableReaderWriter)
+{
+    string writestring;
+    CacheableWriter w(writestring);
+
+    ::mega::byte binary[] = { 1, 2, 3, 4, 5 };
+    string cstr1("test1");
+    string cstr2("test2diffdata");
+    string stringtest("diffstringagaindefinitelybigger");
+    int64_t i64 = 0x8765432112345678;
+    uint32_t u32 = 0x87678765;
+    handle handle1 = 0x998;
+    bool b = true;
+    ::mega::byte by = 5;
+    chunkmac_map cm;
+    cm[777].offset = 888;
+
+    size_t sizeadded = 0;
+
+    w.serializebinary(binary, sizeof(binary));
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, sizeof(binary)));
+
+    w.serializecstr(cstr1.c_str(), true);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 2 + cstr1.size() + 1));
+
+    w.serializecstr(cstr2.c_str(), false);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 2 + cstr2.size()));
+
+    w.serializestring(stringtest);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 2 + stringtest.size()));
+
+    w.serializei64(i64);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 8));
+
+    w.serializeu32(u32);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 4));
+
+    w.serializehandle(handle1);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, sizeof(handle)));
+
+    w.serializebool(b);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, sizeof(bool)));
+
+    w.serializebyte(by);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 1));
+
+    w.serializechunkmacs(cm);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 2 + 1 * (sizeof(m_off_t) + sizeof(ChunkMAC))));
+
+    w.serializeexpansionflags(1, 0, 1, 0, 0, 0, 1, 1);
+    ASSERT_EQ(writestring.size(), checksize(sizeadded, 8));
+
+    writestring += "abc";
+
+    // now read the serialized data back
+    string readstring = writestring;
+    CacheableReader r(readstring);
+
+    ::mega::byte check_binary[5];
+    string check_cstr1;
+    string check_cstr2;
+    string check_stringtest;
+    int64_t check_i64;
+    uint32_t check_u32;
+    handle check_handle1;
+    bool check_b;
+    ::mega::byte check_by;
+    chunkmac_map check_cm;
+
+    ASSERT_TRUE(r.unserializebinary(check_binary, sizeof(check_binary)));
+    ASSERT_EQ(0, memcmp(check_binary, binary, sizeof(binary)));
+
+    ASSERT_TRUE(r.unserializecstr(check_cstr1, true));
+    ASSERT_EQ(check_cstr1, cstr1);
+
+    ASSERT_TRUE(r.unserializecstr(check_cstr2, false));
+    ASSERT_EQ(check_cstr2, cstr2);
+
+    ASSERT_TRUE(r.unserializestring(check_stringtest));
+    ASSERT_EQ(check_stringtest, stringtest);
+
+    ASSERT_TRUE(r.unserializei64(check_i64));
+    ASSERT_EQ(check_i64, i64);
+
+    ASSERT_TRUE(r.unserializeu32(check_u32));
+    ASSERT_EQ(check_u32, u32);
+
+    ASSERT_TRUE(r.unserializehandle(check_handle1));
+    ASSERT_EQ(check_handle1, handle1);
+
+    ASSERT_TRUE(r.unserializebool(check_b));
+    ASSERT_EQ(check_b, b);
+
+    ASSERT_TRUE(r.unserializebyte(check_by));
+    ASSERT_EQ(check_by, by);
+
+    ASSERT_TRUE(r.unserializechunkmacs(check_cm));
+    ASSERT_EQ(check_cm[777].offset, cm[777].offset);
+
+    unsigned char expansions[8];
+    ASSERT_TRUE(r.unserializeexpansionflags(expansions));
+    ASSERT_EQ(expansions[0], 1);
+    ASSERT_EQ(expansions[1], 0);
+    ASSERT_EQ(expansions[2], 1);
+    ASSERT_EQ(expansions[3], 0);
+    ASSERT_EQ(expansions[4], 0);
+    ASSERT_EQ(expansions[5], 0);
+    ASSERT_EQ(expansions[6], 1);
+    ASSERT_EQ(expansions[7], 1);
+
+    r.eraseused(readstring);
+    ASSERT_EQ(readstring, "abc");
+}
+
+
 int main (int argc, char *argv[])
 {
     InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Added classes CacheableReader and CacheableWriter, which wrap up the techniques already used for serialization and deserialisation.
The change means the code can be much more compact, enabling writing, maintaining, and reviewing those functions much more easily.