### PR TITLE
Fix json parser to process `ub` actionpacket

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -810,6 +810,7 @@ private:
 #endif
     void sc_uac();
     void sc_la();
+    void sc_ub();
 
     void init();
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4177,6 +4177,15 @@ bool MegaClient::procsc()
                                 // last acknowledged
                                 sc_la();
                                 break;
+
+                            case MAKENAMEID2('u', 'b'):
+                                // business account update
+                                // `ub` AP has no payload, so we need to set pos
+                                // one character back to avoid to consume `}` character
+                                // and close object properly
+                                sc_ub();
+                                jsonsc.pos--;
+                                break;
                         }
                     }
                 }
@@ -6150,6 +6159,12 @@ void MegaClient::sc_la()
             }
         }
     }
+}
+
+void MegaClient::sc_ub()
+{
+    LOG_info << "Business account update";
+    getuserdata();
 }
 
 // scan notified nodes for


### PR DESCRIPTION
`ub` actionpacket has no payload so it breaks json parser. In order to
fix this issue we need to set pos pointer one position back to be able
to close json object properly.