### PR TITLE
avoid experimental::filesystem on gcc prior to 5.3

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -36,7 +36,7 @@
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM
-#elif !defined(__MINGW32__) && !defined(__ANDROID__) && ( (__cplusplus >= 201100L) || (defined(_MSC_VER) && _MSC_VER >= 1600) )
+#elif !defined(__MINGW32__) && !defined(__ANDROID__) && ( (__cplusplus >= 201100L) || (defined(_MSC_VER) && _MSC_VER >= 1600) ) && (!defined(__GNUC__) || (__GNUC__*100+__GNUC_MINOR__) >= 503)
 #define USE_FILESYSTEM
 #ifdef WIN32
     #include <filesystem>

--- a/include/mega/autocomplete.h
+++ b/include/mega/autocomplete.h
@@ -19,7 +19,7 @@
 * program.
 */
 
-#if !defined(__MINGW32__) && !defined(__ANDROID__) && ( (__cplusplus >= 201100L) || (defined(_MSC_VER) && _MSC_VER >= 1600) )
+#if !defined(__MINGW32__) && !defined(__ANDROID__) && ( (__cplusplus >= 201100L) || (defined(_MSC_VER) && _MSC_VER >= 1600) ) && (!defined(__GNUC__) || (__GNUC__*100+__GNUC_MINOR__) >= 503)
 // autocomplete for clients using c++11 - so far just megacli and megaclc on windows and linux.
 
 #ifndef MEGA_AUTOCOMPLETE_H

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -19,8 +19,8 @@
 * program.
 */
 
-#if !defined(__MINGW32__) && !defined(__ANDROID__) && ( (__cplusplus >= 201100L) || (defined(_MSC_VER) && _MSC_VER >= 1600) )
-// autocomplete for clients using c++11 capabilities
+#if !defined(__MINGW32__) && !defined(__ANDROID__) && ( (__cplusplus >= 201100L) || (defined(_MSC_VER) && _MSC_VER >= 1600) ) && (!defined(__GNUC__) || (__GNUC__*100+__GNUC_MINOR__) >= 503)
+// autocomplete for clients using c++11 capabilities (and that have filesystem available - the one in experimental namespace is ok)
 
 #include <mega/autocomplete.h>
 #include <mega/megaclient.h>


### PR DESCRIPTION
As it was only added in 5.3.  MEGAcmd for some QNAP devices uses a cross compiling gcc 4.8.2 or 4.9.2