### PR TITLE
improvements for building on windows, from release 3.5.2

### DIFF
--- a/contrib/build_pdfium/buildpdfium.bat
+++ b/contrib/build_pdfium/buildpdfium.bat
@@ -59,6 +59,8 @@ git.exe -C build apply -v --ignore-space-change "%PDFium_PATCH_DIR%\rc_compiler.
 cd %PDFium_SOURCE_DIR%
 copy %PDFium_ARGS% %PDFium_BUILD_DIR%\args.gn
 if "%CONFIGURATION%"=="Release" echo is_debug=false >> %PDFium_BUILD_DIR%\args.gn
+if "%CONFIGURATION%"=="Debug" echo is_debug=true >> %PDFium_BUILD_DIR%\args.gn
+if "%CONFIGURATION%"=="Debug" echo is_official_build=false >> %PDFium_BUILD_DIR%\args.gn
 if "%PLATFORM%"=="x86" echo target_cpu="x86" >> %PDFium_BUILD_DIR%\args.gn
 
 : Generate Ninja files

--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -224,12 +224,18 @@ IF(WIN32)
             ImportVcpkgLibrary(ffmpeg_avcodec "${prebuilt_dir}/include/ffmpeg" "${prebuilt_dir}/libs/x32d/avcodec.lib" "${prebuilt_dir}/libs/x32/avcodec.lib")
             ImportVcpkgLibrary(ffmpeg_avfilter "${prebuilt_dir}/include/ffmpeg" "${prebuilt_dir}/libs/x32d/avfilter.lib" "${prebuilt_dir}/libs/x32/avfilter.lib")
             ImportVcpkgLibrary(ffmpeg_avdevice "${prebuilt_dir}/include/ffmpeg" "${prebuilt_dir}/libs/x32d/avdevice.lib" "${prebuilt_dir}/libs/x32/avdevice.lib")
+            ImportVcpkgLibrary(ffmpeg_swscale  "${prebuilt_dir}/include/ffmpeg" "${prebuilt_dir}/libs/x32d/swscale.lib"  "${prebuilt_dir}/libs/x32/swscale.lib")
+            ImportVcpkgLibrary(ffmpeg_swresample "${prebuilt_dir}/include/ffmpeg" "${prebuilt_dir}/libs/x32d/swresample.lib"  "${prebuilt_dir}/libs/x32/swresample.lib")
         ENDIF(HAVE_FFMPEG)
         
         IF(USE_LIBUV)
             ImportVcpkgLibrary(uv       "${prebuilt_dir}/include/libuv" "${prebuilt_dir}/libs/x32d/libuv.lib" "${prebuilt_dir}/libs/x32/libuv.lib")
             SET(HAVE_LIBUV 1)
         ENDIF(USE_LIBUV)
+
+        IF(USE_PDFIUM)
+            ImportVcpkgLibrary(pdfium       "${prebuilt_dir}/include" "${prebuilt_dir}/libs/x32d/pdfium.lib" "${prebuilt_dir}/libs/x32/pdfium.lib")
+        ENDIF(USE_PDFIUM)
         
     else(USE_PREBUILT_3RDPARTY)
 
@@ -441,6 +447,7 @@ target_link_libraries(Mega PUBLIC z
                                               $<${USE_FREEIMAGE}:freeimage_webp> $<${USE_FREEIMAGE}:freeimage_webpdecoder>  $<${USE_FREEIMAGE}:freeimage_webpdemux>  $<${USE_FREEIMAGE}:freeimage_webpmux>                                               
                 $<${HAVE_FFMPEG}:ffmpeg_avformat> $<${HAVE_FFMPEG}:ffmpeg_avcodec> $<${HAVE_FFMPEG}:ffmpeg_avutil> $<${HAVE_FFMPEG}:ffmpeg_avfilter> $<${HAVE_FFMPEG}:ffmpeg_avdevice> $<${HAVE_FFMPEG}:ffmpeg_avdevice > 
                 $<${HAVE_FFMPEG}:ffmpeg_swscale>  $<${HAVE_FFMPEG}:ffmpeg_swresample>  
+                $<${USE_PDFIUM}:pdfium>
                 ${Mega_PlatformSpecificLibs})
 target_compile_definitions(Mega PUBLIC 
                 $<${USE_MEDIAINFO}:USE_MEDIAINFO> 

--- a/src/gfx/qt.cpp
+++ b/src/gfx/qt.cpp
@@ -395,7 +395,7 @@ GfxProcQT::GfxProcQT()
     dir.setFilter(QDir::Files);
     foreach(QString dirFile, dir.entryList())
     {
-        LOG_warn << "Removing unexpected temporary file found from previous executions: " << dirFile.toStdString();
+        LOG_warn << "Removing unexpected temporary file found from previous executions: " << dirFile.toUtf8().constData();
         dir.remove(dirFile);
     }
 #endif
@@ -971,11 +971,11 @@ QImageReader *GfxProcQT::readbitmapPdf(int &w, int &h, int &orientation, QString
         }
         {
             FPDF_CloseDocument(pdf_doc);
-            LOG_err << "Error getting number of pages for " << imagePath.toStdString();
+            LOG_err << "Error getting number of pages for " << imagePath.toUtf8().constData();
         }
     }
     {
-        LOG_err << "Error loading PDF to create thumbnail for " << imagePath.toStdString() << " " << FPDF_GetLastError();
+        LOG_err << "Error loading PDF to create thumbnail for " << imagePath.toUtf8().constData() << " " << FPDF_GetLastError();
     }
 
 #ifdef _WIN32
