### PR TITLE
Non static PrnGen object

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -1856,7 +1856,7 @@ public:
             else
             {
                 byte buf[FOLDERNODEKEYLENGTH];
-                PrnGen::genblock(buf, sizeof buf);
+                client->rng.genblock(buf, sizeof buf);
                 t->nodekey.assign((char*) buf, FOLDERNODEKEYLENGTH);
             }
 
@@ -3871,7 +3871,7 @@ static void process_line(char* l)
                                     newnode->parenthandle = UNDEF;
 
                                     // generate fresh random key for this folder node
-                                    PrnGen::genblock(buf, FOLDERNODEKEYLENGTH);
+                                    client->rng.genblock(buf, FOLDERNODEKEYLENGTH);
                                     newnode->nodekey.assign((char*) buf, FOLDERNODEKEYLENGTH);
                                     key.setkey(buf);
 

--- a/include/mega/backofftimer.h
+++ b/include/mega/backofftimer.h
@@ -31,6 +31,7 @@ class MEGA_API BackoffTimer
     dstime next;
     dstime delta;
     dstime base;
+    PrnGen &rng;
 
 public:
     // reset timer
@@ -63,7 +64,7 @@ public:
     // update time to wait
     void update(dstime*);
 
-    BackoffTimer();
+    BackoffTimer(PrnGen &rng);
 };
 
 
@@ -71,7 +72,7 @@ class MEGA_API TimerWithBackoff: public BackoffTimer {
 
 public:
     int tag;
-    TimerWithBackoff(int tag);
+    TimerWithBackoff(PrnGen &rng, int tag);
 };
 
 } // namespace

--- a/include/mega/crypto/cryptopp.h
+++ b/include/mega/crypto/cryptopp.h
@@ -44,11 +44,9 @@ using std::string;
 /**
  * @brief A generic pseudo-random number generator.
  */
-class MEGA_API PrnGen
+class MEGA_API PrnGen : public CryptoPP::AutoSeededRandomPool
 {
 public:
-    static CryptoPP::AutoSeededRandomPool rng;
-
     /**
      * @brief Generates a block of random bytes of length `len` into a buffer
      *        `buf`.
@@ -58,7 +56,7 @@ public:
      * @param len The number of random bytes to generate.
      * @return Void.
      */
-    static void genblock(byte* buf, int len);
+    void genblock(byte* buf, int len);
 
     /**
      * @brief Generates a random integer between 0 ... max - 1.
@@ -66,7 +64,7 @@ public:
      * @param max The maximum of which the number is to generate under.
      * @return The random number generated.
      */
-    static uint32_t genuint32(uint64_t max);
+    uint32_t genuint32(uint64_t max);
 };
 
 // symmetric cryptography: AES-128
@@ -307,13 +305,14 @@ public:
     /**
      * @brief Encrypts a randomly padded plain text into a buffer.
      *
+     * @param rng Reference to the random block generator
      * @param plain The plain text to encrypt.
      * @param plainlen Length of the plain text.
      * @param buf Buffer to take the cipher text..
      * @param buflen Length of the cipher text.
      * @return Number of bytes encrypted, 0 on failure.
      */
-    int encrypt(const byte* plain, int plainlen, byte* buf, int buflen);
+    int encrypt(PrnGen &rng, const byte* plain, int plainlen, byte* buf, int buflen);
 
     /**
      * @brief Decrypts a cipher text into a buffer and strips random padding.
@@ -374,12 +373,13 @@ public:
     /**
      * @brief Generates an RSA key pair of a given key size.
      *
+     * @param rng Reference to the random block generator
      * @param privk Private key.
      * @param pubk Public key.
      * @param size Size of key to generate in bits (key strength).
      * @return Always returns 1.
      */
-    void genkeypair(CryptoPP::Integer* privk, CryptoPP::Integer* pubk, int size);
+    void genkeypair(PrnGen &rng, CryptoPP::Integer* privk, CryptoPP::Integer* pubk, int size);
 };
 
 class MEGA_API Hash

--- a/include/mega/crypto/sodium.h
+++ b/include/mega/crypto/sodium.h
@@ -28,6 +28,8 @@
 
 namespace mega {
 
+class PrnGen;
+
 /**
  * @brief Asymmetric cryptographic signature using EdDSA with Edwards 25519.
  */
@@ -41,7 +43,7 @@ public:
     static const string TLV_KEY;
     bool initializationOK;
 
-    EdDSA(unsigned char* keySeed = NULL);
+    EdDSA(PrnGen &rng, unsigned char* keySeed = NULL);
     ~EdDSA();
 
     unsigned char keySeed[SEED_KEY_LENGTH];

--- a/include/mega/db.h
+++ b/include/mega/db.h
@@ -29,6 +29,7 @@ namespace mega {
 class MEGA_API DbTable
 {
     static const int IDSPACING = 16;
+    PrnGen &rng;
 
 public:
     // for a full sequential get: rewind to first record
@@ -67,7 +68,7 @@ public:
     // autoincrement
     uint32_t nextid;
 
-    DbTable();
+    DbTable(PrnGen &rng);
     virtual ~DbTable() { }
 };
 
@@ -77,7 +78,7 @@ struct MEGA_API DbAccess
     static const int DB_VERSION = LEGACY_DB_VERSION + 1;
 
     DbAccess();
-    virtual DbTable* open(FileSystemAccess*, string*, bool = false) = 0;
+    virtual DbTable* open(PrnGen &rng, FileSystemAccess*, string*, bool = false) = 0;
 
     virtual ~DbAccess() { }
 

--- a/include/mega/db/sqlite.h
+++ b/include/mega/db/sqlite.h
@@ -31,7 +31,7 @@ class MEGA_API SqliteDbAccess : public DbAccess
     string dbpath;
 
 public:
-    DbTable* open(FileSystemAccess*, string*, bool = false);
+    DbTable* open(PrnGen &rng, FileSystemAccess*, string*, bool = false);
 
     SqliteDbAccess(string* = NULL);
     ~SqliteDbAccess();
@@ -56,7 +56,7 @@ public:
     void abort();
     void remove();
 
-    SqliteDbTable(sqlite3*, FileSystemAccess *fs, string *filepath);
+    SqliteDbTable(PrnGen &rng, sqlite3*, FileSystemAccess *fs, string *filepath);
     ~SqliteDbTable();
 };
 } // namespace

