### PR TITLE
pass usedflags instead of unused to unserializeexpansionflags

### DIFF
--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -379,7 +379,7 @@ struct CacheableReader
     bool unserializebool(bool& s);
     bool unserializechunkmacs(chunkmac_map& m);
 
-    bool unserializeexpansionflags(unsigned char field[8], unsigned unusedFlagCount);
+    bool unserializeexpansionflags(unsigned char field[8], unsigned usedFlagCount);
 
     void eraseused(string& d); // must be the same string, unchanged
 };

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -505,7 +505,7 @@ MegaNodePrivate *MegaNodePrivate::unserialize(string *d)
         !r.unserializestring(pubauth) ||
         !r.unserializebool(isPublicNode) ||
         !r.unserializebool(foreign) ||
-        !r.unserializeexpansionflags(expansions, 6) ||
+        !r.unserializeexpansionflags(expansions, 2) ||
         (expansions[0] && !r.unserializecstr(chatauth, false)) ||
         (expansions[1] && !r.unserializehandle(owner)))
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -262,7 +262,7 @@ bool CacheableReader::unserializebyte(byte& field)
     return true;
 }
 
-bool CacheableReader::unserializeexpansionflags(unsigned char field[8], unsigned unusedFlagCount)
+bool CacheableReader::unserializeexpansionflags(unsigned char field[8], unsigned usedFlagCount)
 {
     if (ptr + 8 > end)
     {
@@ -270,9 +270,9 @@ bool CacheableReader::unserializeexpansionflags(unsigned char field[8], unsigned
     }
     memcpy(field, ptr, 8);
 
-    for (int i = unusedFlagCount; i--; )
+    for (int i = usedFlagCount;  i < 8; i++ )
     {
-        if (field[7 - unusedFlagCount])
+        if (field[i])
         {
             LOG_err << "Unserialization failed in expansion flags, invalid version detected.  Fieldnum: " << fieldnum;
             return false;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -156,8 +156,8 @@ TEST(Cacheable, CacheableReaderWriter)
     ASSERT_EQ(check_cm[777].offset, cm[777].offset);
 
     unsigned char expansions[8];
-    ASSERT_FALSE(r.unserializeexpansionflags(expansions, 1));
-    ASSERT_TRUE(r.unserializeexpansionflags(expansions, 0));
+    ASSERT_FALSE(r.unserializeexpansionflags(expansions, 7));
+    ASSERT_TRUE(r.unserializeexpansionflags(expansions, 8));
     ASSERT_EQ(expansions[0], 1);
     ASSERT_EQ(expansions[1], 0);
     ASSERT_EQ(expansions[2], 1);


### PR DESCRIPTION
this might be less prone to error & easier to move to more different size of expansionflags