### PR TITLE
RequestDispatcher: fix `logout` response calling `clear()` on active …

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -14,14 +14,9 @@
 
 cmake_minimum_required(VERSION 3.7.2)
 
-#set this to 1 if building 64 bit with eg. cmake . -G "Visual Studio 15 2017 Win64"
-#set this to 0 if building 32 bit with eg. cmake . -G "Visual Studio 15 2017"
-set (build_64_bit 1 CACHE TYPE BOOL)
-
 #indicate which dependent libraries to use in the build
 set (USE_CRYPTOPP 1 CACHE TYPE BOOL)
 set (USE_OPENSSL 1 CACHE TYPE BOOL)
-set (OPENSSL_IS_BORINGSSL 0 CACHE TYPE BOOL)
 set (USE_CURL 1 CACHE TYPE BOOL)
 set (USE_SQLITE 1 CACHE TYPE BOOL)
 set (USE_MEDIAINFO 1 CACHE TYPE BOOL)
@@ -85,7 +80,7 @@ endif(build_64_bit)
 IF(WIN32)
     set(MegaDir "${CMAKE_CURRENT_LIST_DIR}/../..")
     if ("${Mega3rdPartyDir}" STREQUAL "")
-        set(Mega3rdPartyDir "${MegaDir}/../3rdParty")
+        set(Mega3rdPartyDir "${MegaDir}/../3rdParty" CACHE TYPE STRING)
     endif()
 ELSE(WIN32)
     set(MegaDir "${CMAKE_CURRENT_LIST_DIR}/../..")

--- a/include/mega/json.h
+++ b/include/mega/json.h
@@ -29,7 +29,7 @@ namespace mega {
 // linear non-strict JSON scanner
 struct MEGA_API JSON
 {
-    const char* pos;
+    const char* pos = nullptr;
 
     bool isnumeric();
 

--- a/include/mega/request.h
+++ b/include/mega/request.h
@@ -35,7 +35,7 @@ private:
     vector<Command*> cmds;
     string jsonresponse;
     JSON json;
-    unsigned processindex;
+    size_t processindex = 0;
 
 public:
     void add(Command*);
@@ -53,7 +53,7 @@ public:
     bool empty() const; 
     void swap(Request&);
 
-    Request();
+    bool stopProcessing = false;
 };
 
 
@@ -64,6 +64,10 @@ class MEGA_API RequestDispatcher
 
     // client-server request double-buffering, in batches of up to MAX_COMMANDS
     deque<Request> nextreqs;
+
+    // flags for dealing with resetting everything from a command in progress
+    bool processing = false;
+    bool clearWhenSafe = false;
 
     static const int MAX_COMMANDS = 10000;
 

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -132,6 +132,7 @@ void Request::clear()
     jsonresponse.clear();
     json.pos = NULL;
     processindex = 0;
+    stopProcessing = false;
 }
 
 bool Request::empty() const

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -55,7 +55,7 @@ void Request::get(string* req, bool& suppressSID) const
 void Request::process(MegaClient* client)
 {
     client->json = json;
-    for (; processindex < (int)cmds.size(); processindex++)
+    for (; processindex < cmds.size() && !stopProcessing; processindex++)
     {
         Command* cmd = cmds[processindex];
 
@@ -148,12 +148,6 @@ void Request::swap(Request& r)
     assert(processindex == 0 && r.processindex == 0);
 }
 
-Request::Request()
-{
-    json.pos = NULL;
-    processindex = 0;
-}
-
 RequestDispatcher::RequestDispatcher()
 {
     nextreqs.push_back(Request());
@@ -207,26 +201,51 @@ void RequestDispatcher::requeuerequest()
 
 void RequestDispatcher::serverresponse(std::string&& movestring, MegaClient *client)
 {
+    processing = true;
     inflightreq.serverresponse(std::move(movestring), client);
     inflightreq.process(client);
     assert(inflightreq.empty());
+    processing = false;
+    if (clearWhenSafe)
+    {
+        clear();
+    }
 }
 
 void RequestDispatcher::servererror(error e, MegaClient *client)
 {
     // notify all the commands in the batch of the failure
     // so that they can deallocate memory, take corrective action etc.
+    processing = true;
     inflightreq.servererror(e, client);
     inflightreq.process(client);
     assert(inflightreq.empty());
+    processing = false;
+    if (clearWhenSafe)
+    {
+        clear();
+    }
 }
 
 void RequestDispatcher::clear()
 {
-    inflightreq.clear();
-    for (deque<Request>::iterator i = nextreqs.begin(); i != nextreqs.end(); ++i)
+    if (processing)
     {
-        i->clear();
+        // we are being called from a command that is in progress (eg. logout) - delay wiping the data structure until that call ends.
+        clearWhenSafe = true;
+        inflightreq.stopProcessing = true;
+    }
+    else
+    {
+        inflightreq.clear();
+        for (auto& r : nextreqs)
+        {
+            r.clear();
+        }
+        nextreqs.clear();
+        nextreqs.push_back(Request());
+        processing = false;
+        clearWhenSafe = false;
     }
 }
 


### PR DESCRIPTION
…structure

Since RequestDispatcher::clear() is called from one of the items managed by the dispatcher, and clear() wipes the entire data structure,
delay that wiping until the function returns (and avoid calling any further command responses in the meantime).
Once we can be sure that none of that data structure is in use anywhere, we perform the clear().
(also fixed a merge issue with the CMakeLists.txt)