### PR TITLE
WIP: #12568. Return error when attempting a folder upload that produces recursivity

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -5008,6 +5008,7 @@ public:
         API_EC_DEFAULT = 0,         ///< Default error code context
         API_EC_DOWNLOAD = 1,        ///< Download transfer context.
         API_EC_IMPORT = 2,          ///< Import context.
+        API_EC_UPLOAD = 3,        ///< Upload transfer context.
     };
 
     /**

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -220,7 +220,9 @@ public:
     void onTransferUpdate(MegaApi *api, MegaTransfer *transfer) override;
     void onTransferFinish(MegaApi* api, MegaTransfer *transfer, MegaError *e) override;
 private:
-    bool checkNotBreaksRecursivity(const string &originlocalpath, const string &localpath, MegaNode *parent, string accumulateddestpath, int &errorCode, bool checkChildrenRecursivity, bool allowUploadsToSelfSynced);
+    void calculatePathRelativeToSyncRoot(Node *node, std::string &pathRelativeToSync);
+    void calculatetransformedSyncDownPath(Node *node, std::string &transformedSyncDownPath);
+    bool checkNotBreaksRecursivity(const string &originlocalpath, const string &localpath, MegaNode *parent, int &errorCode, string parentSyncDownPath = string(), bool checkChildrenRecursivity = true, bool allowUploadsToSelfSynced = true);
 
 };
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -219,6 +219,8 @@ public:
     void onTransferStart(MegaApi *api, MegaTransfer *transfer) override;
     void onTransferUpdate(MegaApi *api, MegaTransfer *transfer) override;
     void onTransferFinish(MegaApi* api, MegaTransfer *transfer, MegaError *e) override;
+private:
+    bool checkNotBreaksRecursivity(const std::string &originlocalpath, const string &localpath, MegaNode *parent);
 };
 
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -220,7 +220,8 @@ public:
     void onTransferUpdate(MegaApi *api, MegaTransfer *transfer) override;
     void onTransferFinish(MegaApi* api, MegaTransfer *transfer, MegaError *e) override;
 private:
-    bool checkNotBreaksRecursivity(const std::string &originlocalpath, const string &localpath, MegaNode *parent);
+    bool checkNotBreaksRecursivity(const string &originlocalpath, const string &localpath, MegaNode *parent, string accumulateddestpath, int &errorCode, bool checkChildrenRecursivity, bool allowUploadsToSelfSynced);
+
 };
 
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -222,7 +222,8 @@ public:
 private:
     void calculatePathRelativeToSyncRoot(Node *node, std::string &pathRelativeToSync);
     void calculatetransformedSyncDownPath(Node *node, std::string &transformedSyncDownPath);
-    bool checkNotBreaksRecursivity(const string &originlocalpath, const string &localpath, MegaNode *parent, int &errorCode, string parentSyncDownPath = string(), bool checkChildrenRecursivity = true, bool allowUploadsToSelfSynced = true);
+    bool checkUploadDoesntBreakRecursivity(const string &localpath, MegaNode *parent, int &errorCode);
+    bool checkNotBreaksRecursivity(const string &originlocalpath, const string &localpath, MegaNode *parent, int &errorCode, std::set<MegaHandle> &syncsNodesAndAncestors, string parentSyncDownPath = string(), bool checkChildrenRecursivity = true, bool allowUploadsToSelfSynced = true);
 
 };
 

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1192,7 +1192,13 @@ const char* MegaError::getErrorString(int errorCode, ErrorContexts context)
         case API_ENOENT:
             return "Not found";
         case API_ECIRCULAR:
-            return "Circular linkage detected";
+            switch (context)
+            {
+                case API_EC_UPLOAD:
+                    return "Upload produces recursivity";
+                default:
+                    return "Circular linkage detected";
+            }
         case API_EACCESS:
             return "Access denied";
         case API_EEXIST:


### PR DESCRIPTION
The idea is that we want to avoid that uploading a folder writes
something into a MEGA location synced with a descendant of that folder.
With one exception: the upload entails the update of a corresponding
local path with its synced MEGA node.
  -> Common use case 1: upload excluded files
  -> Common use case 2: we a have a local structure and the same in MEGA,
and we have something synchronized, but some other folders aren't. We want
to be able to upload to have a manual one-way up-sync.