### PR TITLE
CMake options to build against WebRTC

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -14,14 +14,12 @@
 
 cmake_minimum_required(VERSION 3.7.2)
 
-#set this to 1 if building 64 bit with eg. cmake . -G "Visual Studio 15 2017 Win64"
-#set this to 0 if building 32 bit with eg. cmake . -G "Visual Studio 15 2017"
-set (build_64_bit 1 CACHE TYPE BOOL)
+set(MegaDir "${CMAKE_CURRENT_LIST_DIR}/../..")
+set(Mega3rdPartyDir "${MegaDir}/../3rdParty/" CACHE TYPE STRING)
 
 #indicate which dependent libraries to use in the build
 set (USE_CRYPTOPP 1 CACHE TYPE BOOL)
 set (USE_OPENSSL 1 CACHE TYPE BOOL)
-set (OPENSSL_IS_BORINGSSL 0 CACHE TYPE BOOL)
 set (USE_CURL 1 CACHE TYPE BOOL)
 set (USE_SQLITE 1 CACHE TYPE BOOL)
 set (USE_MEDIAINFO 1 CACHE TYPE BOOL)
@@ -30,15 +28,27 @@ set (USE_SODIUM 0 CACHE TYPE BOOL)
 set (ENABLE_SYNC 1 CACHE TYPE BOOL)
 set (ENABLE_CHAT 0 CACHE TYPE BOOL)
 set (HAVE_FFMPEG 1 CACHE TYPE BOOL)
+set (USE_WEBRTC 0 CACHE TYPE BOOL)
 
 if (WIN32)
     set (NO_READLINE 1 CACHE TYPE BOOL)
+    set (UNCHECKED_ITERATORS 0 CACHE TYPE BOOL)
 else(WIN32)
     set(NO_READLINE 0)
 endif(WIN32)
 
 if (ENABLE_CHAT AND NOT USE_SODIUM)
     message(FATAL_ERROR "ENABLE_CHAT (${ENABLE_CHAT}) requires USE_SODIUM (${USE_SODIUM})")
+endif()
+
+if (WIN32)
+    if("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)")
+        SET(build_64_bit 1)
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        SET(build_64_bit 0)
+    endif()
+else()
+    set (build_64_bit 1 CACHE TYPE BOOL)
 endif()
 
 if(build_64_bit)
@@ -48,23 +58,19 @@ else(build_64_bit)
 endif(build_64_bit)
 
 IF(WIN32)
-    set(MegaDir "${CMAKE_CURRENT_LIST_DIR}/../..")
-    if ("${Mega3rdPartyDir}" STREQUAL "")
-        set(Mega3rdPartyDir "${MegaDir}/../3rdParty")
+    if (UNCHECKED_ITERATORS)
+        if(build_64_bit)
+            set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x64-windows-static-uncheckediterators")
+        else(build_64_bit)
+            set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x86-windows-static-uncheckediterators")
+        endif(build_64_bit)
+    else() 
+        if(build_64_bit)
+            set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x64-windows-static")
+        else(build_64_bit)
+            set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x86-windows-static")
+        endif(build_64_bit)
     endif()
-ELSE(WIN32)
-    set(MegaDir "${CMAKE_CURRENT_LIST_DIR}/../..")
-    if ("${Mega3rdPartyDir}" STREQUAL "")
-        set (Mega3rdPartyDir "${MegaDir}/../3rdParty/")
-    endif()
-ENDIF(WIN32)
-
-IF(WIN32)
-    if(build_64_bit)
-        set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x64-windows-static-uncheckediterators")
-    else(build_64_bit)
-        set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x86-windows-static-uncheckediterators")
-    endif(build_64_bit)
 ELSE(WIN32)
     set(vcpkg_dir "${Mega3rdPartyDir}/vcpkg/installed/x64-linux")
     include_directories( "${vcpkg_dir}/include" )
