### PR TITLE
Add compiler warning flags for the cmake build

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -471,3 +471,8 @@ endif(WIN32)
 #add_test(NAME SdkTestStreaming COMMAND test_sdk "--gtest_filter=\"*Streaming*\"")
 #add_test(NAME SdkTestAll COMMAND test_sdk )
 
+if (WIN32)
+    set(CMAKE_CXX_FLAGS "/W4 /wd4503 /wd4996 /wd4702 /wd4100")
+else()
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wno-unused-parameter")
+endif()

--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -32,6 +32,13 @@ set (USE_LIBUV 0 CACHE TYPE BOOL)
 if (WIN32)
     set (NO_READLINE 1 CACHE TYPE BOOL)
     set (UNCHECKED_ITERATORS 0 CACHE TYPE BOOL)
+    set(USE_PREBUILT_3RDPARTY 0 CACHE TYPE BOOL)
+    set(HAVE_LIBUV ${USE_LIBUV})
+    IF (USE_WEBRTC)
+        IF ("${WebRtcDir}" STREQUAL "")
+            SET (WebRtcDir "${Mega3rdPartyDir}/libwebrtc/build32debug")
+        ENDIF()
+    ENDIF()
 else(WIN32)
     set(NO_READLINE 0)
     set(USE_PREBUILT_3RDPARTY 0)
@@ -472,7 +479,14 @@ endif(WIN32)
 #add_test(NAME SdkTestAll COMMAND test_sdk )
 
 if (WIN32)
