### PR TITLE
Request an avatar for a non user must return API_ENOENT when the user…

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2850,7 +2850,14 @@ void CommandGetUA::procresult()
 
                     if (!u) // retrieval of attributes without contact-relationship
                     {
-                        client->app->getua_result((byte*) value.data(), unsigned(value.size()));
+                        if (at == ATTR_AVATAR && buf == "none")
+                        {
+                            client->app->getua_result(API_ENOENT);
+                        }
+                        else
+                        {
+                            client->app->getua_result((byte*) value.data(), unsigned(value.size()));
+                        }
                         return;
                     }
 


### PR DESCRIPTION
… doesn't have avatar.