### PR TITLE
use TLS v 1 to allow libraw download in build_sdk.sh

### DIFF
--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -141,7 +141,7 @@ package_download() {
         cp /tmp/megasdkbuild/$3 $file 
     else
         echo "Downloading $name to get $3"
-        wget --no-check-certificate -c $url -O $file --progress=bar:force -t 2 -T 30 || \
+        wget --secure-protocol=TLSv1 --no-check-certificate -c $url -O $file --progress=bar:force -t 2 -T 30 || \
         curl -k $url > $file || exit 1
     fi
     


### PR DESCRIPTION
failed in wget in RHEL 8