### PR TITLE
Add method to catch up with API

### DIFF
--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -115,6 +115,9 @@ struct MEGA_API MegaApp
     // nodes now (nearly) current
     virtual void nodes_current() { }
 
+    // up to date with API (regarding actionpackets)
+    virtual void catchup_result() { }
+
     // node addition has failed
     virtual void putnodes_result(error, targettype_t, NewNode*) { }
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -464,6 +464,8 @@ public:
     // close all open HTTP connections
     void disconnect();
 
+    // close server-client HTTP connection
+    void catchup();
     // abort lock request
     void abortlockrequest();
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -2456,6 +2456,7 @@ class MegaRequest
             TYPE_ADD_BACKUP, TYPE_REMOVE_BACKUP, TYPE_TIMER, TYPE_ABORT_CURRENT_BACKUP,
             TYPE_GET_PSA, TYPE_FETCH_TIMEZONE, TYPE_USERALERT_ACKNOWLEDGE,
             TYPE_CHAT_LINK_HANDLE, TYPE_CHAT_LINK_URL, TYPE_SET_PRIVATE_MODE, TYPE_AUTOJOIN_PUBLIC_CHAT,
+            TYPE_CATCHUP,
             TOTAL_OF_REQUEST_TYPES
         };
 
@@ -13506,6 +13507,18 @@ class MegaApi
          * @param listener MegaRequestListener to track this request
          */
         void getMegaAchievements(MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Catch up with API for pending actionpackets
+         *
+         * The associated request type with this request is MegaRequest::TYPE_CATCHUP
+         *
+         * When onRequestFinish is called with MegaError::API_OK, the SDK is guaranteed to be
+         * up to date (as for the time this function is called).
+         *
+         * @param listener MegaRequestListener to track this request
+         */
+        void catchup(MegaRequestListener *listener = NULL);
 
 private:
         MegaApiImpl *pImpl;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1696,6 +1696,7 @@ class RequestQueue
         void push(MegaRequestPrivate *request);
         void push_front(MegaRequestPrivate *request);
         MegaRequestPrivate * pop();
+        MegaRequestPrivate * front();
         void removeListener(MegaRequestListener *listener);
 #ifdef ENABLE_SYNC
         void removeListener(MegaSyncListener *listener);
@@ -2276,6 +2277,8 @@ class MegaApiImpl : public MegaApp
         void getAccountAchievements(MegaRequestListener *listener = NULL);
         void getMegaAchievements(MegaRequestListener *listener = NULL);
 
+        void catchup(MegaRequestListener *listener = NULL);
+
         void fireOnTransferStart(MegaTransferPrivate *transfer);
         void fireOnTransferFinish(MegaTransferPrivate *transfer, MegaError e);
         void fireOnTransferUpdate(MegaTransferPrivate *transfer);
@@ -2372,6 +2375,9 @@ protected:
         RequestQueue requestQueue;
         TransferQueue transferQueue;
         map<int, MegaRequestPrivate *> requestMap;
+
+        // sc requests to close existing wsc and immediately retrieve pending actionpackets
+        RequestQueue scRequestQueue;
 
 #ifdef ENABLE_SYNC
         map<int, MegaSyncPrivate *> syncMap;
@@ -2485,6 +2491,7 @@ protected:
         virtual void userattr_update(User*, int, const char*);
 
         virtual void nodes_current();
+        virtual void catchup_result();
 
         virtual void fetchnodes_result(error);
         virtual void putnodes_result(error, targettype_t, NewNode*);
@@ -2655,6 +2662,7 @@ protected:
         // notify about a finished timer
         virtual void timer_result(error);
 
+        void sendPendingScRequest();
         void sendPendingRequests();
         void sendPendingTransfers();
         void updateBackups();

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3543,6 +3543,11 @@ void MegaApi::getMegaAchievements(MegaRequestListener *listener)
     pImpl->getMegaAchievements(listener);
 }
 
+void MegaApi::catchup(MegaRequestListener *listener)
+{
+    pImpl->catchup(listener);
+}
+
 #ifdef HAVE_LIBUV
 bool MegaApi::httpServerStart(bool localOnly, int port, bool useTLS, const char * certificatepath, const char * keypath)
 {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -13446,9 +13446,10 @@ void MegaApiImpl::nodes_current()
 
 void MegaApiImpl::catchup_result()
 {
-    // sc requests are sent sequentially, it must be the one at front
-    MegaRequestPrivate *request = scRequestQueue.pop();
-    if (!request || (request->getType() != MegaRequest::TYPE_CATCHUP)) return;
+    // sc requests are sent sequentially, it must be the one at front and already started (tag == 1)
+    MegaRequestPrivate *request = scRequestQueue.front();
+    if (!request || (request->getType() != MegaRequest::TYPE_CATCHUP) || !request->getTag()) return;
+    request = scRequestQueue.pop();
 
     fireOnRequestFinish(request, API_OK);
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1982,6 +1982,7 @@ void MegaClient::exec()
             }
             pendingsc->posturl.append(auth);
             pendingsc->type = REQ_JSON;
+            LOG_debug << "Sending keep-alive to waitd";
             pendingsc->post(this);
             jsonsc.pos = NULL;
         }
@@ -3502,6 +3503,21 @@ void MegaClient::disconnect()
     app->notify_disconnect();
 }
 
+// force retrieval of pending actionpackets immediately
+// by closing pending sc, reset backoff and clear waitd URL
+void MegaClient::catchup()
+{
+    if (pendingsc)
+    {
+        pendingsc->disconnect();
+
+        delete pendingsc;
+        pendingsc = NULL;
+    }
+    btcs.reset();
+    scnotifyurl.clear();
+}
+
 void MegaClient::abortlockrequest()
 {
     delete workinglockcs;
@@ -3914,6 +3930,7 @@ bool MegaClient::procsc()
                             useralerts.begincatchup = true;
                         }
                     }
+                    app->catchup_result();
                     return true;
 
                 case 'a':


### PR DESCRIPTION
In order to ensure the client is up to date with the server in terms of reception of recent changes (actionpackets), this method closes existing sc connection (if any) and abort the backoff to immediately retrieve changes.
Since the app may require to check this situation several times, app's requests are queued and sent sequentially.