### PR TITLE
#12280 Improve retrieval of info about folder links

### DIFF
--- a/bindings/ios/MEGARequest.h
+++ b/bindings/ios/MEGARequest.h
@@ -130,8 +130,15 @@ typedef NS_ENUM (NSInteger, MEGARequestType) {
     MEGARequestTypeRemoveBackup,
     MEGARequestTypeTimer,
     MEGARequestTypeAbortCurrentBackup,
-    MEGARequestTypeFetchTimeZone,
     MEGARequestTypeGetPSA,
+    MEGARequestTypeFetchTimeZone,
+    MEGARequestTypeUseralertAcknowledge,
+    MEGARequestTypeChatLinkHandle,
+    MEGARequestTypeChatLinkUrl,
+    MEGARequestTypeSetPrivateMode,
+    MEGARequestTypeAutojoinPublicChat,
+    MEGARequestTypeCatchup,
+    MEGARequestTypePublicLinkInformation,
     TotalOfRequestTypes
 };
 

--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -6479,6 +6479,61 @@ typedef NS_ENUM(NSUInteger, StorageState) {
  */
 - (void)getMegaAchievements;
 
+/**
+ * @brief Retrieve basic information about a folder link
+ *
+ * This function retrieves basic information from a folder link, like the number of files / folders
+ * and the name of the folder. For folder links containing a lot of files/folders,
+ * this function is more efficient than a fetchnodes.
+ *
+ * Valid data in the MegaRequest object received on all callbacks:
+ * - [MEGARequest link] - Returns the public link to the folder
+ *
+ * Valid data in the MegaRequest object received in onRequestFinish when the error code
+ * is MEGAErrorTypeApiOk:
+ * - [MEGARequest megaFolderInfo] - Returns information about the contents of the folder
+ * - [MEGARequest nodeHandle] - Returns the public handle of the folder
+ * - [MEGARequest parentHandle] - Returns the handle of the owner of the folder
+ * - [MEGARequest text] - Returns the name of the folder.
+ * If there's no name, it returns the special status string "CRYPTO_ERROR".
+ * If the length of the name is zero, it returns the special status string "BLANK".
+ *
+ * On the onRequestFinish error, the error code associated to the MegaError can be:
+ * - MEGAErrorTypeApiEArgs - If the link is not a valid folder link
+ * - MEGAErrorTypeApiEKey - If the public link does not contain the key or it is invalid
+ *
+ * @param folderLink Public link to a folder in MEGA
+ * @param delegate MEGARequestDelegate to track this request
+ */
+- (void)getPublicLinkInformationWithFolderLink:(NSString *)folderLink delegate:(id<MEGARequestDelegate>)delegate;
+
+/**
+ * @brief Retrieve basic information about a folder link
+ *
+ * This function retrieves basic information from a folder link, like the number of files / folders
+ * and the name of the folder. For folder links containing a lot of files/folders,
+ * this function is more efficient than a fetchnodes.
+ *
+ * Valid data in the MegaRequest object received on all callbacks:
+ * - [MEGARequest link] - Returns the public link to the folder
+ *
+ * Valid data in the MegaRequest object received in onRequestFinish when the error code
+ * is MEGAErrorTypeApiOk:
+ * - [MEGARequest megaFolderInfo] - Returns information about the contents of the folder
+ * - [MEGARequest nodeHandle] - Returns the public handle of the folder
+ * - [MEGARequest parentHandle] - Returns the handle of the owner of the folder
+ * - [MEGARequest text] - Returns the name of the folder.
+ * If there's no name, it returns the special status string "CRYPTO_ERROR".
+ * If the length of the name is zero, it returns the special status string "BLANK".
+ *
+ * On the onRequestFinish error, the error code associated to the MegaError can be:
+ * - MEGAErrorTypeApiEArgs - If the link is not a valid folder link
+ * - MEGAErrorTypeApiEKey - If the public link does not contain the key or it is invalid
+ *
+ * @param folderLink Public link to a folder in MEGA
+ */
+- (void)getPublicLinkInformationWithFolderLink:(NSString *)folderLink;
+
 #pragma mark - Debug log messages
 
 /**

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -2069,6 +2069,14 @@ using namespace mega;
     self.megaApi->getMegaAchievements();
 }
 
+- (void)getPublicLinkInformationWithFolderLink:(NSString *)folderLink delegate:(id<MEGARequestDelegate>)delegate {
+    self.megaApi->getPublicLinkInformation(folderLink.UTF8String, [self createDelegateMEGARequestListener:delegate singleListener:YES]);
+}
+
+- (void)getPublicLinkInformationWithFolderLink:(NSString *)folderLink {
+    self.megaApi->getPublicLinkInformation(folderLink.UTF8String);
+}
+
 #pragma mark - Debug log messages
 
 + (void)setLogLevel:(MEGALogLevel)logLevel {

--- a/bindings/java/nz/mega/sdk/MegaApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaApiJava.java
@@ -7816,6 +7816,65 @@ public class MegaApiJava {
         megaApi.getMegaAchievements();
     }
 
+    /**
+     * @brief Retrieve basic information about a folder link
+     *
+     * This function retrieves basic information from a folder link, like the number of files / folders
+     * and the name of the folder. For folder links containing a lot of files/folders,
+     * this function is more efficient than a fetchnodes.
+     *
+     * Valid data in the MegaRequest object received on all callbacks:
+     * - MegaRequest::getLink() - Returns the public link to the folder
+     *
+     * Valid data in the MegaRequest object received in onRequestFinish when the error code
+     * is MegaError::API_OK:
+     * - MegaRequest::getMegaFolderInfo() - Returns information about the contents of the folder
+     * - MegaRequest::getNodeHandle() - Returns the public handle of the folder
+     * - MegaRequest::getParentHandle() - Returns the handle of the owner of the folder
+     * - MegaRequest::getText() - Returns the name of the folder.
+     * If there's no name, it returns the special status string "CRYPTO_ERROR".
+     * If the length of the name is zero, it returns the special status string "BLANK".
+     *
+     * On the onRequestFinish error, the error code associated to the MegaError can be:
+     * - MegaError::API_EARGS  - If the link is not a valid folder link
+     * - MegaError::API_EKEY - If the public link does not contain the key or it is invalid
+     *
+     * @param megaFolderLink Public link to a folder in MEGA
+     * @param listener MegaRequestListener to track this request
+     */
+    public void getPublicLinkInformation(String megaFolderLink, MegaRequestListenerInterface listener) {
+        megaApi.getPublicLinkInformation(megaFolderLink, createDelegateRequestListener(listener));
+    }
+
+    /**
+     * @brief Retrieve basic information about a folder link
+     *
+     * This function retrieves basic information from a folder link, like the number of files / folders
+     * and the name of the folder. For folder links containing a lot of files/folders,
+     * this function is more efficient than a fetchnodes.
+     *
+     * Valid data in the MegaRequest object received on all callbacks:
+     * - MegaRequest::getLink() - Returns the public link to the folder
+     *
+     * Valid data in the MegaRequest object received in onRequestFinish when the error code
+     * is MegaError::API_OK:
+     * - MegaRequest::getMegaFolderInfo() - Returns information about the contents of the folder
+     * - MegaRequest::getNodeHandle() - Returns the public handle of the folder
+     * - MegaRequest::getParentHandle() - Returns the handle of the owner of the folder
+     * - MegaRequest::getText() - Returns the name of the folder.
+     * If there's no name, it returns the special status string "CRYPTO_ERROR".
+     * If the length of the name is zero, it returns the special status string "BLANK".
+     *
+     * On the onRequestFinish error, the error code associated to the MegaError can be:
+     * - MegaError::API_EARGS  - If the link is not a valid folder link
+     * - MegaError::API_EKEY - If the public link does not contain the key or it is invalid
+     *
+     * @param megaFolderLink Public link to a folder in MEGA
+     */
+    public void getPublicLinkInformation(String megaFolderLink) {
+        megaApi.getPublicLinkInformation(megaFolderLink);
+    }
+
     /****************************************************************************************************/
     // INTERNAL METHODS
     /****************************************************************************************************/

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -101,6 +101,9 @@ static int ets = 0;
 // import welcome pdf at account creation
 static bool pdf_to_import = false;
 
+// public link information
+static string publiclink;
+
 // local console
 Console* console;
 
@@ -2401,6 +2404,7 @@ void exec_ls(autocomplete::ACState& s);
 void exec_lpwd(autocomplete::ACState& s);
 void exec_lmkdir(autocomplete::ACState& s);
 void exec_import(autocomplete::ACState& s);
+void exec_folderlinkinfo(autocomplete::ACState& s);
 void exec_open(autocomplete::ACState& s);
 void exec_put(autocomplete::ACState& s);
 void exec_putq(autocomplete::ACState& s);
@@ -2503,6 +2507,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_lmkdir, sequence(text("lmkdir"), localFSFolder()));
 #endif
     p->Add(exec_import, sequence(text("import"), exportedLink(true, false)));