@@ -83,8 +89,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
 
 # node deletion in debug under VC++ is pretty slow without this.  However libraries we depend on need to be built with the same setting or linking fails 
 # (hence the build3rdParty script using the xNN-windows-static-uncheckediterators triplets)
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_ITERATOR_DEBUG_LEVEL=0" )
-
+if (UNCHECKED_ITERATORS)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_ITERATOR_DEBUG_LEVEL=0" )
+endif()
 
 # accurate __cplusplus macro for vc++, selecting c++17 here for windows builds though the MEGA SDK library must build for older c++ standards also
 if(WIN32)
@@ -154,19 +161,35 @@ IF(WIN32)
     ENDIF(USE_CRYPTOPP)
 
     IF(USE_SODIUM)
-        ImportVcpkgLibrary(sodium          "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/libsodium.lib"  "${vcpkg_dir}/lib/libsodium.lib")
+        ImportVcpkgLibrary(sodium      "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/libsodium.lib"  "${vcpkg_dir}/lib/libsodium.lib")
     ENDIF(USE_SODIUM)
 
     IF(USE_CURL)
-        ImportVcpkgLibrary(curl        "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/libcurl.lib"  "${vcpkg_dir}/lib/libcurl.lib")
-        ImportVcpkgLibrary(cares       "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/cares.lib" "${vcpkg_dir}/lib/cares.lib")
-    ENDIF(USE_CURL)
+        IF(USE_WEBRTC)
+            ImportVcpkgLibrary(curl         "${Mega3rdPartyDir}/curl/include" "${Mega3rdPartyDir}/curl/build32/lib/Debug/libcurl-d.lib" "${Mega3rdPartyDir}/curl/build32/lib/Release/libcurl.lib")
+        ELSE()
+            ImportVcpkgLibrary(curl        "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/libcurl.lib"  "${vcpkg_dir}/lib/libcurl.lib")
+        ENDIF()
+    ENDIF()
 
-    IF(USE_OPENSSL)
-        ImportVcpkgLibrary(ssl         "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/ssleay32.lib" "${vcpkg_dir}/lib/ssleay32.lib")
-        ImportVcpkgLibrary(crypto      "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/libeay32.lib" "${vcpkg_dir}/lib/libeay32.lib")
-    ENDIF(USE_OPENSSL)
-    
+    IF(USE_CURL)
+        ImportVcpkgLibrary(cares       "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/cares.lib" "${vcpkg_dir}/lib/cares.lib")
+    ENDIF()
+
+    IF(USE_OPENSSL) 
+        IF(USE_WEBRTC)
+            include_directories( "${WebRtcDir}/webrtc/src/third_party/boringssl/src/include" )
+        ELSE()
+            ImportVcpkgLibrary(ssl         "${vcpkg_dir}/include"  ${vcpkg_dir}/debug/lib/ssleay32.lib ${vcpkg_dir}/lib/ssleay32.lib)
+            ImportVcpkgLibrary(crypto      "${vcpkg_dir}/include" ${vcpkg_dir}/debug/lib/libeay32.lib ${vcpkg_dir}/lib/libeay32.lib)
+        ENDIF()
+    ENDIF()
+
+    IF(USE_WEBRTC)
+        ImportVcpkgLibrary(webrtc "${WebRtcDir}/include" "${WebRtcDir}/lib/webrtc.lib" "${WebRtcDir}/lib/webrtc.lib")
+        add_definitions( -DWEBRTC_WIN )
+    ENDIF()
+
     ImportVcpkgLibrary(z               "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/zlibd.lib" "${vcpkg_dir}/lib/zlib.lib") 
 
     ImportVcpkgLibrary(gtest           "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/manual-link/gtestd.lib" "${vcpkg_dir}/lib/manual-link/gtest.lib") 