@@ -1012,14 +1012,14 @@ QImageReader *GfxProcQT::readbitmapFfmpeg(int &w, int &h, int &orientation, QStr
     AVFormatContext* formatContext = avformat_alloc_context();
     if (avformat_open_input(&formatContext, imagePath.toUtf8().constData(), NULL, NULL))
     {
-        LOG_warn << "Error opening video: " << imagePath.toStdString();
+        LOG_warn << "Error opening video: " << imagePath.toUtf8().constData();
         return NULL;
     }
 
     // Get stream information
     if (avformat_find_stream_info(formatContext, NULL))
     {
-        LOG_warn << "Stream info not found: " << imagePath.toStdString();
+        LOG_warn << "Stream info not found: " << imagePath.toUtf8().constData();
         avformat_close_input(&formatContext);
         return NULL;
     }
@@ -1039,7 +1039,7 @@ QImageReader *GfxProcQT::readbitmapFfmpeg(int &w, int &h, int &orientation, QStr
 
     if (!videoStream)
     {
-        LOG_warn << "Video stream not found: " << imagePath.toStdString();
+        LOG_warn << "Video stream not found: " << imagePath.toUtf8().constData();
         avformat_close_input(&formatContext);
         return NULL;
     }

--- a/src/gfx/qt.cpp
+++ b/src/gfx/qt.cpp
@@ -966,7 +966,7 @@ QImageReader *GfxProcQT::readbitmapPdf(int &w, int &h, int &orientation, QString
             }
             {
                 FPDF_CloseDocument(pdf_doc);
-                LOG_err << "Error loading PDF page to create thumb for " << imagePath.toStdString();
+                LOG_err << "Error loading PDF page to create thumb for " << imagePath.toUtf8().constData();
             }
         }
         {

--- a/src/gfx/qt.cpp
+++ b/src/gfx/qt.cpp
@@ -395,7 +395,7 @@ GfxProcQT::GfxProcQT()
     dir.setFilter(QDir::Files);
     foreach(QString dirFile, dir.entryList())
     {
-        LOG_warn << "Removing unexpected temporary file found from previous executions: " << dirFile;
+        LOG_warn << "Removing unexpected temporary file found from previous executions: " << dirFile.toStdString();
         dir.remove(dirFile);
     }
 #endif
@@ -966,16 +966,16 @@ QImageReader *GfxProcQT::readbitmapPdf(int &w, int &h, int &orientation, QString
             }
             {
                 FPDF_CloseDocument(pdf_doc);
-                LOG_err << "Error loading PDF page to create thumb for " << imagePath;
+                LOG_err << "Error loading PDF page to create thumb for " << imagePath.toStdString();
             }
         }
         {
             FPDF_CloseDocument(pdf_doc);
-            LOG_err << "Error getting number of pages for " << imagePath;
+            LOG_err << "Error getting number of pages for " << imagePath.toStdString();
         }
     }
     {
-        LOG_err << "Error loading PDF to create thumbnail for " << imagePath << " " << FPDF_GetLastError();
+        LOG_err << "Error loading PDF to create thumbnail for " << imagePath.toStdString() << " " << FPDF_GetLastError();
     }
 
 #ifdef _WIN32
@@ -1012,14 +1012,14 @@ QImageReader *GfxProcQT::readbitmapFfmpeg(int &w, int &h, int &orientation, QStr
     AVFormatContext* formatContext = avformat_alloc_context();
     if (avformat_open_input(&formatContext, imagePath.toUtf8().constData(), NULL, NULL))
     {
-        LOG_warn << "Error opening video: " << imagePath;
+        LOG_warn << "Error opening video: " << imagePath.toStdString();
         return NULL;
     }
 
     // Get stream information
     if (avformat_find_stream_info(formatContext, NULL))
     {
-        LOG_warn << "Stream info not found: " << imagePath;
+        LOG_warn << "Stream info not found: " << imagePath.toStdString();
         avformat_close_input(&formatContext);
         return NULL;
     }
@@ -1039,7 +1039,7 @@ QImageReader *GfxProcQT::readbitmapFfmpeg(int &w, int &h, int &orientation, QStr
 
     if (!videoStream)
     {
-        LOG_warn << "Video stream not found: " << imagePath;
+        LOG_warn << "Video stream not found: " << imagePath.toStdString();
         avformat_close_input(&formatContext);
         return NULL;
     }

--- a/src/raid.cpp
+++ b/src/raid.cpp
@@ -30,7 +30,7 @@
 namespace mega
 {
 
-constexpr unsigned RAID_ACTIVE_CHANNEL_FAIL_THRESHOLD = 5;
+const unsigned RAID_ACTIVE_CHANNEL_FAIL_THRESHOLD = 5;
 
 struct FaultyServers
 {


### PR DESCRIPTION
pdfium debug build
cmake reference to pdfium
qt.cpp had problems streaming QT strings to log
constexpr in raid.cpp wasn't accepted by older compilers