### PR TITLE
Fix overflow of integer

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -3621,7 +3621,7 @@ void CommandGetUserQuota::procresult()
                         LOG_debug << "Account full";
                         client->activateoverquota(0);
                     }
-                    else if (details->storage_used >= (details->storage_max * uslw / 10000))
+                    else if (details->storage_used >= (details->storage_max / 10000 * uslw))
                     {
                         LOG_debug << "Few storage space available";
                         client->setstoragestatus(STORAGE_ORANGE);


### PR DESCRIPTION
Business accounts have unlimited storage, so the maximum is set to the max value by API and it overflows when it's multiplied by `uslw` to calculate the percentage for the overquota's warning.