### PR TITLE
Allow streaming in IPv6 networks

### DIFF
--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -1973,7 +1973,7 @@ using namespace mega;
 }
 
 - (NSURL *)httpServerGetLocalLink:(MEGANode *)node {
-    const char *val = self.megaApi->httpServerGetLocalLink([node getCPtr]);
+    const char *val = self.megaApi->httpServerGetLocalLink([node getCPtr], true);
     if (!val) return nil;
     
     NSURL *ret = [NSURL URLWithString:[NSString stringWithUTF8String:val]];

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -12478,9 +12478,10 @@ class MegaApi
          * You take the ownership of the returned value
          *
          * @param node Node to generate the local HTTP link
+         * @param formatIPv6 true to use [::1] as host, false to use 127.0.0.1
          * @return URL to the node in the local HTTP proxy server, otherwise NULL
          */
-        char *httpServerGetLocalLink(MegaNode *node);
+        char *httpServerGetLocalLink(MegaNode *node, bool formatIPv6 = false);
 
         /**
          * @brief Returns a WEBDAV valid URL to a node in the local HTTP proxy server

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2181,7 +2181,7 @@ class MegaApiImpl : public MegaApp
         int httpServerIsRunning();
 
         // management
-        char *httpServerGetLocalLink(MegaNode *node);
+        char *httpServerGetLocalLink(MegaNode *node, bool formatIPv6 = false);
         char *httpServerGetLocalWebDavLink(MegaNode *node);
         MegaStringList *httpServerGetWebDavLinks();
         MegaNodeList *httpServerGetWebDavAllowedNodes();
@@ -2895,7 +2895,7 @@ public:
     int getRestrictedMode();
     bool isHandleAllowed(handle h);
     void clearAllowedHandles();
-    char* getLink(MegaNode *node, std::string protocol = "http");
+    char* getLink(MegaNode *node, std::string protocol = "http", bool formatIPv6 = false);
 
     set<handle> getAllowedHandles();
     void removeAllowedHandle(MegaHandle handle);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3634,9 +3634,9 @@ void MegaApi::httpServerRemoveListener(MegaTransferListener *listener)
     pImpl->httpServerRemoveListener(listener);
 }
 
-char *MegaApi::httpServerGetLocalLink(MegaNode *node)
+char *MegaApi::httpServerGetLocalLink(MegaNode *node, bool formatIPv6)
 {
-    return pImpl->httpServerGetLocalLink(node);
+    return pImpl->httpServerGetLocalLink(node, formatIPv6);
 }
 
 char *MegaApi::httpServerGetLocalWebDavLink(MegaNode *node)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -23048,14 +23048,14 @@ void MegaTCPServer::run()
 
     uv_tcp_keepalive(&server, 0, 0);
 
-    struct sockaddr_in address;
+    struct sockaddr_in6 address;
     if (localOnly)
     {
-        uv_ip4_addr("127.0.0.1", port, &address);
+        uv_ip6_addr("::1", port, &address);
     }
     else
     {
-        uv_ip4_addr("0.0.0.0", port, &address);
+        uv_ip6_addr("::", port, &address);
     }
     uv_connection_cb onNewClientCB;
 #ifdef ENABLE_EVT_TLS
@@ -23134,14 +23134,14 @@ void MegaTCPServer::initializeAndStartListening()
 
     uv_tcp_keepalive(&server, 0, 0);
 
-    struct sockaddr_in address;
+    struct sockaddr_in6 address;
     if (localOnly)
     {
-        uv_ip4_addr("127.0.0.1", port, &address);
+        uv_ip6_addr("::1", port, &address);
     }
     else
     {
-        uv_ip4_addr("0.0.0.0", port, &address);
+        uv_ip6_addr("::", port, &address);
     }
     uv_connection_cb onNewClientCB;
 #ifdef ENABLE_EVT_TLS
@@ -23267,7 +23267,7 @@ char *MegaTCPServer::getLink(MegaNode *node, string protocol)
     allowedHandles.insert(lastHandle);
 
     ostringstream oss;
-    oss << protocol << (useTLS ? "s" : "") << "://127.0.0.1:" << port << "/";
+    oss << protocol << (useTLS ? "s" : "") << "://[::1]:" << port << "/";
     char *base64handle = node->getBase64Handle();
     oss << base64handle;
     delete [] base64handle;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7934,7 +7934,7 @@ int MegaApiImpl::httpServerIsRunning()
     return result;
 }
 
-char *MegaApiImpl::httpServerGetLocalLink(MegaNode *node)
+char *MegaApiImpl::httpServerGetLocalLink(MegaNode *node, bool formatIPv6)
 {
     if (!node)
     {
@@ -7948,7 +7948,7 @@ char *MegaApiImpl::httpServerGetLocalLink(MegaNode *node)
         return NULL;
     }
 
-    char *result = httpServer->getLink(node);
+    char *result = httpServer->getLink(node, "http", formatIPv6);
     sdkMutex.unlock();
     return result;
 }
@@ -23256,7 +23256,7 @@ void MegaTCPServer::clearAllowedHandles()
     lastHandle = INVALID_HANDLE;
 }
 
-char *MegaTCPServer::getLink(MegaNode *node, string protocol)
+char *MegaTCPServer::getLink(MegaNode *node, string protocol, bool formatIPv6)
 {
     if (!node)
     {
@@ -23265,9 +23265,11 @@ char *MegaTCPServer::getLink(MegaNode *node, string protocol)
 
     lastHandle = node->getHandle();
     allowedHandles.insert(lastHandle);
+    
+    string localhostIP = formatIPv6 ? "[::1]" : "127.0.0.1";
 
     ostringstream oss;
-    oss << protocol << (useTLS ? "s" : "") << "://[::1]:" << port << "/";
+    oss << protocol << (useTLS ? "s" : "") << "://" << localhostIP << ":" << port << "/";
     char *base64handle = node->getBase64Handle();
     oss << base64handle;
     delete [] base64handle;


### PR DESCRIPTION
From http://docs.libuv.org/en/v1.x/guide/networking.html#ipv6-stack-only

> IPv6 sockets can be used for both IPv4 and IPv6 communication
