### PR TITLE
Fix retry pending connections

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6729,9 +6729,8 @@ class MegaApi
          * - MegaRequest::getFlag - Returns the first parameter
          * - MegaRequest::getNumber - Returns the second parameter
          *
-         * If there is no Internet connection available, in iOS, this method will retry for up to 5 seconds and
-         * may fail with the error code MegaError::API_EACCESS in onRequestFinish() if not possible to retrieve the
-         * DNS servers from the system.
+         * If not possible to retrieve the DNS servers from the system, in iOS, this request will fail with
+         * the error code MegaError::API_EACCESS in onRequestFinish().
          *
          * @param disconnect true if you want to disconnect already connected requests
          * It's not recommended to set this flag to true if you are not fully sure about what are you doing. If you

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6729,6 +6729,10 @@ class MegaApi
          * - MegaRequest::getFlag - Returns the first parameter
          * - MegaRequest::getNumber - Returns the second parameter
          *
+         * If there is no Internet connection available, in iOS, this method will retry for up to 5 seconds and
+         * may fail with the error code MegaError::API_EACCESS in onRequestFinish() if not possible to retrieve the
+         * DNS servers from the system.
+         *
          * @param disconnect true if you want to disconnect already connected requests
          * It's not recommended to set this flag to true if you are not fully sure about what are you doing. If you
          * send a request that needs some time to complete and you disconnect it in a loop without giving it enough time,

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -18132,7 +18132,8 @@ void MegaApiImpl::sendPendingRequests()
                 {
 #if TARGET_OS_IPHONE
                 // Workaround to get the IP of valid DNS servers on iOS
-                while (true)
+                int retries = 5;
+                while (retries)
                 {
                     __res_state res;
                     bool valid;
@@ -18173,7 +18174,15 @@ void MegaApiImpl::sendPendingRequests()
                     if (servers.size())
                         break;
 
+                    retries--;
                     sleep(1);
+                }
+
+                if (!retries)
+                {
+                    LOG_warn << "Failed to get DNS servers at Retry Pending Connections";
+                    e = API_EACCESS;
+                    break;
                 }
 #endif
                 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -18128,13 +18128,10 @@ void MegaApiImpl::sendPendingRequests()
                 {
                     servers = dnsservers;
                 }
+#if TARGET_OS_IPHONE
                 else
                 {
-#if TARGET_OS_IPHONE
-                // Workaround to get the IP of valid DNS servers on iOS
-                int retries = 5;
-                while (retries)
-                {
+                    // Workaround to get the IP of valid DNS servers on iOS
                     __res_state res;
                     bool valid;
                     if (res_ninit(&res) == 0)
@@ -18171,21 +18168,14 @@ void MegaApiImpl::sendPendingRequests()
                         res_ndestroy(&res);
                     }
 
-                    if (servers.size())
+                    if (!servers.size())
+                    {
+                        LOG_warn << "Failed to get DNS servers at Retry Pending Connections";
+                        e = API_EACCESS;    // ie. when iOS has no Internet connection at all
                         break;
-
-                    retries--;
-                    sleep(1);
-                }
-
-                if (!retries)
-                {
-                    LOG_warn << "Failed to get DNS servers at Retry Pending Connections";
-                    e = API_EACCESS;
-                    break;
+                    }
                 }
 #endif
-                }
 #ifndef __MINGW32__
                 if (servers.size())
                 {


### PR DESCRIPTION
When there's no internet connection in iOS, a call to `MegaApi::retryPendingConnections(true)` will lock the mutex forever, since the DNS servers are not available and it will retry forever, blocking the any caller thread as soon as they require any action from the SDK.