### PR TITLE
restore fseventsfd parameter which is used on iOS (and maybe mac)

### DIFF
--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -607,7 +607,7 @@ PosixFileSystemAccess::PosixFileSystemAccess(int fseventsfd)
         }
     }
 #else
-    fseventsfd;  // suppress warning
+    (void)fseventsfd;  // suppress warning
 #endif
 }
 

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -504,7 +504,7 @@ bool PosixFileAccess::fopen(string* f, bool read, bool write)
     return false;
 }
 
-PosixFileSystemAccess::PosixFileSystemAccess(int /*fseventsfd*/)
+PosixFileSystemAccess::PosixFileSystemAccess(int fseventsfd)
 {
     assert(sizeof(off_t) == 8);
 
@@ -606,6 +606,8 @@ PosixFileSystemAccess::PosixFileSystemAccess(int /*fseventsfd*/)
             close(fd);
         }
     }
+#else
+    fseventsfd;  // suppress warning
 #endif
 }
 


### PR DESCRIPTION
still suppress the warning on other platforms though