### PR TITLE
Different timestamps were needed to get the testable order right.

### DIFF
--- a/src/request.cpp
+++ b/src/request.cpp
@@ -89,7 +89,7 @@ void Request::process(MegaClient* client)
         }
     }
     json = client->json;
-    if (processindex == cmds.size())
+    if (processindex == cmds.size() || stopProcessing)
     {
         clear();
     }

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -3898,7 +3898,7 @@ TEST_F(SdkTest, SdkRecentsTest)
         for (int j = 0; j < buckets->get(i)->getNodes()->size(); ++j)
         {
             auto node = bucket->getNodes()->get(j);
-            cout << node->getName() << " " << bucket->getTimestamp() << " " << bucket->getParentHandle() << " " << bucket->isUpdate() << " " << bucket->isMedia() << endl;
+            cout << node->getName() << " " << node->getCreationTime() << " " << bucket->getTimestamp() << " " << bucket->getParentHandle() << " " << bucket->isUpdate() << " " << bucket->isMedia() << endl;
         }
     }
 

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -3871,6 +3871,8 @@ TEST_F(SdkTest, SdkRecentsTest)
     waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
     ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload an updated test file (error: " << lastError[0] << ")";
 
+    WaitMillisec(2000);  // make sure of different timestamp
+
     string filename2 = DOWNFILE;
     createFile(filename2, false);
     transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
@@ -3888,10 +3890,20 @@ TEST_F(SdkTest, SdkRecentsTest)
     WaitMillisec(2000);
 
     MegaRecentActionBucketList* buckets = megaApi[0]->getRecentActions(1, 10);
+
+    for (int i = 0; i < buckets->size(); ++i)
+    {
+        cout << "bucket " << i << endl;
+        for (int j = 0; j < buckets->get(i)->getNodes()->size(); ++j)
+        {
+            cout << buckets->get(i)->getNodes()->get(j)->getName() << endl;
+        }
+    }
+
     ASSERT_TRUE(buckets != nullptr);
     ASSERT_TRUE(buckets->size() > 0);
-    ASSERT_TRUE(buckets->get(0)->getNodes()->size() > 0);
-    ASSERT_TRUE(buckets->get(0)->getNodes()->get(0)->getName() == DOWNFILE);
-    ASSERT_TRUE(buckets->get(0)->getNodes()->get(1)->getName() == UPFILE);
+    ASSERT_TRUE(buckets->get(0)->getNodes()->size() > 1);
+    ASSERT_EQ(string(buckets->get(0)->getNodes()->get(0)->getName()), DOWNFILE);
+    ASSERT_EQ(string(buckets->get(0)->getNodes()->get(1)->getName()), UPFILE);
 }
 

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -3887,16 +3887,18 @@ TEST_F(SdkTest, SdkRecentsTest)
     waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
     ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload an updated test file2 (error: " << lastError[0] << ")";
 
-    WaitMillisec(2000);
+    WaitMillisec(4000);
 
     MegaRecentActionBucketList* buckets = megaApi[0]->getRecentActions(1, 10);
 
     for (int i = 0; i < buckets->size(); ++i)
     {
         cout << "bucket " << i << endl;
+        auto bucket = buckets->get(i);
         for (int j = 0; j < buckets->get(i)->getNodes()->size(); ++j)
         {
-            cout << buckets->get(i)->getNodes()->get(j)->getName() << endl;
+            auto node = bucket->getNodes()->get(j);
+            cout << node->getName() << " " << bucket->getTimestamp() << " " << bucket->getParentHandle() << " " << bucket->isUpdate() << " " << bucket->isMedia() << endl;
         }
     }
 


### PR DESCRIPTION
Also, a single bucket result would crash
Also, while running all tests, discovered a case where logout with a command following (updating last password reminder user attribute) would cause an assert failure.