### PR TITLE
Fix building with C++11 using qmake

### DIFF
--- a/bindings/qt/sdk.pri
+++ b/bindings/qt/sdk.pri
@@ -64,6 +64,7 @@ CONFIG(USE_AUTOCOMPLETE) {
     !win32 {
         #to have autocomplete support, c++11 & libstdc++fs are required:
         CONFIG+=c++11
+        QMAKE_CXXFLAGS+=-std=c++11
         LIBS+=-lstdc++fs
     }
 }


### PR DESCRIPTION
In older OS like Ubuntu, the default C++ standard is c++0x -->
compilation fails.