+    p->Add(exec_folderlinkinfo, sequence(text("folderlink"), opt(param("link"))));
     p->Add(exec_open, sequence(text("open"), exportedLink(false, true)));
     p->Add(exec_put, sequence(text("put"), localFSPath("localpattern"), opt(either(remoteFSPath(client, &cwd, "dst"),param("dstemail")))));
     p->Add(exec_putq, sequence(text("putq"), opt(param("cancelslot"))));
@@ -4866,6 +4871,23 @@ void exec_import(autocomplete::ACState& s)
     }
 }
 
+void exec_folderlinkinfo(autocomplete::ACState& s)
+{
+    publiclink = s.words[1].s;
+
+    handle ph = UNDEF;
+    byte folderkey[SymmCipher::KEYLENGTH];
+    if (client->parsefolderlink(publiclink.c_str(), ph, folderkey) == API_OK)
+    {
+        cout << "Loading public folder link info..." << endl;
+        client->getpubliclinkinfo(ph);
+    }
+    else
+    {
+        cout << "Malformed link: " << publiclink << endl;
+    }
+}
+
 void exec_reload(autocomplete::ACState& s)
 {
     cout << "Reloading account..." << endl;
@@ -6251,6 +6273,71 @@ void DemoApp::openfilelink_result(handle ph, const byte* key, m_off_t size,
     }
 
     delete [] buf;
+}
+
+void DemoApp::folderlinkinfo_result(error e, handle owner, handle /*ph*/, string *attr, string* k, m_off_t currentSize, uint32_t numFiles, uint32_t numFolders, m_off_t versionsSize, uint32_t numVersions)
+{
+    if (e != API_OK)
+    {
+        cout << "Retrieval of public folder link information failed: " << e << endl;
+        return;
+    }
+
+    handle ph;
+    byte folderkey[SymmCipher::KEYLENGTH];
+    error eaux = client->parsefolderlink(publiclink.c_str(), ph, folderkey);
+    assert(eaux == API_OK);
+
+    // Decrypt nodekey with the key of the folder link
+    SymmCipher cipher;
+    cipher.setkey(folderkey);
+    const char *nodekeystr = k->data() + 9;    // skip the userhandle(8) and the `:`
+    byte nodekey[FOLDERNODEKEYLENGTH];
+    if (client->decryptkey(nodekeystr, nodekey, sizeof(nodekey), &cipher, 0, UNDEF))
+    {
+        // Decrypt node attributes with the nodekey
+        cipher.setkey(nodekey);
+        byte* buf = Node::decryptattr(&cipher, attr->c_str(), attr->size());
+        if (buf)
+        {
+            AttrMap attrs;
+            string fileName;
+            string fingerprint;
+            FileFingerprint ffp;
+            m_time_t mtime = 0;
+            Node::parseattr(buf, attrs, currentSize, mtime, fileName, fingerprint, ffp);
+
+            // Normalize node name to UTF-8 string
+            attr_map::iterator it = attrs.map.find('n');
+            if (it != attrs.map.end() && !it->second.empty())
+            {
+                client->fsaccess->normalize(&(it->second));
+                fileName = it->second.c_str();
+            }
+
+            std::string ownerStr, ownerBin((const char *)&owner, sizeof(owner));
+            Base64::btoa(ownerBin, ownerStr);
+
+            cout << "Folder link information:" << publiclink << endl;
+            cout << "\tFolder name: " << fileName << endl;
+            cout << "\tOwner: " << ownerStr << endl;
+            cout << "\tNum files: " << numFiles << endl;
+            cout << "\tNum folders: " << numFolders - 1 << endl;
+            cout << "\tNum versions: " << numVersions << endl;
+
+            delete [] buf;
+        }
+        else
+        {
+            cout << "folderlink: error decrypting node attributes with decrypted nodekey" << endl;
+        }
+    }
+    else
+    {
+        cout << "folderlink: error decrypting nodekey with folder link key";
+    }
+
+    publiclink.clear();
 }
 
 void DemoApp::checkfile_result(handle /*h*/, error e)

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -192,6 +192,8 @@ struct DemoApp : public MegaApp
     void openfilelink_result(error) override;
     void openfilelink_result(handle, const byte*, m_off_t, string*, string*, int) override;
 
