### PR TITLE
WIP: Prevent log messages too long

### DIFF
--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -1251,7 +1251,14 @@ void CurlHttpIO::send_request(CurlHttpContext* httpctx)
     }
     else
     {
-        LOG_debug << httpctx->req->logname << "Sending: " << *req->out;
+        if (req->out->size() < 10240)
+        {
+            LOG_debug << httpctx->req->logname << "Sending: " << *req->out;
+        }
+        else
+        {
+            LOG_debug << httpctx->req->logname << "Sending: " << req->out->substr(0, 5116) << " [...] " << req->out->substr(req->out->size() - 5116, string::npos);
+        }
     }
 
     httpctx->headers = clone_curl_slist(req->type == REQ_JSON ? httpio->contenttypejson : httpio->contenttypebinary);


### PR DESCRIPTION
The `cs Received:` are already truncated in the middle of the JSON when posted as log message (for efficiency, to not overload the logger that may do I/O). This commit aims to achieve the same for the `cs Sending:`.

We have detected crashes upon trying to import a huge number of nodes from a folder link, resulting in a huge _putnodes_ that produces a too large log --> crash due to OOM in iOS.