### PR TITLE
support non-ascii pdf thumbnails in windows

### DIFF
--- a/contrib/build_pdfium/buildpdfium.bat
+++ b/contrib/build_pdfium/buildpdfium.bat
@@ -1,0 +1,85 @@
+: Variables to provide:
+set CONFIGURATION=Release
+set PDFium_BRANCH=chromium/3710
+set PLATFORM=x86
+set GITPATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd
+set WINSDKVER=10.0.17763.0
+
+: Input
+set WindowsSDK_DIR=C:\Program Files (x86)\Windows Kits\10\bin\%WINSDKVER%\%PLATFORM%
+set DepotTools_URL=https://storage.googleapis.com/chrome-infra/depot_tools.zip
+set DepotTools_DIR=%CD%/depot_tools
+set PDFium_URL=https://pdfium.googlesource.com/pdfium.git
+set PDFium_SOURCE_DIR=%CD%\pdfium
+set PDFium_BUILD_DIR=%PDFium_SOURCE_DIR%\out
+set PDFium_PATCH_DIR=%CD%\patches
+set PDFium_ARGS=%CD%\windows.args.gn
+
+: Output
+set PDFium_STAGING_DIR=%CD%\staging
+set PDFium_INCLUDE_DIR=%PDFium_STAGING_DIR%\include
+set PDFium_LIB_DIR=%PDFium_STAGING_DIR%\%PLATFORM%\lib
+set PDFium_ARTIFACT=%CD%\pdfium-windows-%PLATFORM%.zip
+if "%CONFIGURATION%"=="Debug" set PDFium_ARTIFACT=%CD%\pdfium-windows-%PLATFORM%-debug.zip
+
+echo on
+
+: Prepare directories
+mkdir %PDFium_BUILD_DIR%
+mkdir %PDFium_STAGING_DIR%
+mkdir %PDFium_LIB_DIR%
+
+: Download depot_tools
+set PATH=%GITPATH%;%PATH%
+call curl -fsSL -o depot_tools.zip %DepotTools_URL% || exit /b
+if not exist %DepotTools_DIR% powershell Expand-Archive depot_tools.zip %DepotTools_DIR% || exit /b
+
+set PATH=%DepotTools_DIR%;%WindowsSDK_DIR%;%PATH%
+set DEPOT_TOOLS_WIN_TOOLCHAIN=0
+
+: check that rc.exe is in PATH
+where rc.exe || exit /b
+
+:: Clone
+:call gclient config --unmanaged %PDFium_URL% || exit /b
+:call gclient sync || exit /b
+
+:: Checkout branch (or ignore if it doesn't exist)
+echo on
+cd %PDFium_SOURCE_DIR%
+:git.exe checkout %PDFium_BRANCH% && call gclient sync
+
+:: Patch
+cd %PDFium_SOURCE_DIR%
+copy "%PDFium_PATCH_DIR%\resources.rc" . || exit /b
+git.exe apply -v "%PDFium_PATCH_DIR%\shared_library.patch" || exit /b
+git.exe -C build apply -v "%PDFium_PATCH_DIR%\rc_compiler.patch" || exit /b
+
+: Configure
+cd %PDFium_SOURCE_DIR%
+copy %PDFium_ARGS% %PDFium_BUILD_DIR%\args.gn
+if "%CONFIGURATION%"=="Release" echo is_debug=false >> %PDFium_BUILD_DIR%\args.gn
+if "%PLATFORM%"=="x86" echo target_cpu="x86" >> %PDFium_BUILD_DIR%\args.gn
+
+: Generate Ninja files
+call gn gen %PDFium_BUILD_DIR% || exit /b
+
+: Build
+:call ninja -C %PDFium_BUILD_DIR% pdfium -t clean || exit /b
+call ninja -C %PDFium_BUILD_DIR% pdfium -j 5 || exit /b
+
+: Install
+echo on
+copy %PDFium_SOURCE_DIR%\LICENSE %PDFium_STAGING_DIR% || exit /b
+xcopy /S /Y %PDFium_SOURCE_DIR%\public %PDFium_INCLUDE_DIR%\ || exit /b
+del %PDFium_INCLUDE_DIR%\DEPS
+del %PDFium_INCLUDE_DIR%\README
+del %PDFium_INCLUDE_DIR%\PRESUBMIT.py
+move %PDFium_BUILD_DIR%\pdfium.dll.lib %PDFium_LIB_DIR%\pdfium.lib || exit /b
+move %PDFium_BUILD_DIR%\pdfium.dll %PDFium_LIB_DIR% || exit /b
+move %PDFium_BUILD_DIR%\pdfium.dll.pdb %PDFium_LIB_DIR%
+
+: Pack
+cd %PDFium_STAGING_DIR%
+del %PDFium_ARTIFACT%
+call powershell Compress-Archive * %PDFium_ARTIFACT%

--- a/contrib/build_pdfium/patches/rc_compiler.patch
+++ b/contrib/build_pdfium/patches/rc_compiler.patch
@@ -1,0 +1,13 @@
+diff --git a/toolchain/win/BUILD.gn b/toolchain/win/BUILD.gn
+index 43fecc65d..cb6ccd6fd 100644
+--- a/toolchain/win/BUILD.gn
++++ b/toolchain/win/BUILD.gn
+@@ -198,7 +198,7 @@ template("msvc_toolchain") {
+     }
+ 
+     tool("rc") {
+-      command = "$python_path $tool_wrapper_path rc-wrapper $env rc.exe /nologo {{defines}} {{include_dirs}} /fo{{output}} {{source}}"
++      command = "rc.exe /fo{{output}} {{source}}"
+       depsformat = "msvc"
+       outputs = [
+         "$object_subdir/{{source_name_part}}.res",

--- a/contrib/build_pdfium/patches/resources.rc
+++ b/contrib/build_pdfium/patches/resources.rc
@@ -1,0 +1,20 @@
+1 VERSIONINFO
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "CompanyName",      "Google Inc."
+            VALUE "FileDescription",  "PDFium (compiled by github.com/bblanchon)"
+            VALUE "InternalName",     "pdfium"
+            VALUE "OriginalFilename", "pdfium.dll"
+            VALUE "ProductName",      "pdfium"
+            VALUE "LegalCopyright",   "Copyright 2018 PDFium Authors. All rights reserved."
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252
+    END
+END

--- a/contrib/build_pdfium/patches/shared_library.patch
+++ b/contrib/build_pdfium/patches/shared_library.patch
@@ -1,0 +1,64 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 6885fc27d..f4533ee76 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -22,6 +22,7 @@ config("pdfium_common_config") {
+   defines = [
+     "PNG_PREFIX",
+     "PNG_USE_READ_MACROS",
++    "FPDFSDK_EXPORTS"
+   ]
+ 
+   if (!use_system_libopenjpeg2) {
+@@ -132,7 +133,7 @@ jumbo_source_set("pdfium_public_headers") {
+   public_configs = [ ":pdfium_public_config" ]
+ }
+ 
+-jumbo_static_library("pdfium") {
++shared_library("pdfium") {
+   sources = [
+     "fpdfsdk/fpdf_annot.cpp",
+     "fpdfsdk/fpdf_attachment.cpp",
+@@ -202,6 +203,9 @@ jumbo_static_library("pdfium") {
+       "gdi32.lib",
+       "user32.lib",
+     ]
++    sources += [
++      "resources.rc"
++    ]
+   }
+ 
+   if (is_mac) {
+diff --git a/public/fpdfview.h b/public/fpdfview.h
+index 7d78186ac..73a3e1fbb 100644
+--- a/public/fpdfview.h
++++ b/public/fpdfview.h
+@@ -154,13 +154,22 @@ typedef int FPDF_ANNOT_APPEARANCEMODE;
+ // Dictionary value types.
+ typedef int FPDF_OBJECT_TYPE;
+ 
+-#if defined(_WIN32) && defined(FPDFSDK_EXPORTS)
+-// On Windows system, functions are exported in a DLL
+-#define FPDF_EXPORT __declspec(dllexport)
+-#define FPDF_CALLCONV __stdcall
++#ifdef FPDFSDK_EXPORTS
++# if defined(_WIN32)
++#  define FPDF_EXPORT __declspec(dllexport)
++#  define FPDF_CALLCONV __stdcall
++# else
++#  define FPDF_EXPORT __attribute__((visibility("default")))
++#  define FPDF_CALLCONV
++# endif
+ #else
+-#define FPDF_EXPORT
+-#define FPDF_CALLCONV
++# if defined(_WIN32)
++#  define FPDF_EXPORT __declspec(dllimport)
++#  define FPDF_CALLCONV __stdcall
++# else
++#  define FPDF_EXPORT
++#  define FPDF_CALLCONV
++# endif
+ #endif
+ 
+ // Exported Functions

--- a/contrib/build_pdfium/windows.args.gn
+++ b/contrib/build_pdfium/windows.args.gn
@@ -1,0 +1,7 @@
+pdf_is_standalone = true
+pdf_bundle_freetype = true
+is_component_build = false
+is_official_build = true
+is_debug = false
+pdf_enable_xfa = false
+pdf_enable_v8 = false


### PR DESCRIPTION
for non supported filenames use memory loader except for files > 100 MB
(use temporary file for those)