+    void folderlinkinfo_result(error, handle, handle, string *, string*, m_off_t, uint32_t, uint32_t, m_off_t, uint32_t) override;
+
     void checkfile_result(handle, error) override;
     void checkfile_result(handle, error, byte*, m_off_t, m_time_t, m_time_t, string*, string*, string*) override;
 

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -1098,6 +1098,15 @@ public:
     CommandSetLastAcknowledged(MegaClient*);
 };
 
+class MEGA_API CommandFolderLinkInfo: public Command
+{
+    handle ph;
+
+public:
+    void procresult();
+
+    CommandFolderLinkInfo(MegaClient*, handle);
+};
 
 } // namespace
 

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -1100,8 +1100,6 @@ public:
 
 class MEGA_API CommandFolderLinkInfo: public Command
 {
-    handle ph;
-
 public:
     void procresult();
 

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -1100,6 +1100,7 @@ public:
 
 class MEGA_API CommandFolderLinkInfo: public Command
 {
+    handle ph = UNDEF;
 public:
     void procresult();
 

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -351,6 +351,9 @@ struct MEGA_API MegaApp
     // result of the user alert acknowledge request
     virtual void acknowledgeuseralerts_result(error) { }
 
+    // get info about a folder link
+    virtual void folderlinkinfo_result(error, handle , handle, string*, string* , m_off_t, uint32_t , uint32_t , m_off_t , uint32_t) {}
+
     virtual ~MegaApp() { }
 };
 } // namespace

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -557,6 +557,9 @@ public:
     // change the storage status
     bool setstoragestatus(storagestatus_t);
 
+    // get info about a folder link
+    void getPublicLinkInformation(handle);
+
 #ifdef ENABLE_CHAT
 
     // create a new chat with multiple users and different privileges

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -561,7 +561,7 @@ public:
     bool setstoragestatus(storagestatus_t);
 
     // get info about a folder link
-    void getPublicLinkInformation(handle h);
+    void getpubliclinkinfo(handle h);
 
 #ifdef ENABLE_CHAT
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -307,6 +307,9 @@ public:
     void killsession(handle session);
     void killallsessions();
 
+    // extract public handle and key from folder link
+    error parsefolderlink(const char* folderlink, handle &h, byte *key);
+
     // set folder link: node, key
     error folderaccess(const char*folderlink);
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -558,7 +558,7 @@ public:
     bool setstoragestatus(storagestatus_t);
 
     // get info about a folder link
-    void getPublicLinkInformation(handle);
+    void getPublicLinkInformation(handle h);
 
 #ifdef ENABLE_CHAT
 

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -143,6 +143,9 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     // decrypt node attribute string
     static byte* decryptattr(SymmCipher*, const char*, int);
 
+    // parse node attributes from an incoming buffer, this function must be called after call decryptattr
+    static void parseattr(byte*, AttrMap&, m_off_t, m_time_t&, string&, string&, FileFingerprint&);
+
     // inbound share
     Share* inshare;
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -2595,7 +2595,7 @@ class MegaRequest
             TYPE_ADD_BACKUP, TYPE_REMOVE_BACKUP, TYPE_TIMER, TYPE_ABORT_CURRENT_BACKUP,
             TYPE_GET_PSA, TYPE_FETCH_TIMEZONE, TYPE_USERALERT_ACKNOWLEDGE,
             TYPE_CHAT_LINK_HANDLE, TYPE_CHAT_LINK_URL, TYPE_SET_PRIVATE_MODE, TYPE_AUTOJOIN_PUBLIC_CHAT,
-            TYPE_CATCHUP,
+            TYPE_CATCHUP, TYPE_PUBLIC_LINK_INFORMATION,
             TOTAL_OF_REQUEST_TYPES
         };
 
