### PR TITLE
Fix .pro for new Test getMimeType()

### DIFF
--- a/contrib/QtCreator/MEGATestSuite/MEGAcryptotests/MEGAcryptotests.pro
+++ b/contrib/QtCreator/MEGATestSuite/MEGAcryptotests/MEGAcryptotests.pro
@@ -10,6 +10,8 @@ CONFIG(release, debug|release) {
 TARGET = MEGAcryptotests
 TEMPLATE = app
 
+CONFIG += USE_MEGAAPI
+CONFIG += USE_LIBUV
 CONFIG += USE_MEDIAINFO
 CONFIG += USE_LIBRAW
 CONFIG += USE_FFMPEG
@@ -18,6 +20,7 @@ CONFIG -= qt
 LIBS += -lgtest
 
 include(../../../../bindings/qt/sdk.pri)
+
 SOURCES += ../../../../tests/crypto_test.cpp \
            ../../../../tests/tests.cpp  \
            ../../../../tests/paycrypt_test.cpp


### PR DESCRIPTION
Without this configuration, the QtCreator project will fail to link the `getMimeType()` test.