--- a/include/mega/fileattributefetch.h
+++ b/include/mega/fileattributefetch.h
@@ -31,6 +31,8 @@ namespace mega {
 // file attribute fetching for a specific source cluster
 struct MEGA_API FileAttributeFetchChannel
 {
+    MegaClient *client;
+
     handle fahref;
 
     BackoffTimer bt;
@@ -45,15 +47,15 @@ struct MEGA_API FileAttributeFetchChannel
     error e;
 
     // dispatch new and retrying attributes by POSTing to existing URL
-    void dispatch(MegaClient*);
+    void dispatch();
 
     // parse fetch result and remove completed attributes from pending
-    void parse(MegaClient*, int, bool);
+    void parse(int, bool);
 
     // notify app of nodes that failed to receive their requested attribute
-    void failed(MegaClient*);
+    void failed();
 
-    FileAttributeFetchChannel();
+    FileAttributeFetchChannel(MegaClient*);
 };
 
 // pending individual attribute fetch

--- a/include/mega/http.h
+++ b/include/mega/http.h
@@ -293,7 +293,7 @@ struct MEGA_API HttpReq
 
 struct MEGA_API GenericHttpReq : public HttpReq
 {
-    GenericHttpReq(bool = false);
+    GenericHttpReq(PrnGen &rng, bool = false);
 
     // tag related to the request
     int tag;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1259,6 +1259,9 @@ public:
     void proccr(JSON*);
     void procsr(JSON*);
 
+    // pseudo-random number generator
+    PrnGen rng;
+
     // account access: master key
     // folder link access: folder key
     SymmCipher key;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -216,6 +216,9 @@ public:
     // Account has VOIP push enabled (only for Apple)
     bool aplvp_enabled;
 
+    // pseudo-random number generator
+    PrnGen rng;
+
 #ifdef ENABLE_CHAT
     // all chats
     textchat_map chats;
@@ -1258,9 +1261,6 @@ public:
 
     void proccr(JSON*);
     void procsr(JSON*);
-
-    // pseudo-random number generator
-    PrnGen rng;
 
     // account access: master key
     // folder link access: folder key

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -66,7 +66,7 @@ struct MEGA_API PaddedCBC
      *     for encryption will be generated and available through the reference.
      * @return Void.
      */
-    static void encrypt(string* data, SymmCipher* key, string* iv = NULL);
+    static void encrypt(PrnGen &rng, string* data, SymmCipher* key, string* iv = NULL);
 
     /**
      * @brief Decrypts a string and strips the padding.
@@ -141,12 +141,17 @@ class MEGA_API PayCrypter
      */
     byte iv[IV_BYTES];
 
+    /**
+     * @brief Random blocks generator
+     */
+    PrnGen &rng;
+
 public:
 
     /**
      * @brief Constructor. Initializes keys with random values.
      */
-    PayCrypter();
+    PayCrypter(PrnGen &rng);
 
     /**
      * @brief Updates the crypto keys (mainly for testing)
@@ -256,7 +261,7 @@ private:
      * @param encSetting Block encryption mode to be used by AES
      * @return A new string holding the encrypted byte array. You take the ownership of the string.
      */
-    string *tlvRecordsToContainer(SymmCipher *key, encryptionsetting_t encSetting = AES_GCM_12_16);
+    string *tlvRecordsToContainer(PrnGen &rng, SymmCipher *key, encryptionsetting_t encSetting = AES_GCM_12_16);
 
     /**
      * @brief Converts the TLV records into a byte array

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6204,7 +6204,7 @@ class MegaApi
          * @param data Byte array with random data
          * @param size Size of the byte array (in bytes)
          */
-        static void addEntropy(char* data, unsigned int size);
+        void addEntropy(char* data, unsigned int size);
 
 #ifdef WINDOWS_PHONE
         /**

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1761,7 +1761,7 @@ class MegaApiImpl : public MegaApp
         static const char* ebcEncryptKey(const char* encryptionKey, const char* plainKey);
         void retryPendingConnections(bool disconnect = false, bool includexfers = false, MegaRequestListener* listener = NULL);
         void setDnsServers(const char *dnsServers, MegaRequestListener* listener = NULL);
-        static void addEntropy(char* data, unsigned int size);
+        void addEntropy(char* data, unsigned int size);
         static string userAttributeToString(int);
         static string userAttributeToLongName(int);
         static int userAttributeFromString(const char *name);

--- a/src/backofftimer.cpp
+++ b/src/backofftimer.cpp
@@ -25,7 +25,8 @@
 
 namespace mega {
 // timer with capped exponential backoff
-BackoffTimer::BackoffTimer()
+BackoffTimer::BackoffTimer(PrnGen &rng)
+    : rng(rng)
 {
     reset();
 }
@@ -48,7 +49,7 @@ void BackoffTimer::backoff()
         base = 6000;
     }
 
-    delta = base + (dstime)((base / 2.0) * (PrnGen::genuint32(RAND_MAX)/(float)RAND_MAX));
+    delta = base + (dstime)((base / 2.0) * (rng.genuint32(RAND_MAX)/(float)RAND_MAX));
 }
 
 void BackoffTimer::backoff(dstime newdelta)
@@ -129,7 +130,8 @@ void BackoffTimer::update(dstime* waituntil)
     }
 }
 
-TimerWithBackoff::TimerWithBackoff(int tag)
+TimerWithBackoff::TimerWithBackoff(PrnGen &rng, int tag)
+    : BackoffTimer(rng)
 {
     this->tag = tag;
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -209,7 +209,7 @@ void CommandGetFA::procresult()
                     {
                         Node::copystring(&it->second->posturl, p);
                         it->second->urltime = Waiter::ds;
-                        it->second->dispatch(client);
+                        it->second->dispatch();
                     }
                     else
                     {
@@ -1857,7 +1857,7 @@ CommandSetShare::CommandSetShare(MegaClient* client, Node* n, User* u, accesslev
 
         if (u && u->pubk.isvalid())
         {
-            t = u->pubk.encrypt(asymmkey, SymmCipher::KEYLENGTH, asymmkey, sizeof asymmkey);
+            t = u->pubk.encrypt(client->rng, asymmkey, SymmCipher::KEYLENGTH, asymmkey, sizeof asymmkey);
         }
 
         // outgoing handle authentication
@@ -2533,7 +2533,7 @@ void CommandPutMultipleUAVer::procresult()
                         string prEd255 = tlvRecords->get(EdDSA::TLV_KEY);
                         if (prEd255.size() == EdDSA::SEED_KEY_LENGTH)
                         {
-                            client->signkey = new EdDSA((unsigned char *) prEd255.data());
+                            client->signkey = new EdDSA(client->rng, (unsigned char *) prEd255.data());
                         }
                     }
 
@@ -2651,7 +2651,7 @@ void CommandPutUAVer::procresult()
     }
 }
 
-CommandPutUA::CommandPutUA(MegaClient* client, attr_t at, const byte* av, unsigned avl, int ctag)
+CommandPutUA::CommandPutUA(MegaClient* /*client*/, attr_t at, const byte* av, unsigned avl, int ctag)
 {
     this->at = at;
     this->av.assign((const char*)av, avl);
@@ -2868,7 +2868,7 @@ void CommandGetUA::procresult()
                             }
 
                             // store the value for private user attributes (decrypted version of serialized TLV)
-                            string *tlvString = tlvRecords->tlvRecordsToContainer(&client->key);
+                            string *tlvString = tlvRecords->tlvRecordsToContainer(client->rng, &client->key);
                             u->setattr(at, tlvString, &version);
                             delete tlvString;
                             client->app->getua_result(tlvRecords);

--- a/src/crypto/sodium.cpp
+++ b/src/crypto/sodium.cpp
@@ -29,7 +29,7 @@ namespace mega
 
 const std::string EdDSA::TLV_KEY = "prEd255";
 
-EdDSA::EdDSA(unsigned char *keySeed)
+EdDSA::EdDSA(PrnGen &rng, unsigned char *keySeed)
 {
     initializationOK = false;
 
@@ -45,7 +45,7 @@ EdDSA::EdDSA(unsigned char *keySeed)
     }
     else    // make the new key seed.
     {
-        PrnGen::genblock(this->keySeed, EdDSA::SEED_KEY_LENGTH);
+        rng.genblock(this->keySeed, EdDSA::SEED_KEY_LENGTH);
     }
 
     // derive public and private keys from the seed

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -24,7 +24,8 @@
 #include "mega/logging.h"
 
 namespace mega {
-DbTable::DbTable()
+DbTable::DbTable(PrnGen &rng)
+    : rng(rng)
 {
     nextid = 0;
 }
@@ -48,7 +49,7 @@ bool DbTable::put(uint32_t type, Cachable* record, SymmCipher* key)
         return true;
     }
 
-    PaddedCBC::encrypt(&data, key);
+    PaddedCBC::encrypt(rng, &data, key);
 
     if (!record->dbid)
     {

--- a/src/db/sqlite.cpp
+++ b/src/db/sqlite.cpp
@@ -35,7 +35,7 @@ SqliteDbAccess::~SqliteDbAccess()
 {
 }
 
-DbTable* SqliteDbAccess::open(FileSystemAccess* fsaccess, string* name, bool recycleLegacyDB)
+DbTable* SqliteDbAccess::open(PrnGen &rng, FileSystemAccess* fsaccess, string* name, bool recycleLegacyDB)
 {
     //Each table will use its own database object and its own file
     sqlite3* db;
@@ -134,10 +134,11 @@ DbTable* SqliteDbAccess::open(FileSystemAccess* fsaccess, string* name, bool rec
         return NULL;
     }
 
-    return new SqliteDbTable(db, fsaccess, &dbfile);
+    return new SqliteDbTable(rng, db, fsaccess, &dbfile);
 }
 
-SqliteDbTable::SqliteDbTable(sqlite3* cdb, FileSystemAccess *fs, string *filepath)
+SqliteDbTable::SqliteDbTable(PrnGen &rng, sqlite3* cdb, FileSystemAccess *fs, string *filepath)
+    : DbTable(rng)
 {
     db = cdb;
     pStmt = NULL;

--- a/src/fileattributefetch.cpp
+++ b/src/fileattributefetch.cpp
@@ -25,7 +25,8 @@
 #include "mega/logging.h"
 
 namespace mega {
-FileAttributeFetchChannel::FileAttributeFetchChannel()
+FileAttributeFetchChannel::FileAttributeFetchChannel(MegaClient* client)
+    : client(client), bt(client->rng), timeout(client->rng)
 {
     req.binary = true;
     req.status = REQ_READY;
@@ -44,7 +45,7 @@ FileAttributeFetch::FileAttributeFetch(handle h, string key, fatype t, int ctag)
     tag = ctag;
 }
 
-void FileAttributeFetchChannel::dispatch(MegaClient* client)
+void FileAttributeFetchChannel::dispatch()
 {
     faf_map::iterator it;
  
@@ -90,7 +91,7 @@ void FileAttributeFetchChannel::dispatch(MegaClient* client)
 }
 
 // communicate received file attributes to the application
-void FileAttributeFetchChannel::parse(MegaClient* client, int /*fac*/, bool final)
+void FileAttributeFetchChannel::parse(int /*fac*/, bool final)
 {
 #pragma pack(push,1)
     struct FaHeader
@@ -152,7 +153,7 @@ void FileAttributeFetchChannel::parse(MegaClient* client, int /*fac*/, bool fina
 }
 
 // notify the application of the request failure and remove records no longer needed
-void FileAttributeFetchChannel::failed(MegaClient* client)
+void FileAttributeFetchChannel::failed()
 {
     for (faf_map::iterator it = fafs[1].begin(); it != fafs[1].end(); )
     {

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -769,7 +769,8 @@ m_off_t SpeedController::getMeanSpeed()
     return meanSpeed;
 }
 
-GenericHttpReq::GenericHttpReq(bool binary) : HttpReq(binary)
+GenericHttpReq::GenericHttpReq(PrnGen &rng, bool binary)
+    : HttpReq(binary), bt(rng), maxbt(rng)
 {
     tag = 0;
     maxretries = 0;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1723,7 +1723,7 @@ void MegaApi::fetchTimeZone(MegaRequestListener *listener)
 
 void MegaApi::addEntropy(char *data, unsigned int size)
 {
-    MegaApiImpl::addEntropy(data, size);
+    pImpl->addEntropy(data, size);
 }
 
 #ifdef WINDOWS_PHONE

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4846,9 +4846,9 @@ void MegaApiImpl::setDnsServers(const char *dnsServers, MegaRequestListener *lis
 
 void MegaApiImpl::addEntropy(char *data, unsigned int size)
 {
-    if(PrnGen::rng.CanIncorporateEntropy())
+    if(client && client->rng.CanIncorporateEntropy())
     {
-        PrnGen::rng.IncorporateEntropy((const byte*)data, size);
+        client->rng.IncorporateEntropy((const byte*)data, size);
     }
 
 #ifdef USE_OPENSSL
@@ -16613,7 +16613,7 @@ void MegaApiImpl::sendPendingRequests()
 			newnode->parenthandle = UNDEF;
 
 			// generate fresh random key for this folder node
-			PrnGen::genblock(buf,FOLDERNODEKEYLENGTH);
+            client->rng.genblock(buf,FOLDERNODEKEYLENGTH);
 			newnode->nodekey.assign((char*)buf,FOLDERNODEKEYLENGTH);
 			key.setkey(buf);
 
@@ -17429,7 +17429,7 @@ void MegaApiImpl::sendPendingRequests()
                 delete keys;
 
                 // serialize and encrypt the TLV container
-                string *container = tlv.tlvRecordsToContainer(&client->key);
+                string *container = tlv.tlvRecordsToContainer(client->rng, &client->key);
 
                 client->putua(type, (byte *)container->data(), unsigned(container->size()));
                 delete container;
@@ -18661,7 +18661,7 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_TIMER:
         {
             int delta = int(request->getNumber());
-            TimerWithBackoff *twb = new TimerWithBackoff(request->getTag());
+            TimerWithBackoff *twb = new TimerWithBackoff(client->rng, request->getTag());
             twb->backoff(delta);
             e = client->addtimer(twb);
             break;
@@ -19731,7 +19731,7 @@ void TreeProcCopy::proc(MegaClient* client, Node* n)
 		else
 		{
 			byte buf[FOLDERNODEKEYLENGTH];
-			PrnGen::genblock(buf,sizeof buf);
+            client->rng.genblock(buf,sizeof buf);
 			t->nodekey.assign((char*)buf,FOLDERNODEKEYLENGTH);
 		}
 
@@ -21133,7 +21133,7 @@ bool MegaTreeProcCopy::processMegaNode(MegaNode *n)
         else
         {
             byte buf[FOLDERNODEKEYLENGTH];
-            PrnGen::genblock(buf,sizeof buf);
+            client->rng.genblock(buf,sizeof buf);
             t->nodekey.assign((char*)buf, FOLDERNODEKEYLENGTH);
         }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1041,8 +1041,10 @@ void MegaClient::init()
 }
 
 MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, DbAccess* d, GfxProc* g, const char* k, const char* u)
-    : useralerts(*this), btugexpiration(rng), btcs(rng), btbadhost(rng), btworkinglock(rng), btsc(rng), btpfa(rng),
-      syncfslockretrybt(rng), syncdownbt(rng), syncnaglebt(rng), syncextrabt(rng), syncscanbt(rng)
+    : useralerts(*this), btugexpiration(rng), btcs(rng), btbadhost(rng), btworkinglock(rng), btsc(rng), btpfa(rng)
+#ifdef ENABLE_SYNC
+    ,syncfslockretrybt(rng), syncdownbt(rng), syncnaglebt(rng), syncextrabt(rng), syncscanbt(rng)
+#endif
 {
     sctable = NULL;
     pendingsccommit = false;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -688,11 +688,11 @@ void MegaClient::confirmrecoverylink(const char *code, const char *email, const 
         {
             // create a new masterkey
             byte masterkey[SymmCipher::KEYLENGTH];
-            PrnGen::genblock(masterkey, sizeof masterkey);
+            rng.genblock(masterkey, sizeof masterkey);
 
             // generate a new session
             byte initialSession[2 * SymmCipher::KEYLENGTH];
-            PrnGen::genblock(initialSession, sizeof initialSession);
+            rng.genblock(initialSession, sizeof initialSession);
             key.setkey(masterkey);
             key.ecb_encrypt(initialSession, initialSession + SymmCipher::KEYLENGTH, SymmCipher::KEYLENGTH);
 
@@ -705,7 +705,7 @@ void MegaClient::confirmrecoverylink(const char *code, const char *email, const 
     else
     {
         byte clientkey[SymmCipher::KEYLENGTH];
-        PrnGen::genblock(clientkey, sizeof(clientkey));
+        rng.genblock(clientkey, sizeof(clientkey));
 
         string salt;
         HashSHA256 hasher;
@@ -741,11 +741,11 @@ void MegaClient::confirmrecoverylink(const char *code, const char *email, const 
         {
             // create a new masterkey
             byte masterkey[SymmCipher::KEYLENGTH];
-            PrnGen::genblock(masterkey, sizeof masterkey);
+            rng.genblock(masterkey, sizeof masterkey);
 
             // generate a new session
             byte initialSession[2 * SymmCipher::KEYLENGTH];
-            PrnGen::genblock(initialSession, sizeof initialSession);
+            rng.genblock(initialSession, sizeof initialSession);
             key.setkey(masterkey);
             key.ecb_encrypt(initialSession, initialSession + SymmCipher::KEYLENGTH, SymmCipher::KEYLENGTH);
 
@@ -1041,7 +1041,8 @@ void MegaClient::init()
 }
 
 MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, DbAccess* d, GfxProc* g, const char* k, const char* u)
-    : useralerts(*this)
+    : useralerts(*this), btugexpiration(rng), btcs(rng), btbadhost(rng), btworkinglock(rng), btsc(rng), btpfa(rng),
+      syncfslockretrybt(rng), syncdownbt(rng), syncnaglebt(rng), syncextrabt(rng), syncscanbt(rng)
 {
     sctable = NULL;
     pendingsccommit = false;
@@ -1141,13 +1142,13 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
     // actions in server-client stream)
     for (i = sizeof sessionid; i--; )
     {
-        sessionid[i] = 'a' + PrnGen::genuint32(26);
+        sessionid[i] = 'a' + rng.genuint32(26);
     }
 
     // initialize random API request sequence ID (server API is idempotent)
     for (i = sizeof reqid; i--; )
     {
-        reqid[i] = 'a' + PrnGen::genuint32(26);
+        reqid[i] = 'a' + rng.genuint32(26);
     }
 
     nextuh = 0;  
@@ -1489,11 +1490,11 @@ void MegaClient::exec()
                         }
                         else
                         {
-                            fc->parse(this, cit->first, true);
+                            fc->parse(cit->first, true);
                         }
 
                         // notify app in case some attributes were not returned, then redispatch
-                        fc->failed(this);
+                        fc->failed();
                         fc->req.disconnect();
                         fc->req.status = REQ_PREPARED;
                         fc->timeout.reset();
@@ -1509,7 +1510,7 @@ void MegaClient::exec()
                         if (fc->inbytes != fc->req.in.size())
                         {
                             httpio->lock();
-                            fc->parse(this, cit->first, false);
+                            fc->parse(cit->first, false);
                             httpio->unlock();
 
                             fc->timeout.backoff(100);
@@ -1534,7 +1535,7 @@ void MegaClient::exec()
                             sendevent(99436, "Automatic change to HTTPS", 0);
                         }
 
-                        fc->failed(this);
+                        fc->failed();
                         fc->timeout.reset();
                         fc->bt.backoff();
                         fc->urltime = 0;
@@ -1560,7 +1561,7 @@ void MegaClient::exec()
                     {
                         // redispatch cached URL if not older than one minute
                         LOG_debug << "Using cached download URL";
-                        fc->dispatch(this);
+                        fc->dispatch();
                     }
                 }
             }
@@ -3064,7 +3065,7 @@ bool MegaClient::dispatch(direction_t d)
             {
                 // generate fresh random encryption key/CTR IV for this file
                 byte keyctriv[SymmCipher::KEYLENGTH + sizeof(int64_t)];
-                PrnGen::genblock(keyctriv, sizeof keyctriv);
+                rng.genblock(keyctriv, sizeof keyctriv);
                 memcpy(nexttransfer->transferkey, keyctriv, SymmCipher::KEYLENGTH);
                 nexttransfer->ctriv = MemAccess::get<uint64_t>((const char*)keyctriv + SymmCipher::KEYLENGTH);
             }
@@ -3684,7 +3685,7 @@ void MegaClient::getlocalsslcertificate()
 
 void MegaClient::dnsrequest(const char *hostname)
 {
-    GenericHttpReq *req = new GenericHttpReq();
+    GenericHttpReq *req = new GenericHttpReq(rng);
     req->tag = reqtag;
     req->maxretries = 0;
     pendinghttp[reqtag] = req;
@@ -3694,7 +3695,7 @@ void MegaClient::dnsrequest(const char *hostname)
 
 void MegaClient::gelbrequest(const char *service, int timeoutds, int retries)
 {
-    GenericHttpReq *req = new GenericHttpReq();
+    GenericHttpReq *req = new GenericHttpReq(rng);
     req->tag = reqtag;
     req->maxretries = retries;
     if (timeoutds > 0)
@@ -3711,7 +3712,7 @@ void MegaClient::gelbrequest(const char *service, int timeoutds, int retries)
 
 void MegaClient::sendchatstats(const char *json, int port)
 {
-    GenericHttpReq *req = new GenericHttpReq();
+    GenericHttpReq *req = new GenericHttpReq(rng);
     req->tag = reqtag;
     req->maxretries = 0;
     pendinghttp[reqtag] = req;
@@ -3731,7 +3732,7 @@ void MegaClient::sendchatstats(const char *json, int port)
 
 void MegaClient::sendchatlogs(const char *json, const char *aid, int port)
 {
-    GenericHttpReq *req = new GenericHttpReq();
+    GenericHttpReq *req = new GenericHttpReq(rng);
     req->tag = reqtag;
     req->maxretries = 0;
     pendinghttp[reqtag] = req;
@@ -3753,7 +3754,7 @@ void MegaClient::sendchatlogs(const char *json, const char *aid, int port)
 
 void MegaClient::httprequest(const char *url, int method, bool binary, const char *json, int retries)
 {
-    GenericHttpReq *req = new GenericHttpReq(binary);
+    GenericHttpReq *req = new GenericHttpReq(rng, binary);
     req->tag = reqtag;
     req->maxretries = retries;
     pendinghttp[reqtag] = req;
@@ -4447,7 +4448,7 @@ error MegaClient::getfa(handle h, string *fileattrstring, string *nodekey, fatyp
 
         if (!*fafcp)
         {
-            *fafcp = new FileAttributeFetchChannel();
+            *fafcp = new FileAttributeFetchChannel(this);
         }
 
         if (!(*fafcp)->fafs[1].count(fah))
@@ -7666,7 +7667,7 @@ void MegaClient::login(const char* email, const byte* pwkey, const char* pin)
     uint64_t emailhash = stringhash64(&lcemail, &key);
 
     byte sek[SymmCipher::KEYLENGTH];
-    PrnGen::genblock(sek, sizeof sek);
+    rng.genblock(sek, sizeof sek);
 
     reqs.add(new CommandLogin(this, email, (byte*)&emailhash, sizeof(emailhash), sek, 0, pin));
 }
@@ -7691,7 +7692,7 @@ void MegaClient::login2(const char *email, const byte *derivedKey, const char* p
     const byte *authKey = derivedKey + SymmCipher::KEYLENGTH;
 
     byte sek[SymmCipher::KEYLENGTH];
-    PrnGen::genblock(sek, sizeof sek);
+    rng.genblock(sek, sizeof sek);
 
     reqs.add(new CommandLogin(this, email, authKey, SymmCipher::KEYLENGTH, sek, 0, pin));
 }
@@ -7701,7 +7702,7 @@ void MegaClient::fastlogin(const char* email, const byte* pwkey, uint64_t emailh
     key.setkey((byte*)pwkey);
 
     byte sek[SymmCipher::KEYLENGTH];
-    PrnGen::genblock(sek, sizeof sek);
+    rng.genblock(sek, sizeof sek);
 
     reqs.add(new CommandLogin(this, email, (byte*)&emailhash, sizeof(emailhash), sek));
 }
@@ -7751,7 +7752,7 @@ void MegaClient::login(const byte* session, int size)
         }
 
         byte sek[SymmCipher::KEYLENGTH];
-        PrnGen::genblock(sek, sizeof sek);
+        rng.genblock(sek, sizeof sek);
 
         reqs.add(new CommandLogin(this, NULL, NULL, 0, sek, sessionversion));
         getuserdata();
@@ -7907,7 +7908,7 @@ void MegaClient::opensctable()
 
         if (dbname.size())
         {
-            sctable = dbaccess->open(fsaccess, &dbname);
+            sctable = dbaccess->open(rng, fsaccess, &dbname);
             pendingsccommit = false;
         }
     }
@@ -8446,7 +8447,7 @@ error MegaClient::creditcardstore(const char *ccplain)
 
     string ccenc;
     string ccplain1 = ccplain;
-    PayCrypter payCrypter;
+    PayCrypter payCrypter(rng);
     if (!payCrypter.hybridEncrypt(&ccplain1, pubkdata, pubkdatalen, &ccenc))
     {
         return API_EARGS;
@@ -9803,7 +9804,7 @@ error MegaClient::encryptlink(const char *link, const char *pwd, string *encrypt
         // Derive MAC key with salt+pwd
         byte derivedKey[64];
         byte salt[32];
-        PrnGen::genblock(salt, 32);
+        rng.genblock(salt, 32);
         unsigned int iterations = 100000;
         PBKDF2_HMAC_SHA512 pbkdf2;
         pbkdf2.deriveKey(derivedKey, sizeof derivedKey,
@@ -9928,7 +9929,7 @@ error MegaClient::changepw(const char* password, const char *pin)
     }
 
     byte clientRandomValue[SymmCipher::KEYLENGTH];
-    PrnGen::genblock(clientRandomValue, sizeof(clientRandomValue));
+    rng.genblock(clientRandomValue, sizeof(clientRandomValue));
 
     string salt;
     HashSHA256 hasher;
@@ -9966,9 +9967,9 @@ void MegaClient::createephemeral()
     byte pwbuf[SymmCipher::KEYLENGTH];
     byte sscbuf[2 * SymmCipher::KEYLENGTH];
 
-    PrnGen::genblock(keybuf, sizeof keybuf);
-    PrnGen::genblock(pwbuf, sizeof pwbuf);
-    PrnGen::genblock(sscbuf, sizeof sscbuf);
+    rng.genblock(keybuf, sizeof keybuf);
+    rng.genblock(pwbuf, sizeof pwbuf);
+    rng.genblock(sscbuf, sizeof sscbuf);
 
     key.setkey(keybuf);
     key.ecb_encrypt(sscbuf, sscbuf + SymmCipher::KEYLENGTH, SymmCipher::KEYLENGTH);
@@ -9990,9 +9991,9 @@ void MegaClient::sendsignuplink(const char* email, const char* name, const byte*
     byte c[2 * SymmCipher::KEYLENGTH];
 
     memcpy(c, key.key, sizeof key.key);
-    PrnGen::genblock(c + SymmCipher::KEYLENGTH, SymmCipher::KEYLENGTH / 4);
+    rng.genblock(c + SymmCipher::KEYLENGTH, SymmCipher::KEYLENGTH / 4);
     memset(c + SymmCipher::KEYLENGTH + SymmCipher::KEYLENGTH / 4, 0, SymmCipher::KEYLENGTH / 2);
-    PrnGen::genblock(c + 2 * SymmCipher::KEYLENGTH - SymmCipher::KEYLENGTH / 4, SymmCipher::KEYLENGTH / 4);
+    rng.genblock(c + 2 * SymmCipher::KEYLENGTH - SymmCipher::KEYLENGTH / 4, SymmCipher::KEYLENGTH / 4);
 
     pwcipher.ecb_encrypt(c, c, sizeof c);
 
@@ -10002,7 +10003,7 @@ void MegaClient::sendsignuplink(const char* email, const char* name, const byte*
 string MegaClient::sendsignuplink2(const char *email, const char *password, const char* name)
 {
     byte clientrandomvalue[SymmCipher::KEYLENGTH];
-    PrnGen::genblock(clientrandomvalue, sizeof(clientrandomvalue));
+    rng.genblock(clientrandomvalue, sizeof(clientrandomvalue));
 
     string salt;
     HashSHA256 hasher;
@@ -10063,7 +10064,7 @@ void MegaClient::setkeypair()
 
     string privks, pubks;
 
-    asymkey.genkeypair(asymkey.key, pubk, 2048);
+    asymkey.genkeypair(rng, asymkey.key, pubk, 2048);
 
     AsymmCipher::serializeintarray(pubk, AsymmCipher::PUBKEY, &pubks);
     AsymmCipher::serializeintarray(asymkey.key, AsymmCipher::PRIVKEY, &privks);
@@ -10072,7 +10073,7 @@ void MegaClient::setkeypair()
     unsigned t = unsigned(privks.size());
 
     privks.resize((t + SymmCipher::BLOCKSIZE - 1) & - SymmCipher::BLOCKSIZE);
-    PrnGen::genblock((byte*)(privks.data() + t), int(privks.size() - t));
+    rng.genblock((byte*)(privks.data() + t), int(privks.size() - t));
 
     key.ecb_encrypt((byte*)privks.data(), (byte*)privks.data(), (unsigned)privks.size());
 
@@ -10271,7 +10272,7 @@ void MegaClient::enabletransferresumption(const char *loggedoutid)
 
     dbname.insert(0, "transfers_");
 
-    tctable = dbaccess->open(fsaccess, &dbname, true);
+    tctable = dbaccess->open(rng, fsaccess, &dbname, true);
     if (!tctable)
     {
         return;
@@ -10365,7 +10366,7 @@ void MegaClient::disabletransferresumption(const char *loggedoutid)
     }
     dbname.insert(0, "transfers_");
 
-    tctable = dbaccess->open(fsaccess, &dbname, true);
+    tctable = dbaccess->open(rng, fsaccess, &dbname, true);
     if (!tctable)
     {
         return;
@@ -10533,7 +10534,7 @@ void MegaClient::initializekeys()
                 string prEd255 = tlvRecords->get(EdDSA::TLV_KEY);
                 if (prEd255.size() == EdDSA::SEED_KEY_LENGTH)
                 {
-                    signkey = new EdDSA((unsigned char *) prEd255.data());
+                    signkey = new EdDSA(rng, (unsigned char *) prEd255.data());
                     if (!signkey->initializationOK)
                     {
                         delete signkey;
@@ -10672,7 +10673,7 @@ void MegaClient::initializekeys()
         else    // No keys were set --> generate keypairs and related attributes
         {
             // generate keypairs
-            EdDSA *signkey = new EdDSA();
+            EdDSA *signkey = new EdDSA(rng);
             ECDH *chatkey = new ECDH();
 
             if (!chatkey->initializationOK || !signkey->initializationOK)
@@ -10688,7 +10689,7 @@ void MegaClient::initializekeys()
             TLVstore tlvRecords;
             tlvRecords.set(EdDSA::TLV_KEY, string((const char*)signkey->keySeed, EdDSA::SEED_KEY_LENGTH));
             tlvRecords.set(ECDH::TLV_KEY, string((const char*)chatkey->privKey, ECDH::PRIVATE_KEY_LENGTH));
-            string *tlvContainer = tlvRecords.tlvRecordsToContainer(&key);
+            string *tlvContainer = tlvRecords.tlvRecordsToContainer(rng, &key);
 
             // prepare signatures
             string pubkStr;
@@ -12198,7 +12199,7 @@ void MegaClient::syncupdate()
                 {
                     // this is a folder - create, use fresh key & attributes
                     nnp->nodekey.resize(FOLDERNODEKEYLENGTH);
-                    PrnGen::genblock((byte*)nnp->nodekey.data(), FOLDERNODEKEYLENGTH);
+                    rng.genblock((byte*)nnp->nodekey.data(), FOLDERNODEKEYLENGTH);
                     tattrs.map.clear();
                 }
 
@@ -12547,7 +12548,7 @@ void MegaClient::execmovetosyncdebris()
             nn->parenthandle = i ? 0 : UNDEF;
 
             nn->nodekey.resize(FOLDERNODEKEYLENGTH);
-            PrnGen::genblock((byte*)nn->nodekey.data(), FOLDERNODEKEYLENGTH);
+            rng.genblock((byte*)nn->nodekey.data(), FOLDERNODEKEYLENGTH);
 
             // set new name, encrypt and attach attributes
             tattrs.map['n'] = (i || target == SYNCDEL_DEBRIS) ? buf : SYNCDEBRISFOLDERNAME;

--- a/src/pubkeyaction.cpp
+++ b/src/pubkeyaction.cpp
@@ -46,7 +46,7 @@ void PubKeyActionPutNodes::proc(MegaClient* client, User* u)
         // re-encrypt all node keys to the user's public key
         for (int i = nc; i--;)
         {
-            if (!(t = u->pubk.encrypt((const byte*)nn[i].nodekey.data(), nn[i].nodekey.size(), buf, sizeof buf)))
+            if (!(t = u->pubk.encrypt(client->rng, (const byte*)nn[i].nodekey.data(), nn[i].nodekey.size(), buf, sizeof buf)))
             {
                 return client->app->putnodes_result(API_EINTERNAL, USER_HANDLE, nn);
             }
@@ -78,7 +78,7 @@ void PubKeyActionSendShareKey::proc(MegaClient* client, User* u)
         int t;
         byte buf[AsymmCipher::MAXKEYLENGTH];
 
-        if ((t = u->pubk.encrypt(n->sharekey->key, SymmCipher::KEYLENGTH, buf, sizeof buf)))
+        if ((t = u->pubk.encrypt(client->rng, n->sharekey->key, SymmCipher::KEYLENGTH, buf, sizeof buf)))
         {
             client->reqs.add(new CommandShareKeyUpdate(client, sh, u->uid.c_str(), buf, t));
         }
@@ -102,7 +102,7 @@ void PubKeyActionCreateShare::proc(MegaClient* client, User* u)
         // no: create
         byte key[SymmCipher::KEYLENGTH];
 
-        PrnGen::genblock(key, sizeof key);
+        client->rng.genblock(key, sizeof key);
 
         n->sharekey = new SymmCipher(key);
     }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -114,7 +114,7 @@ Sync::Sync(MegaClient* cclient, string* crootpath, const char* cdebris,
             dbname.resize(sizeof tableid * 4 / 3 + 3);
             dbname.resize(Base64::btoa((byte*)tableid, sizeof tableid, (char*)dbname.c_str()));
 
-            statecachetable = client->dbaccess->open(client->fsaccess, &dbname);
+            statecachetable = client->dbaccess->open(client->rng, client->fsaccess, &dbname);
 
             readstatecache();
         }

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -33,6 +33,7 @@
 namespace mega {
 
 Transfer::Transfer(MegaClient* cclient, direction_t ctype)
+    : bt(cclient->rng)
 {
     type = ctype;
     client = cclient;

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -50,6 +50,7 @@ const dstime TransferSlot::PROGRESSTIMEOUT = 10;
 const m_off_t TransferSlot::MAX_UPLOAD_GAP = 62914560; // 60 MB (up to 63 chunks)
 
 TransferSlot::TransferSlot(Transfer* ctransfer)
+    : retrybt(transfer->client->rng)
 {
     starttime = 0;
     lastprogressreport = 0;

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -50,7 +50,7 @@ const dstime TransferSlot::PROGRESSTIMEOUT = 10;
 const m_off_t TransferSlot::MAX_UPLOAD_GAP = 62914560; // 60 MB (up to 63 chunks)
 
 TransferSlot::TransferSlot(Transfer* ctransfer)
-    : retrybt(transfer->client->rng)
+    : retrybt(ctransfer->client->rng)
 {
     starttime = 0;
     lastprogressreport = 0;

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -230,7 +230,7 @@ User* User::unserialize(MegaClient* client, string* d)
         {
             if (tlvRecords->find(EdDSA::TLV_KEY))
             {
-                client->signkey = new EdDSA((unsigned char *) tlvRecords->get(EdDSA::TLV_KEY).data());
+                client->signkey = new EdDSA(client->rng, (unsigned char *) tlvRecords->get(EdDSA::TLV_KEY).data());
                 if (!client->signkey->initializationOK)
                 {
                     delete client->signkey;

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -210,7 +210,8 @@ TEST(Crypto, Ed25519_Signing)
     ASSERT_EQ(keySeedLen, Base64::atob(prEd255str.data(), keySeed, keySeedLen))
             << "Failed to convert Ed25519 private key to binary";
 
-    EdDSA signkey(keySeed);
+    PrnGen rng;
+    EdDSA signkey(rng, keySeed);
 
     string puEd255bin;
     puEd255bin.resize(puEd255str.size() * 3 / 4 + 3);
@@ -311,7 +312,7 @@ TEST(Crypto, Ed25519_Signing)
     string sig;
     for (int i = 0; i < 100; i++)
     {
-        PrnGen::genblock(key, keylen);
+        rng.genblock(key, keylen);
         signkey.signKey((unsigned char *) key, keylen, &sig);
 
         ASSERT_TRUE(signkey.verifyKey((unsigned char*) pubRSAbin.data(), pubRSAbin.size(),

--- a/tests/paycrypt_test.cpp
+++ b/tests/paycrypt_test.cpp
@@ -121,8 +121,9 @@ TEST(PayCrypterTest, allFeatures)
 
 
     //Test PayCrypter:encryptPayload()
+    PrnGen rng;
     string payCrypterResult;
-    PayCrypter payCrypter;
+    PayCrypter payCrypter(rng);
     payCrypter.setKeys(enckey, hmacKey, iv);
     ASSERT_TRUE(payCrypter.encryptPayload(&input, &payCrypterResult));
 


### PR DESCRIPTION
In iOS (and probably MacOS), the `backoff()` crashes when it calls `genuint32()`. We suspect the static global object used for random block generation is initialized too late, after the `Backoff` attempts to use
it. This commit aims to make the `PrnGen` dynamic, initialized along with `MegaClient`.