-    set(CMAKE_CXX_FLAGS "/W4 /wd4503 /wd4996 /wd4702 /wd4100")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4201")  # nameless struct/union (nonstandard)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100")  # unreferenced formal parameter
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4706")  # assignment within conditional
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4458")  # identifier hides class member
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4324")  # structure was padded due to alignment specifier (common in Sodium)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4456")  # declaration hides previous local declaration
+    #TODO: remove some of those gradually.  also consider: /wd4503 /wd4996 /wd4702
 else()
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wno-unused-parameter")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wconversion -Wno-unused-parameter")
 endif()

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -5226,7 +5226,7 @@ static void process_line(char* l)
                     }
                     else if (words[0] == "alerts")
                     {
-                        bool shownew = false, showold = false, toggleNotify = false;
+                        bool shownew = false, showold = false;
                         size_t showN = 0; 
                         if (words.size() == 1)
                         {
@@ -5283,7 +5283,7 @@ static void process_line(char* l)
                             {
                                 if ((*i)->relevant)
                                 {
-                                    if (--n < showN || shownew && !(*i)->seen || showold && (*i)->seen)
+                                    if (--n < showN || (shownew && !(*i)->seen) || (showold && (*i)->seen))
                                     {
                                         printAlert(**i);
                                     }

--- a/include/mega/autocomplete.h
+++ b/include/mega/autocomplete.h
@@ -255,6 +255,6 @@ namespace autocomplete {
     ACN remoteFSFolder(MegaClient*, ::mega::handle*, const std::string descriptionPrefix = "");
     ACN contactEmail(MegaClient*);
 
-}}; //namespaces
+}} //namespaces
 #endif
 #endif

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -288,8 +288,6 @@ typedef vector<LocalNode*> localnode_vector;
 
 typedef map<handle, LocalNode*> handlelocalnode_map;
 
-typedef list<LocalNode*> localnode_list;
-
 typedef set<LocalNode*> localnode_set;
 
 typedef multimap<int32_t, LocalNode*> idlocalnode_map;
@@ -343,7 +341,6 @@ typedef vector<handle> handle_vector;
 typedef set<pair<handle, handle> > handlepair_set;
 
 // node and user vectors
-typedef vector<struct NodeCore*> nodecore_vector;
 typedef vector<struct User*> user_vector;
 typedef vector<UserAlert::Base*> useralert_vector;
 typedef vector<struct PendingContactRequest*> pcr_vector;
@@ -357,18 +354,6 @@ typedef map<handle, int> uh_map;
 // maps lowercase user e-mail addresses to userids
 typedef map<string, int> um_map;
 
-// file attribute data
-typedef map<unsigned, string> fadata_map;
-
-// syncid to node handle mapping
-typedef map<handle, handle> syncidhandle_map;
-
-// NewNodes index to syncid mapping
-typedef map<int, handle> newnodesyncid_map;
-
-// for dynamic node addition requests, used by the sync subsystem
-typedef vector<struct NewNode*> newnode_vector;
-
 // file attribute fetch map
 typedef map<handle, FileAttributeFetch*> faf_map;
 
@@ -377,8 +362,6 @@ typedef map<int, FileAttributeFetchChannel*> fafc_map;
 
 // transfer type
 typedef enum { GET = 0, PUT, API, NONE } direction_t;
-
-typedef set<pair<int, handle> > fareq_set;
 
 struct StringCmp
 {
@@ -395,14 +378,6 @@ typedef list<DirectReadSlot*> drs_list;
 
 typedef map<const string*, LocalNode*, StringCmp> localnode_map;
 typedef map<const string*, Node*, StringCmp> remotenode_map;
-
-// FIXME: use forward_list instead
-typedef list<NewNode*> newnode_list;
-typedef list<handle> handle_list;
-
-typedef map<handle, NewNode*> handlenewnode_map;
-
-typedef map<handle, char> handlecount_map;
 
 // maps FileFingerprints to node
 typedef multiset<FileFingerprint*, FileFingerprintCmp> fingerprint_set;

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -3140,7 +3140,7 @@ public:
      *
      * @return Number relative to this event
      */
-    virtual const int getNumber() const;
+    virtual int getNumber() const;
 };
 
 /**

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1115,7 +1115,7 @@ public:
 
     virtual int getType() const;
     virtual const char *getText() const;
-    virtual const int getNumber() const;
+    virtual int getNumber() const;
 
     void setText(const char* text);
     void setNumber(int number);

--- a/src/attrmap.cpp
+++ b/src/attrmap.cpp
@@ -26,11 +26,12 @@ namespace mega {
 // or name length into account
 unsigned AttrMap::storagesize(int perrecord) const
 {
+    assert(perrecord >= 0);
     unsigned t = 0;
 
     for (attr_map::const_iterator it = map.begin(); it != map.end(); it++)
     {
-        t += perrecord + it->second.size();
+        t += static_cast<unsigned>(perrecord + it->second.size());
     }
 
     return t;
@@ -174,7 +175,7 @@ void AttrMap::getjson(string* s) const
             pptr = it->second.c_str();
             ptr = it->second.c_str();
 
-            for (int i = it->second.size(); i-- >= 0; ptr++)
+            for (int i = static_cast<int>(it->second.size()); i-- >= 0; ptr++)
             {
                 if ((i < 0) || ((*(const signed char*)ptr >= 0) && (*ptr < ' ')) || (*ptr == '"') || (*ptr == '\\'))
                 {

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -1002,20 +1002,6 @@ bool autoExec(const std::string line, size_t insertPos, ACN syntax, bool unixSty
     return true;
 }
 
-
-static size_t utf8strlen(const std::string s)
-{
-    size_t len = 0;
-    for (char c : s)
-    {
-        if ((c & 0xC0) != 0x80)
-        {
-            len += 1;
-        }
-    }
-    return len;
-}
-
 unsigned utf8GlyphCount(const string &str) 
 {
     int c, i, ix, q;

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -155,12 +155,12 @@ void GfxProc::loop()
         }
     }
 
-    while (job = requests.pop())
+    while ((job = requests.pop()))
     {
         delete job;
     }
 
-    while (job = responses.pop())
+    while ((job = responses.pop()))
     {
         for (unsigned i = 0; i < job->imagetypes.size(); i++)
         {
@@ -180,7 +180,7 @@ int GfxProc::checkevents(Waiter *)
     GfxJob *job = NULL;
     bool needexec = false;
     SymmCipher key;
-    while (job = responses.pop())
+    while ((job = responses.pop()))
     {
         for (unsigned i = 0; i < job->images.size(); i++)
         {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5463,7 +5463,7 @@ const char *MegaEvent::getText() const
     return NULL;
 }
 
-const int MegaEvent::getNumber() const
+int MegaEvent::getNumber() const
 {
     return 0;
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -28812,7 +28812,7 @@ const char *MegaEventPrivate::getText() const
     return text;
 }
 
-const int MegaEventPrivate::getNumber() const
+int MegaEventPrivate::getNumber() const
 {
     return number;
 }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3971,7 +3971,9 @@ bool MegaClient::procsc()
                      || memcmp(jsonsc.pos + 5, sessionid, sizeof sessionid)
                      || jsonsc.pos[5 + sizeof sessionid] != '"')
                     {
-//                        bool readingPublicChat = false;
+#ifdef ENABLE_CHAT
+                        bool readingPublicChat = false;
+#endif
                         switch (name)
                         {
                             case 'u':

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3971,7 +3971,7 @@ bool MegaClient::procsc()
                      || memcmp(jsonsc.pos + 5, sessionid, sizeof sessionid)
                      || jsonsc.pos[5 + sizeof sessionid] != '"')
                     {
-                        bool readingPublicChat = false;
+//                        bool readingPublicChat = false;
                         switch (name)
                         {
                             case 'u':

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -755,7 +755,7 @@ int Node::hasfileattribute(const string *fileattrstring, fatype t)
     char buf[24];
 
     sprintf(buf, ":%u*", t);
-    return fileattrstring->find(buf) + 1;
+    return static_cast<int>(fileattrstring->find(buf) + 1);
 }
 
 // attempt to apply node key - sets nodekey to a raw key if successful

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -1533,7 +1533,7 @@ bool CurlHttpIO::crackurl(string* url, string* scheme, string* hostname, int* po
         }
         else
         {
-            for (unsigned int i = startport; i < endport; i++)
+            for (size_t i = startport; i < endport; i++)
             {
                 int c = url->data()[i];
 

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -32,7 +32,7 @@ void Request::add(Command* c)
 
 int Request::cmdspending() const
 {
-    return cmds.size();
+    return static_cast<int>(cmds.size());
 }
 
 void Request::get(string* req) const

--- a/src/sharenodekeys.cpp
+++ b/src/sharenodekeys.cpp
@@ -29,7 +29,7 @@ namespace mega {
 // add share node and return its index
 int ShareNodeKeys::addshare(Node* sn)
 {
-    for (int i = shares.size(); i--;)
+    for (int i = static_cast<int>(shares.size()); i--;)
     {
         if (shares[i] == sn)
         {
@@ -39,7 +39,7 @@ int ShareNodeKeys::addshare(Node* sn)
 
     shares.push_back(sn);
 
-    return shares.size() - 1;
+    return static_cast<int>(shares.size() - 1);
 }
 
 void ShareNodeKeys::add(Node* n, Node* sn, int specific)


### PR DESCRIPTION
This also fixes a few compiler warnings.

Unused typdefs are also removed from `include/mega/types.h`.