### PR TITLE
Fix for logging of negative chunk size during download

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -272,7 +272,7 @@ IF(WIN32)
     
         ImportVcpkgLibrary(z               "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/zlibd.lib" "${vcpkg_dir}/lib/zlib.lib") 
 
-        ImportVcpkgLibrary(gtest           "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/manual-link/gtestd.lib" "${vcpkg_dir}/lib/manual-link/gtest.lib") 
+        ImportVcpkgLibrary(gtest           "${vcpkg_dir}/include" "${vcpkg_dir}/debug/lib/gtestd.lib" "${vcpkg_dir}/lib/gtest.lib") 
 
         IF(USE_MEDIAINFO)
             ImportStaticLibrary(mediainfo   "${Mega3rdPartyDir}/MediaInfoLib-mw/Source"

--- a/src/raid.cpp
+++ b/src/raid.cpp
@@ -852,7 +852,7 @@ std::pair<m_off_t, m_off_t> TransferBufferManager::nextNPosForConnection(unsigne
             transfer->pos = 0;
         }
 
-        if (transfer->type == GET && transfer->size)
+        if (transfer->type == GET && transfer->size && npos > transfer->pos)
         {
             m_off_t maxReqSize = (transfer->size - transfer->progresscompleted) / connectionCount / 2;
             if (maxReqSize > maxRequestSize)
@@ -887,6 +887,7 @@ std::pair<m_off_t, m_off_t> TransferBufferManager::nextNPosForConnection(unsigne
                 it = transfer->chunkmacs.find(npos);
             }
             LOG_debug << "Downloading chunk of size " << reqSize;
+            assert(reqSize > 0);
         }
         return std::make_pair(transfer->pos, npos);
     }


### PR DESCRIPTION
The file still downloaded correctly, but if some of the last 4 chunks of a non-raided file had completed and others were available for a 'next chunk', the calculation would be performed, and a negative chunk size logged, but no action taken (no http request resulted).