@@ -227,7 +250,7 @@ IF(WIN32)
 
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -DCURL_STATICLIB -DCARES_STATICLIB -DWIN32_LEAN_AND_MEAN -DUNICODE -DSODIUM_STATIC -DPCRE_STATICWIN32 -D_CONSOLE)
     SET(Mega_PlatformSpecificIncludes ${MegaDir}/include/mega/$<IF:${USE_CURL},wincurl,win32>)
-    SET(Mega_PlatformSpecificLibs ws2_32 winhttp Shlwapi Secur32.lib)
+    SET(Mega_PlatformSpecificLibs ws2_32 winhttp Shlwapi Secur32.lib  $<${USE_WEBRTC}:Wldap32.lib> )
 
     SET(Mega_PlatformSpecificFiles ${MegaDir}/src/win32/console.cpp 
     ${MegaDir}/src/win32/consolewaiter.cpp 
@@ -252,6 +275,11 @@ ELSE(WIN32)
     SET(Mega_PlatformSpecificFiles $<$<NOT:${GLOB_H_FOUND}>:${MegaDir}/src/mega_glob.c> ${MegaDir}/src/posix/console.cpp ${MegaDir}/src/posix/consolewaiter.cpp ${MegaDir}/src/posix/fs.cpp ${MegaDir}/src/posix/net.cpp ${MegaDir}/src/posix/waiter.cpp ${MegaDir}/src/thread/posixthread.cpp )
     SET(Mega_PlatformSpecificIncludes ${MegaDir}/include/mega/posix)
     SET(Mega_PlatformSpecificLibs crypto pthread rt z dl termcap stdc++fs)
+
+    IF(USE_WEBRTC)
+        ImportVcpkgLibrary(webrtc "${WebRtcDir}/include" "${WebRtcDir}/lib/webrtc.lib" "${WebRtcDir}/lib/webrtc.lib")
+        add_definitions( -DWEBRTC_POSIX )
+    ENDIF()
 
 ENDIF(WIN32)
 
@@ -309,8 +337,11 @@ target_include_directories(Mega PUBLIC ${MegaDir}/include ${Mega_PlatformSpecifi
 target_link_libraries(Mega PUBLIC z 
                 $<${USE_CRYPTOPP}:cryptopp> 
                 $<${USE_SODIUM}:sodium> 
-                $<${USE_OPENSSL}:ssl> $<${USE_OPENSSL}:crypto> 
-                $<${USE_CURL}:curl>  $<${USE_CURL}:cares> 
+                $<$<AND:${USE_OPENSSL},$<NOT:${USE_WEBRTC}>>:ssl> 
+                $<$<AND:${USE_OPENSSL},$<NOT:${USE_WEBRTC}>>:crypto> 
+                $<${USE_WEBRTC}:webrtc> 
+                $<${USE_CURL}:curl>  
+                $<${USE_CURL}:cares> 
                 $<${USE_SQLITE}:sqlite3> 
                 $<${USE_MEDIAINFO}:mediainfo> $<${USE_MEDIAINFO}:zen> 
                 $<${USE_FREEIMAGE}:freeimage> $<${USE_FREEIMAGE}:freeimage_IlmImf> $<${USE_FREEIMAGE}:freeimage_IlmImfUtil> $<${USE_FREEIMAGE}:freeimage_IlmThread> $<${USE_FREEIMAGE}:freeimage_Iex> $<${USE_FREEIMAGE}:freeimage_IexMath>

--- a/contrib/cmake/build3rdparty.cmd
+++ b/contrib/cmake/build3rdparty.cmd
@@ -1,65 +1,57 @@
 REM best to use this script outside of the MEGA repo.  Once the libraries are built, the CMakeLists.txt can be adjusted to refer to them.
 mkdir 3rdParty
 cd 3rdParty
-
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 CALL .\bootstrap-vcpkg.bat
 
-REM Set up build triplets: x86-windows-static-uncheckediterators, x64-windows-static-uncheckediterators
-REM Since we use a lot of map iterators, and the checking is linear, causing big delays in node deletion for example
-copy .\triplets\x86-windows-static.cmake .\triplets\x86-windows-static-uncheckediterators.cmake
-copy .\triplets\x64-windows-static.cmake .\triplets\x64-windows-static-uncheckediterators.cmake
-echo #comment >> .\triplets\x86-windows-static-uncheckediterators.cmake
-echo #comment >> .\triplets\x64-windows-static-uncheckediterators.cmake
-echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
-echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
-echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
-echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
+REM To build in a similar fashion to official versions, install the VS2015.3 v14.00 (v140) toolset for desktop, and the Windows XP Support For C++.  
+REM Then rename the v140_xp folder to v140 (rename that one out of the way first) to force the build to be compatible with windows XP.
+REM Comment these out if you prefer to use a different toolset
+copy .\triplets\x86-windows-static.cmake .\triplets\x86-windows-static-140xp.cmake
+copy .\triplets\x64-windows-static.cmake .\triplets\x64-windows-static-140xp.cmake
+echo #comment >> .\triplets\x86-windows-static-140xp.cmake
+echo #comment >> .\triplets\x64-windows-static-140xp.cmake
+echo set(VCPKG_PLATFORM_TOOLSET "v140") >> .\triplets\x86-windows-static-140xp.cmake
+echo set(VCPKG_PLATFORM_TOOLSET "v140") >> .\triplets\x64-windows-static-140xp.cmake
+set tripletsuffix="-140xp"
 
-REM for libsodium for x86, currently some adjustments are needed:
-REM add this to its portfile.cmake's vcpkg_build_msbuild call (having moved that definition before it):  PLATFORM ${BUILD_ARCH}
-REM also edit its vcproj file to set Configuration->AllOptions->TargetMachine to x86 for the Win32 configurations.
-REM you can build everything first then make those adjustments and manually call vcpkg for libsodium x86.
-REM OR avoid using it by turning off ENABLE_CHAT and USE_SODIUM
+REM You may want to build with Checked Iterators turned off (ie. define _ITERATOR_DEBUG_LEVEL=0)
+REM You would want that because otherwise some operations (eg. deleting the node tree) can be slow in debug builds
+REM You can enable that by uncommenting this section below, or edit your STL headers to disable it.
+REM Disabling it in the STL headers might seem extreme, but it works for WinRTC (which you need for MEGAchat if using that)
+
+REM copy .\triplets\x86-windows-static.cmake .\triplets\x86-windows-static-uncheckediterators.cmake
+REM copy .\triplets\x64-windows-static.cmake .\triplets\x64-windows-static-uncheckediterators.cmake
+REM echo #comment >> .\triplets\x86-windows-static-uncheckediterators.cmake
+REM echo #comment >> .\triplets\x64-windows-static-uncheckediterators.cmake
+REM echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
+REM echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
+REM echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
+REM echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
+REM set tripletsuffix="-uncheckediterators"
+
 
 CALL :build_one zlib
 CALL :build_one cryptopp
-CALL :build_one libsodium
-CALL :build_one openssl
-CALL :build_one curl
 CALL :build_one c-ares
 CALL :build_one sqlite3
-CALL :build_one gtest
+CALL :build_one libevent
+CALL :build_one libsodium
 CALL :build_one freeimage
 CALL :build_one ffmpeg
+CALL :build_one gtest
+CALL :build_one openssl
+CALL :build_one curl
 
-REM for megachat:
-REM CALL :build_one libuv
-REM CALL :build_one libwebsockets
-
-REM currently for libwebsockets a few changes are needed (mainly get 2.4.2, turn off ipv6, turn on libuv features)
-REM modify these attributes in its portfile: 
-REM     REF v2.4.2
-REM     SHA512 
-REM     7bee49f6763ff3ab7861fcda25af8d80f6757c56e197ea42be53e0b2480969eee73de3aee5198f5ff06fd1cb8ab2be4c6495243e83cd0acc235b0da83b2353d1
-REM     HEAD_REF v2.4-stable
-REM also find libwebsocket's CMakeLists.txt file and modify the libuv find_library, adding 'libuv' as that's what the libuv vcpkg produces:
-REM     find_library(LIBUV_LIBRARIES NAMES uv libuv)
-REM and add these lines in the vcpkg_configure_cmake in its portfile (LWS_IPV6 replaces an existing line):
-REM     -DLWS_IPV6=OFF
-REM     -DLWS_WITH_LIBUV=ON
-REM     -DLIBUV_LIBRARIES=${CURRENT_PACKAGES_DIR}/lib
-REM     -DLIBUV_INCLUDE_DIR=${CURRENT_PACKAGES_DIR}/include
-REM then use "vcpkg remove" and "vcpkg install" again, for libwebsockets.
-
-
+REM MEGASync needs libuv
+CALL :build_one libuv
 
 exit /b 0
 
 :build_one 
-.\vcpkg.exe install --triplet x64-windows-static-uncheckediterators %1%
-echo %errorlevel% %1% x64-windows-static-uncheckediterators >> buildlog
-.\vcpkg.exe install --triplet x86-windows-static-uncheckediterators %1%
-echo %errorlevel% %1% x86-windows-static-uncheckediterators >> buildlog
+.\vcpkg.exe install --triplet x64-windows-static%tripletsuffix% %1%
+echo %errorlevel% %1% x64-windows-static%tripletsuffix% >> buildlog
+.\vcpkg.exe install --triplet x86-windows-static%tripletsuffix% %1%
+echo %errorlevel% %1% x86-windows-static%tripletsuffix% >> buildlog
 exit /b 0

--- a/contrib/cmake/build3rdparty_chat.cmd
+++ b/contrib/cmake/build3rdparty_chat.cmd
@@ -1,0 +1,82 @@
+REM Use this method to build all the third party libraries when you are using MEGAchat libray with WebRTC
+REM Normally this script is used outside of the git repo, so that 3rdParty_chat is created next to the projects
+
+mkdir 3rdParty_chat
+cd 3rdParty_chat
+
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+CALL .\bootstrap-vcpkg.bat
+
+REM we use a lot of map iterators, and the checking is linear, causing big delays in node deletion for example
+copy .\triplets\x86-windows-static.cmake .\triplets\x86-windows-static-uncheckediterators.cmake
+copy .\triplets\x64-windows-static.cmake .\triplets\x64-windows-static-uncheckediterators.cmake
+echo #comment >> .\triplets\x86-windows-static-uncheckediterators.cmake
+echo #comment >> .\triplets\x64-windows-static-uncheckediterators.cmake
+echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
+echo set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
+echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x86-windows-static-uncheckediterators.cmake
+echo set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_ITERATOR_DEBUG_LEVEL=0") >> .\triplets\x64-windows-static-uncheckediterators.cmake
+
+CALL :build_one zlib
+CALL :build_one cryptopp
+CALL :build_one c-ares
+CALL :build_one sqlite3
+CALL :build_one libevent
+CALL :build_one libsodium
+CALL :build_one freeimage
+CALL :build_one ffmpeg
+CALL :build_one gtest
+CALL :build_one libuv
+
+REM currently for libwebsockets a few changes are needed (mainly get 2.4.2, turn off ipv6, turn on libuv features)
+REM modify these attributes in its portfile: 
+REM     REF v2.4.2
+REM     SHA512 
+REM     7bee49f6763ff3ab7861fcda25af8d80f6757c56e197ea42be53e0b2480969eee73de3aee5198f5ff06fd1cb8ab2be4c6495243e83cd0acc235b0da83b2353d1
+REM     HEAD_REF v2.4-stable
+REM and add libuv dependency (this might not be strictly necessary)
+REM     Feature: libuv
+REM     Build-Depends: libuv
+REM     Description: turns on LWS_WITH_LIBUU
+REM then use remove and install again.
+REM also find libwebsocket's CMakeLists.txt file and modify the libuv find_library, adding 'libuv' as that's what the libuv vcpkg produces:
+REM     find_library(LIBUV_LIBRARIES NAMES uv libuv)
+
+
+cd ..
+git clone https://github.com/aisouard/libwebrtc
+cd libwebrtc
+mkdir build32debug
+cd build32debug
+c:\cmake\bin\cmake.exe -DCMAKE_CONFIGURATION_TYPES=Debug -DWEBRTC_BRANCH_HEAD="" -DWEBRTC_REVISION=c1a58bae4196651d2f7af183be1878bb00d45a57 ..
+cd ..\..
+
+
+git clone https://github.com/curl/curl.git
+cd curl
+git checkout curl-7_62_0
+mkdir build32
+cd build32
+c:\cmake\bin\cmake -DCMAKE_TOOLCHAIN_FILE="C:\Users\MATTW\source\repos\3rdParty_chat\vcpkg\scripts\buildsystems\vcpkg.cmake" -DCARES_INCLUDE_DIR="C:\Users\MATTW\source\repos\3rdParty_chat\vcpkg\installed\x86-windows-static-uncheckediterators\include" -DBUILD_CURL_EXE=NO -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO -DCMAKE_USE_OPENSSL=YES -DCURL_STATIC_CRT=YES -DENABLE_ARES=YES -DENABLE_CURLDEBUG=YES -DENABLE_DEBUG=YES ..
+cd ../..
+
+git clone https://github.com/warmcat/libwebsockets.git
+cd libwebsockets
+git checkout v2.4.2
+REM <apply patch>
+mkdir build32
+cd build32
+c:\cmake\bin\cmake -DCMAKE_BULID_TYPE=Debug -DLWS_IPV6=OFF -DLIBUV_INCLUDE_DIRS=C:\Users\MATTW\source\repos\3rdParty_chat\vcpkg\installed\x86-windows-static-uncheckediterators\include -DLIBUV_LIBRARIES="C:\Users\MATTW\source\repos\3rdParty_chat\vcpkg\installed\x86-windows-static-uncheckediterators\lib\libuv.lib" -DOPENSSL_INCLUDE_DIRS="C:\Users\MATTW\source\repos\3rdParty_chat\libwebrtc\build32debug\webrtc\src\third_party\boringssl\src\include" -DLWS_WITHOUT_SERVER=ON LWS_WITHOUT_TESTAPPS=ON -DLWS_WITH_BORINGSSL=ON -DLWS_WITH_LIBUV=ON -DLWS_WITH_SHARED=OFF -DLWS_WITH_STATIC=ON -DOPENSSL_INCLUDE_DIR="C:\Users\MATTW\source\repos\3rdParty_chat\libwebrtc\build32debug\webrtc\src\third_party\boringssl\src\include"  ..
+REM (manually switch msvc projects to /MT /MTd and build each)
+cd ../..
+
+
+exit /b 0
+
+:build_one 
+.\vcpkg.exe install --triplet x64-windows-static-uncheckediterators %1%
+echo %errorlevel% %1% x64-windows-static-uncheckediterators >> buildlog
+.\vcpkg.exe install --triplet x86-windows-static-uncheckediterators %1%
+echo %errorlevel% %1% x86-windows-static-uncheckediterators >> buildlog
+exit /b 0

--- a/include/mega/win32/megasys.h
+++ b/include/mega/win32/megasys.h
@@ -80,7 +80,7 @@
 #include <windows.h>
 
 #ifndef WINDOWS_PHONE
- #include <wincrypt.h>
+ //#include <wincrypt.h> // x509 define clashes with webrtc
  #include <shlwapi.h>
 #endif
 


### PR DESCRIPTION
Also added a script to build the 3rdParty dependencies consistent with WebRTC
Tidy up 32/64 setting - no need to specify that explicitly on windows.
Default to not turning off checked iterators (ie normal for vc++ debug runtime)