@@ -14304,6 +14304,32 @@ class MegaApi
          * @param listener MegaRequestListener to track this request
          */
         void catchup(MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Retrieve basic information about a folder link
+         *
+         * This function retrieves basic information from a folder link, like the number of files / folders
+         * and the name of the folder. For folder links containing a lot of files/folders,
+         * this function is more efficient than a fetchnodes.
+         *
+         * Valid data in the MegaRequest object received on all callbacks:
+         * - MegaRequest::getNodeHandle - Returns the public handle of the folder link
+         *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getNodeHandle() - Returns the public handle of the folder
+         * - MegaRequest::getMegaFolderInfo() - Returns information about the contents of the folder
+         * - MegaRequest::getParentHandle() - Returns the handle of the owner of the folder
+         * - MegaRequest::getText() - Returns the name of the folder
+         *
+         * On the onRequestFinish error, the error code associated to the MegaError can be:
+         * - MegaError::API_EARGS  - If the public handle not corresponds to a valid folder link
+         * - MegaError::API_ENOENT - If the public handle is not valid.
+         *
+         * @param ph MegaHandle that represents the public handle of the folder
+         * @param listener MegaRequestListener to track this request
+         */
+        void getPublicLinkInformation(MegaHandle ph, MegaRequestListener *listener = NULL);
 
 private:
         MegaApiImpl *pImpl;

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -14320,7 +14320,9 @@ class MegaApi
          * - MegaRequest::getMegaFolderInfo() - Returns information about the contents of the folder
          * - MegaRequest::getNodeHandle() - Returns the public handle of the folder
          * - MegaRequest::getParentHandle() - Returns the handle of the owner of the folder
-         * - MegaRequest::getText() - Returns the name of the folder
+         * - MegaRequest::getText() - Returns the name of the folder. If there's no name
+         * returns the special status string "CRYPTO_ERROR". If the length
+         * of the name is zero returns the special status string "BLANK".
          *
          * On the onRequestFinish error, the error code associated to the MegaError can be:
          * - MegaError::API_EARGS  - If the link is not a valid folder link

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -14313,23 +14313,23 @@ class MegaApi
          * this function is more efficient than a fetchnodes.
          *
          * Valid data in the MegaRequest object received on all callbacks:
-         * - MegaRequest::getNodeHandle - Returns the public handle of the folder link
+         * - MegaRequest::getLink() - Returns the public link to the folder
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
-         * - MegaRequest::getNodeHandle() - Returns the public handle of the folder
          * - MegaRequest::getMegaFolderInfo() - Returns information about the contents of the folder
+         * - MegaRequest::getNodeHandle() - Returns the public handle of the folder
          * - MegaRequest::getParentHandle() - Returns the handle of the owner of the folder
          * - MegaRequest::getText() - Returns the name of the folder
          *
          * On the onRequestFinish error, the error code associated to the MegaError can be:
-         * - MegaError::API_EARGS  - If the public handle not corresponds to a valid folder link
-         * - MegaError::API_ENOENT - If the public handle is not valid.
+         * - MegaError::API_EARGS  - If the link is not a valid folder link
+         * - MegaError::API_EINCOMPLETE - If the public link does not contain the key
          *
-         * @param ph MegaHandle that represents the public handle of the folder
+         * @param megaFolderLink Public link to a folder in MEGA
          * @param listener MegaRequestListener to track this request
          */
-        void getPublicLinkInformation(MegaHandle ph, MegaRequestListener *listener = NULL);
+        void getPublicLinkInformation(const char *megaFolderLink, MegaRequestListener *listener = NULL);
 
 private:
         MegaApiImpl *pImpl;

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -14296,9 +14296,9 @@ class MegaApi
          * - MegaRequest::getMegaFolderInfo() - Returns information about the contents of the folder
          * - MegaRequest::getNodeHandle() - Returns the public handle of the folder
          * - MegaRequest::getParentHandle() - Returns the handle of the owner of the folder
-         * - MegaRequest::getText() - Returns the name of the folder. If there's no name
-         * returns the special status string "CRYPTO_ERROR". If the length
-         * of the name is zero returns the special status string "BLANK".
+         * - MegaRequest::getText() - Returns the name of the folder.
+         * If there's no name, it returns the special status string "CRYPTO_ERROR".
+         * If the length of the name is zero, it returns the special status string "BLANK".
          *
          * On the onRequestFinish error, the error code associated to the MegaError can be:
          * - MegaError::API_EARGS  - If the link is not a valid folder link

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -14301,7 +14301,7 @@ class MegaApi
          * If the length of the name is zero, it returns the special status string "BLANK".
          *
          * On the onRequestFinish error, the error code associated to the MegaError can be:
-         * - MegaError::API_EARGS  - If the link is not a valid folder link
+         * - MegaError::API_EARGS - If the link is not a valid folder link
          * - MegaError::API_EKEY - If the public link does not contain the key or it is invalid
          *
          * @param megaFolderLink Public link to a folder in MEGA

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -14324,7 +14324,7 @@ class MegaApi
          *
          * On the onRequestFinish error, the error code associated to the MegaError can be:
          * - MegaError::API_EARGS  - If the link is not a valid folder link
-         * - MegaError::API_EINCOMPLETE - If the public link does not contain the key
+         * - MegaError::API_EKEY - If the public link does not contain the key or it is invalid
          *
          * @param megaFolderLink Public link to a folder in MEGA
          * @param listener MegaRequestListener to track this request

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2403,7 +2403,7 @@ class MegaApiImpl : public MegaApp
         void getMegaAchievements(MegaRequestListener *listener = NULL);
 
         void catchup(MegaRequestListener *listener = NULL);
-        void getPublicLinkInformation(MegaHandle ph, MegaRequestListener *listener = NULL);
+        void getPublicLinkInformation(const char *megaFolderLink, MegaRequestListener *listener);
 
         void fireOnTransferStart(MegaTransferPrivate *transfer);
         void fireOnTransferFinish(MegaTransferPrivate *transfer, MegaError e);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2680,6 +2680,9 @@ protected:
         void openfilelink_result(error) override;
         void openfilelink_result(handle, const byte*, m_off_t, string*, string*, int) override;
 
+        // retrieval of public link information
+        void folderlinkinfo_result(error, handle, handle, string *, string*, m_off_t, uint32_t, uint32_t, m_off_t, uint32_t) override;
+
         // global transfer queue updates (separate signaling towards the queued objects)
         void file_added(File*) override;
         void file_removed(File*, error e) override;
@@ -2732,7 +2735,6 @@ protected:
         void chatlinkurl_result(handle, int, string*, string*, int, m_time_t, error) override;
         void chatlinkclose_result(error) override;
         void chatlinkjoin_result(error) override;
-        void folderlinkinfo_result(error, handle, handle, string *, string*, m_off_t, uint32_t, uint32_t, m_off_t, uint32_t) override;
 #endif
 
 #ifdef ENABLE_SYNC

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2403,6 +2403,7 @@ class MegaApiImpl : public MegaApp
         void getMegaAchievements(MegaRequestListener *listener = NULL);
 
         void catchup(MegaRequestListener *listener = NULL);
+        void getPublicLinkInformation(MegaHandle ph, MegaRequestListener *listener = NULL);
 
         void fireOnTransferStart(MegaTransferPrivate *transfer);
         void fireOnTransferFinish(MegaTransferPrivate *transfer, MegaError e);
@@ -2734,6 +2735,7 @@ protected:
         virtual void chatlinkurl_result(handle, int, string*, string*, int, m_time_t, error);
         virtual void chatlinkclose_result(error);
         virtual void chatlinkjoin_result(error);
+        virtual void folderlinkinfo_result(error, handle , handle, string*, string* , m_off_t, uint32_t , uint32_t , m_off_t , uint32_t);
 #endif
 
 #ifdef ENABLE_SYNC

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2712,6 +2712,7 @@ protected:
         virtual void getlocalsslcertificate_result(m_time_t, string *certdata, error);
         virtual void getmegaachievements_result(AchievementsDetails*, error);
         virtual void getwelcomepdf_result(handle, string*, error);
+        virtual void folderlinkinfo_result(error, handle , handle, string*, string* , m_off_t, uint32_t , uint32_t , m_off_t , uint32_t);
 
 #ifdef ENABLE_CHAT
         // chat-related commandsresult
@@ -2735,7 +2736,6 @@ protected:
         virtual void chatlinkurl_result(handle, int, string*, string*, int, m_time_t, error);
         virtual void chatlinkclose_result(error);
         virtual void chatlinkjoin_result(error);
-        virtual void folderlinkinfo_result(error, handle , handle, string*, string* , m_off_t, uint32_t , uint32_t , m_off_t , uint32_t);
 #endif
 
 #ifdef ENABLE_SYNC

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6952,10 +6952,10 @@ void CommandFolderLinkInfo::procresult()
         case 's':
             if (client->json.enterarray())
             {
-                currentSize = int(client->json.getint());
+                currentSize = client->json.getint();
                 numFiles = int(client->json.getint());
                 numFolders = int(client->json.getint());
-                versionsSize  = int(client->json.getint());
+                versionsSize  = client->json.getint();
                 numVersions = int(client->json.getint());
                 client->json.leavearray();
             }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6970,12 +6970,27 @@ void CommandFolderLinkInfo::procresult()
                      break;
 
                  case EOO:
-                    if (!attr.size())
+                    if (attr.empty())
                     {
-                       return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+                        LOG_err << "The folder link information doesn't contain the attr string";
+                        return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
                     }
+                    if (key.empty())
+                    {
+                        LOG_err << "The folder link information doesn't contain the decryption key";
+                        return client->app->folderlinkinfo_result(API_EKEY, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+                    }
+                    else
+                    {
+                        size_t pos = key.find(":");
+                        if (pos == string::npos)
+                        {
+                            LOG_warn << "The folder link information has no valid decryption key";
+                            return client->app->folderlinkinfo_result(API_EKEY, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+                        }
 
-                    return client->app->folderlinkinfo_result(API_OK, owner, ph, &attr, &key, currentSize, numFiles, numFolders, versionsSize, numVersions);
+                        return client->app->folderlinkinfo_result(API_OK, owner, ph, &attr, &key, currentSize, numFiles, numFolders, versionsSize, numVersions);
+                    }
 
                  default:
                     if (!client->json.storeobject())

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6892,7 +6892,7 @@ CommandSetLastAcknowledged::CommandSetLastAcknowledged(MegaClient* client)
     cmd("sla");
     notself(client);
     tag = client->reqtag;
-};
+}
 
 void CommandSetLastAcknowledged::procresult()
 {
@@ -6905,16 +6905,17 @@ void CommandSetLastAcknowledged::procresult()
         client->json.storeobject();
         client->app->acknowledgeuseralerts_result(API_EINTERNAL);
     }
-};
+}
 
 CommandFolderLinkInfo::CommandFolderLinkInfo(MegaClient* client, handle publichandle)
 {
+    ph = publichandle;
+
     cmd("pli");
     arg("ph", (byte*)&publichandle, MegaClient::NODEHANDLE);
 
-    notself(client);
     tag = client->reqtag;
-};
+}
 
 void CommandFolderLinkInfo::procresult()
 {
@@ -6922,83 +6923,76 @@ void CommandFolderLinkInfo::procresult()
     {
         return client->app->folderlinkinfo_result((error)client->json.getint(), UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
     }
-    else
+    string attr;
+    string key;
+    handle owner = UNDEF;
+    handle ph = 0;
+    m_off_t currentSize = 0;
+    m_off_t versionsSize  = 0;
+    int numFolders = 0;
+    int numFiles = 0;
+    int numVersions = 0;
+
+    for (;;)
     {
-        string attr;
-        string key;
-        handle owner = UNDEF;
-        handle ph =  UNDEF;
-        m_off_t currentSize = 0;
-        m_off_t versionsSize  = 0;
-        int numFolders = 0;
-        int numFiles = 0;
-        int numVersions = 0;
-
-        for (;;)
+        switch (client->json.getnameid())
         {
-            switch (client->json.getnameid())
+        case MAKENAMEID5('a','t','t','r','s'):
+            client->json.storeobject(&attr);
+            break;
+
+        case MAKENAMEID2('p','h'):
+            ph = client->json.gethandle(MegaClient::NODEHANDLE);
+            break;
+
+        case 'u':
+            owner = client->json.gethandle(MegaClient::USERHANDLE);
+            break;
+
+        case 's':
+            if (client->json.enterarray())
             {
-                case MAKENAMEID5('a','t','t','r','s'):
-                    client->json.storeobject(&attr);
-                    break;
-
-                case MAKENAMEID2('p','h'):
-                    ph = client->json.gethandle(MegaClient::NODEHANDLE);
-                    break;
-
-                case 'u':
-                    owner = client->json.gethandle(MegaClient::USERHANDLE);
-                    break;
-
-                case 's':
-                    if (client->json.enterarray())
-                    {
-                        currentSize = int(client->json.getint());
-                        numFiles = int(client->json.getint());
-                        numFolders = int(client->json.getint());
-                        versionsSize  = int(client->json.getint());
-                        numVersions = int(client->json.getint());
-                        client->json.leavearray();
-                    }
-                    break;
-
-                 case 'k':
-                     client->json.storeobject(&key);
-                     break;
-
-                 case EOO:
-                    if (attr.empty())
-                    {
-                        LOG_err << "The folder link information doesn't contain the attr string";
-                        return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
-                    }
-                    if (key.empty())
-                    {
-                        LOG_err << "The folder link information doesn't contain the decryption key";
-                        return client->app->folderlinkinfo_result(API_EKEY, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
-                    }
-                    else
-                    {
-                        size_t pos = key.find(":");
-                        if (pos == string::npos)
-                        {
-                            LOG_warn << "The folder link information has no valid decryption key";
-                            return client->app->folderlinkinfo_result(API_EKEY, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
-                        }
-
-                        return client->app->folderlinkinfo_result(API_OK, owner, ph, &attr, &key, currentSize, numFiles, numFolders, versionsSize, numVersions);
-                    }
-
-                 default:
-                    if (!client->json.storeobject())
-                    {
-                        LOG_err << "Failed to parse folder link information response";
-                        return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
-                    }
-                    break;
+                currentSize = int(client->json.getint());
+                numFiles = int(client->json.getint());
+                numFolders = int(client->json.getint());
+                versionsSize  = int(client->json.getint());
+                numVersions = int(client->json.getint());
+                client->json.leavearray();
             }
+            break;
+
+        case 'k':
+            client->json.storeobject(&key);
+            break;
+
+        case EOO:
+            if (attr.empty())
+            {
+                LOG_err << "The folder link information doesn't contain the attr string";
+                return client->app->folderlinkinfo_result(API_EINCOMPLETE, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+            }
+            if (key.size() <= 9 || key.find(":") == string::npos)
+            {
+                LOG_err << "The folder link information doesn't contain a valid decryption key";
+                return client->app->folderlinkinfo_result(API_EKEY, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+            }
+            if (ph != this->ph)
+            {
+                LOG_err << "Folder link information: public handle doesn't match";
+                return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+            }
+
+            return client->app->folderlinkinfo_result(API_OK, owner, ph, &attr, &key, currentSize, numFiles, numFolders, versionsSize, numVersions);
+
+        default:
+            if (!client->json.storeobject())
+            {
+                LOG_err << "Failed to parse folder link information response";
+                return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+            }
+            break;
         }
     }
-};
+}
 
 } // namespace

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6911,7 +6911,6 @@ void CommandSetLastAcknowledged::procresult()
 
 CommandFolderLinkInfo::CommandFolderLinkInfo(MegaClient* client, handle publichandle)
 {
-    this->ph = ph;
     cmd("pli");
     arg("ph", (byte*)&publichandle, MegaClient::NODEHANDLE);
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6923,7 +6923,7 @@ void CommandFolderLinkInfo::procresult()
 {
     if (client->json.isnumeric())
     {
-        client->app->folderlinkinfo_result((error)client->json.getint(), UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+        return client->app->folderlinkinfo_result((error)client->json.getint(), UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
     }
     else
     {
@@ -6972,18 +6972,18 @@ void CommandFolderLinkInfo::procresult()
                  case EOO:
                     if (!attr.size())
                     {
-                        client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+                       return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
                     }
 
-                    client->app->folderlinkinfo_result(API_OK, owner, ph, &attr, &key, currentSize, numFiles, numFolders, versionsSize, numVersions);
-                    return;
+                    return client->app->folderlinkinfo_result(API_OK, owner, ph, &attr, &key, currentSize, numFiles, numFolders, versionsSize, numVersions);
 
                  default:
                     if (!client->json.storeobject())
                     {
                         LOG_err << "Failed to parse folder link information response";
-                        client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
+                        return client->app->folderlinkinfo_result(API_EINTERNAL, UNDEF, UNDEF, NULL, NULL, 0, 0, 0, 0, 0);
                     }
+                    break;
             }
         }
     }

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3706,6 +3706,11 @@ void MegaApi::catchup(MegaRequestListener *listener)
     pImpl->catchup(listener);
 }
 
+void MegaApi::getPublicLinkInformation(MegaHandle ph, MegaRequestListener *listener)
+{
+    pImpl->getPublicLinkInformation(ph, listener);
+}
+
 #ifdef HAVE_LIBUV
 bool MegaApi::httpServerStart(bool localOnly, int port, bool useTLS, const char * certificatepath, const char * keypath, bool useIPv6)
 {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3706,9 +3706,9 @@ void MegaApi::catchup(MegaRequestListener *listener)
     pImpl->catchup(listener);
 }
 
-void MegaApi::getPublicLinkInformation(MegaHandle ph, MegaRequestListener *listener)
+void MegaApi::getPublicLinkInformation(const char *megaFolderLink, MegaRequestListener *listener)
 {
-    pImpl->getPublicLinkInformation(ph, listener);
+    pImpl->getPublicLinkInformation(megaFolderLink, listener);
 }
 
 #ifdef HAVE_LIBUV

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19985,13 +19985,13 @@ void MegaApiImpl::sendPendingRequests()
             }
 
             handle h = UNDEF;
-            byte folderkey[SymmCipher::KEYLENGTH];
+            byte folderkey[SymmCipher::KEYLENGTH + 1];
             e = client->parsefolderlink(link, h, folderkey);
             if (e == API_OK)
             {
-                const string binfolderkey((const char *)folderkey, sizeof (folderkey));
+                folderkey[SymmCipher::KEYLENGTH] = '\0';
                 request->setNodeHandle(h);
-                request->setPrivateKey(binfolderkey.data());
+                request->setPrivateKey((const char*)folderkey);
                 client->getpubliclinkinfo(h);
             }
             break;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -11599,7 +11599,7 @@ void MegaApiImpl::folderlinkinfo_result(error e, handle owner, handle ph, string
     if (e == API_OK)
     {
         // Extract the folder key from the link (skip the public handle)
-        handle h = 0;
+        handle h = UNDEF;
         byte folderkeybuf[SymmCipher::KEYLENGTH];
         error parseError = client->parsefolderlink(request->getLink(), h, folderkeybuf);
         assert(parseError == API_OK);
@@ -20128,7 +20128,7 @@ void MegaApiImpl::sendPendingRequests()
                 break;
             }
 
-            handle h = 0;
+            handle h = UNDEF;
             byte folderkey[SymmCipher::KEYLENGTH];
             e = client->parsefolderlink(link, h, folderkey);
             if (e == API_OK)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -11509,13 +11509,13 @@ void MegaApiImpl::folderlinkinfo_result(error e, handle owner, handle /*ph*/, st
     {
         // Decrypt nodekey with the key of the folder link
         SymmCipher cipher;
-        cipher.setkey((const byte *)request->getPrivateKey(), sizeof(request->getPrivateKey());
-        const char *nodekeystr = k->data() + 10;    // skip the userhandle(8) and the `:`
+        cipher.setkey((const byte *)request->getPrivateKey(), sizeof(request->getPrivateKey()));
+        const char *nodekeystr = k->data() + 9;    // skip the userhandle(8) and the `:`
         byte nodekey[FOLDERNODEKEYLENGTH];
         if (client->decryptkey(nodekeystr, nodekey, sizeof(nodekey), &cipher, 0, UNDEF))
         {
             // Decrypt node attributes with the nodekey
-            cipher.setkey(&nodekey);
+            cipher.setkey(nodekey);
             byte* buf = Node::decryptattr(&cipher, attr->c_str(), attr->size());
             if (buf)
             {
@@ -19989,8 +19989,9 @@ void MegaApiImpl::sendPendingRequests()
             e = client->parsefolderlink(link, h, folderkey);
             if (e == API_OK)
             {
+                const string binfolderkey((const char *)folderkey, sizeof (folderkey));
                 request->setNodeHandle(h);
-                request->setPrivateKey(folderkey);
+                request->setPrivateKey(binfolderkey.data());
                 client->getpubliclinkinfo(h);
             }
             break;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -11601,8 +11601,8 @@ void MegaApiImpl::folderlinkinfo_result(error e, handle owner, handle ph, string
         // Extract the folder key from the link (skip the public handle)
         handle h = 0;
         byte folderkeybuf[SymmCipher::KEYLENGTH];
-        error e = client->parsefolderlink(request->getLink(), h, folderkeybuf);
-        assert(e == API_OK);
+        error parseError = client->parsefolderlink(request->getLink(), h, folderkeybuf);
+        assert(parseError == API_OK);
         assert(h == ph);
         const string binfolderkey((const char *)folderkeybuf, sizeof (folderkeybuf));
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -11599,7 +11599,7 @@ void MegaApiImpl::folderlinkinfo_result(error e, handle owner, handle ph, string
     if (e == API_OK)
     {
         // Extract the folder key from the link (skip the public handle)
-        handle h = UNDEF;
+        handle h = 0;
         byte folderkeybuf[SymmCipher::KEYLENGTH];
         error e = client->parsefolderlink(request->getLink(), h, folderkeybuf);
         assert(e == API_OK);
@@ -20128,12 +20128,12 @@ void MegaApiImpl::sendPendingRequests()
                 break;
             }
 
-            handle h = UNDEF;
+            handle h = 0;
             byte folderkey[SymmCipher::KEYLENGTH];
-            error e = client->parsefolderlink(link, h, folderkey);
+            e = client->parsefolderlink(link, h, folderkey);
             if (e == API_OK)
             {
-                client->getPublicLinkInformation(client->getpublicfolderhandle());
+                client->getPublicLinkInformation(h);
             }
             break;
         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7675,7 +7675,7 @@ bool MegaClient::readusers(JSON* j, bool actionpackets)
     return j->leavearray();
 }
 
-error MegaClient::folderaccess(const char *folderlink)
+error MegaClient::parsefolderlink(const char *folderlink, handle &h, byte *key)
 {
     // structure of public folder links: https://mega.nz/#F!<handle>!<key>
 
@@ -7697,25 +7697,33 @@ error MegaClient::folderaccess(const char *folderlink)
         return API_EARGS;
     }
 
-    const char *k = ptr + 1;
-
-    handle h = 0;
-    byte folderkey[SymmCipher::KEYLENGTH];
-
     if (Base64::atob(f, (byte*)&h, NODEHANDLE) != NODEHANDLE)
     {
         return API_EARGS;
     }
 
-    if (Base64::atob(k, folderkey, sizeof folderkey) != sizeof folderkey)
+    const char *k = ptr + 1;
+    if (Base64::atob(k, key, sizeof key) != sizeof key)
     {
         return API_EARGS;
     }
 
-    setrootnode(h);
-    key.setkey(folderkey);
-
     return API_OK;
+}
+
+error MegaClient::folderaccess(const char *folderlink)
+{
+    handle h = UNDEF;
+    byte folderkey[SymmCipher::KEYLENGTH];
+
+    error e;
+    if ((e = parsefolderlink(folderlink, h, folderkey)) == API_OK)
+    {
+        setrootnode(h);
+        key.setkey(folderkey);
+    }
+
+    return e;
 }
 
 void MegaClient::prelogin(const char *email)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7697,23 +7697,28 @@ error MegaClient::parsefolderlink(const char *folderlink, handle &h, byte *key)
         return API_EARGS;
     }
 
-    if (Base64::atob(f, (byte*)&h, NODEHANDLE) != NODEHANDLE)
+    // Node handle size is 6 Bytes, so we init with zeros to avoid comparison problems
+    handle auxh = 0;
+    if (Base64::atob(f, (byte*)&auxh, NODEHANDLE) != NODEHANDLE)
     {
         return API_EARGS;
     }
 
+    byte auxkey[SymmCipher::KEYLENGTH];
     const char *k = ptr + 1;
-    if (Base64::atob(k, key, SymmCipher::KEYLENGTH) != SymmCipher::KEYLENGTH)
+    if (Base64::atob(k, auxkey, sizeof auxkey) != sizeof auxkey)
     {
         return API_EARGS;
     }
 
+    h = auxh;
+    memcpy(key, auxkey, sizeof auxkey);
     return API_OK;
 }
 
 error MegaClient::folderaccess(const char *folderlink)
 {
-    handle h = 0;
+    handle h = UNDEF;
     byte folderkey[SymmCipher::KEYLENGTH];
 
     error e;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4627,7 +4627,7 @@ bool MegaClient::setstoragestatus(storagestatus_t status)
     return false;
 }
 
-void MegaClient::getPublicLinkInformation(handle h)
+void MegaClient::getpubliclinkinfo(handle h)
 {
     reqs.add(new CommandFolderLinkInfo(this, h));
 }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7703,7 +7703,7 @@ error MegaClient::parsefolderlink(const char *folderlink, handle &h, byte *key)
     }
 
     const char *k = ptr + 1;
-    if (Base64::atob(k, key, sizeof key) != sizeof key)
+    if (Base64::atob(k, key, SymmCipher::KEYLENGTH) != SymmCipher::KEYLENGTH)
     {
         return API_EARGS;
     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7713,7 +7713,7 @@ error MegaClient::parsefolderlink(const char *folderlink, handle &h, byte *key)
 
 error MegaClient::folderaccess(const char *folderlink)
 {
-    handle h = UNDEF;
+    handle h = 0;
     byte folderkey[SymmCipher::KEYLENGTH];
 
     error e;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4647,6 +4647,11 @@ bool MegaClient::setstoragestatus(storagestatus_t status)
     return false;
 }
 
+void MegaClient::getPublicLinkInformation(handle h)
+{
+    reqs.add(new CommandFolderLinkInfo(this, h));
+}
+
 void MegaClient::dispatchmore(direction_t d)
 {
     // keep pipeline full by dispatching additional queued transfers, if

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -569,6 +569,52 @@ byte* Node::decryptattr(SymmCipher* key, const char* attrstring, int attrstrlen)
     return NULL;
 }
 
+void Node::parseattr(byte *bufattr, AttrMap &attrs, m_off_t size, m_time_t &mtime , string &fileName, string &fingerprint, FileFingerprint &ffp)
+{
+    JSON json;
+    nameid name;
+    string *t;
+
+    json.begin((char*)bufattr+5);
+    while ((name = json.getnameid()) != EOO && json.storeobject((t = &attrs.map[name])))
+    {
+        JSON::unescape(t);
+    }
+
+    attr_map::iterator it;
+    it = attrs.map.find('n');
+    if (it == attrs.map.end())
+    {
+        fileName = "CRYPTO_ERROR";
+    }
+    else if (!it->second.size())
+    {
+        fileName = "BLANK";
+    }
+
+    it = attrs.map.find('c');
+    if (it != attrs.map.end())
+    {
+        if (ffp.unserializefingerprint(&it->second))
+        {
+            ffp.size = size;
+            mtime = ffp.mtime;
+
+            char bsize[sizeof(size)+1];
+            int l = Serialize64::serialize((byte *)bsize, size);
+            char *buf = new char[l * 4 / 3 + 4];
+            char ssize = 'A' + Base64::btoa((const byte *)bsize, l, buf);
+
+            string result(1, ssize);
+            result.append(buf);
+            result.append(it->second);
+            delete [] buf;
+
+            fingerprint = result;
+        }
+    }
+}
+
 // return temporary SymmCipher for this nodekey
 SymmCipher* Node::nodecipher()
 {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -575,24 +575,23 @@ void Node::parseattr(byte *bufattr, AttrMap &attrs, m_off_t size, m_time_t &mtim
     nameid name;
     string *t;
 
-    json.begin((char*)bufattr+5);
+    json.begin((char*)bufattr + 5);
     while ((name = json.getnameid()) != EOO && json.storeobject((t = &attrs.map[name])))
     {
         JSON::unescape(t);
     }
 
-    attr_map::iterator it;
-    it = attrs.map.find('n');
+    attr_map::iterator it = attrs.map.find('n');   // filename
     if (it == attrs.map.end())
     {
         fileName = "CRYPTO_ERROR";
     }
-    else if (!it->second.size())
+    else if (it->second.empty())
     {
         fileName = "BLANK";
     }
 
-    it = attrs.map.find('c');
+    it = attrs.map.find('c');   // checksum
     if (it != attrs.map.end())
     {
         if (ffp.unserializefingerprint(&it->second))
@@ -600,7 +599,7 @@ void Node::parseattr(byte *bufattr, AttrMap &attrs, m_off_t size, m_time_t &mtim
             ffp.size = size;
             mtime = ffp.mtime;
 
-            char bsize[sizeof(size)+1];
+            char bsize[sizeof(size) + 1];
             int l = Serialize64::serialize((byte *)bsize, size);
             char *buf = new char[l * 4 / 3 + 4];
             char ssize = 'A' + Base64::btoa((const byte *)bsize, l, buf);


### PR DESCRIPTION
The information retrieval of a folder link that contains a lot of files/folders, it's very slow process with a fetchnodes.
We need to add support to `pli` command in order to retrieve the information faster.