### PR TITLE
Some fixes related to IPv4/IPv6 streaming

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -6021,7 +6021,7 @@ typedef NS_ENUM(NSUInteger, StorageState) {
  * ready to accept connections. The initialization is synchronous.
  *
  * The server will serve files using this URL format:
- * http://127.0.0.1/<NodeHandle>/<NodeName>
+ * http://[::1]/<NodeHandle>/<NodeName>
  *
  * The node name must be URL encoded and must match with the node handle.
  * You can generate a correct link for a MEGANode using [MEGASdk httpServerGetLocalLink]
@@ -6042,7 +6042,7 @@ typedef NS_ENUM(NSUInteger, StorageState) {
  *
  * The HTTP server will only stream a node if it's allowed by all configuration options.
  *
- * @param localOnly YES to listen on 127.0.0.1 only, NO to listen on all network interfaces
+ * @param localOnly YES to listen on ::1 only, NO to listen on all network interfaces
  * @param port Port in which the server must accept connections
  * @return YES is the server is ready, NO if the initialization failed
  */

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -1944,7 +1944,7 @@ using namespace mega;
 #pragma mark - HTTP Proxy Server
 
 - (BOOL)httpServerStart:(BOOL)localOnly port:(NSInteger)port {
-    return self.megaApi->httpServerStart(localOnly, (int)port);
+    return self.megaApi->httpServerStart(localOnly, (int)port, false, NULL, NULL, true);
 }
 
 - (void)httpServerStop {
@@ -2000,7 +2000,7 @@ using namespace mega;
 }
 
 - (NSURL *)httpServerGetLocalLink:(MEGANode *)node {
-    const char *val = self.megaApi->httpServerGetLocalLink([node getCPtr], true);
+    const char *val = self.megaApi->httpServerGetLocalLink([node getCPtr]);
     if (!val) return nil;
     
     NSURL *ret = [NSURL URLWithString:[NSString stringWithUTF8String:val]];

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -3056,7 +3056,7 @@ public:
     static void returnHttpCodeAsyncBasedOnRequestError(MegaHTTPContext* httpctx, MegaError *e);
     static void returnHttpCodeAsync(MegaHTTPContext* httpctx, int errorCode, std::string errorMessage = string());
 
-    MegaHTTPServer(MegaApiImpl *megaApi, string basePath, bool useTLS = false, std::string certificatepath = std::string(), std::string keypath = std::string());
+    MegaHTTPServer(MegaApiImpl *megaApi, string basePath, bool useTLS = false, std::string certificatepath = std::string(), std::string keypath = std::string(), bool useIPv6 = false);
     virtual ~MegaHTTPServer();
     char *getWebDavLink(MegaNode *node);
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8010,7 +8010,7 @@ bool MegaApiImpl::httpServerStart(bool localOnly, int port, bool useTLS, const c
     }
 
     httpServerStop();
-    httpServer = new MegaHTTPServer(this, basePath, useTLS, certificatepath ? certificatepath : string(), keypath ? keypath : string());
+    httpServer = new MegaHTTPServer(this, basePath, useTLS, certificatepath ? certificatepath : string(), keypath ? keypath : string(), useIPv6);
     httpServer->setMaxBufferSize(httpServerMaxBufferSize);
     httpServer->setMaxOutputSize(httpServerMaxOutputSize);
     httpServer->enableFileServer(httpServerEnableFiles);
@@ -23952,8 +23952,8 @@ void MegaTCPServer::processAsyncEvent(MegaTCPContext *tcpctx)
 //  MegaHTTPServer specifics //
 ///////////////////////////////
 
-MegaHTTPServer::MegaHTTPServer(MegaApiImpl *megaApi, string basePath, bool useTLS, string certificatepath, string keypath)
-    : MegaTCPServer(megaApi, basePath, useTLS, certificatepath, keypath)
+MegaHTTPServer::MegaHTTPServer(MegaApiImpl *megaApi, string basePath, bool useTLS, string certificatepath, string keypath, bool useIPv6)
+    : MegaTCPServer(megaApi, basePath, useTLS, certificatepath, keypath, useIPv6)
 {
     // parser callbacks
     parsercfg.on_url = onUrlReceived;


### PR DESCRIPTION
- Fix broken iOS compilation.
- Pass useIPv6 parameter to MegaTCPServer constructor.