### PR TITLE
use catchup() instead of waiting some arbitrary time.

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14001,7 +14001,8 @@ void MegaApiImpl::getua_result(byte* data, unsigned len, attr_t type)
 
     if (request->getType() == MegaRequest::TYPE_SET_ATTR_USER)
     {
-        if (type == MegaApi::USER_ATTR_PWD_REMINDER)
+        static_assert(int(ATTR_PWD_REMINDER) == int(MegaApi::USER_ATTR_PWD_REMINDER));
+        if (type == ATTR_PWD_REMINDER)
         {
             // merge received value with updated items
             string newValue;
@@ -14071,12 +14072,16 @@ void MegaApiImpl::getua_result(byte* data, unsigned len, attr_t type)
                 string str((const char*)data,len);
                 request->setText(str.c_str());
 
-                if (type == MegaApi::USER_ATTR_DISABLE_VERSIONS
-                        || type == MegaApi::USER_ATTR_CONTACT_LINK_VERIFICATION)
+                static_assert(int(MegaApi::USER_ATTR_DISABLE_VERSIONS) == ATTR_DISABLE_VERSIONS);
+                static_assert(int(MegaApi::USER_ATTR_CONTACT_LINK_VERIFICATION) == ATTR_CONTACT_LINK_VERIFICATION);
+                static_assert(int(MegaApi::USER_ATTR_PWD_REMINDER) == ATTR_PWD_REMINDER);
+
+                if (type == ATTR_DISABLE_VERSIONS
+                        || type == ATTR_CONTACT_LINK_VERIFICATION)
                 {
                     request->setFlag(str == "1");
                 }
-                else if (type == MegaApi::USER_ATTR_PWD_REMINDER)
+                else if (type == ATTR_PWD_REMINDER)
                 {
                     m_time_t currenttime = m_time();
                     bool isMasterKeyExported = User::getPwdReminderData(User::PWD_MK_EXPORTED, (const char*)data, len);
@@ -14112,7 +14117,9 @@ void MegaApiImpl::getua_result(byte* data, unsigned len, attr_t type)
 
                 request->setNumber(value);
 
-                if (type == MegaApi::USER_ATTR_STORAGE_STATE && (value < MegaApi::STORAGE_STATE_GREEN || value > MegaApi::STORAGE_STATE_RED))
+                static_assert(int(MegaApi::USER_ATTR_STORAGE_STATE) == ATTR_STORAGE_STATE);
+
+                if (type == ATTR_STORAGE_STATE && (value < MegaApi::STORAGE_STATE_GREEN || value > MegaApi::STORAGE_STATE_RED))
                 {
                     e = API_EINTERNAL;
                 }

--- a/tests/sdk_test.cpp
+++ b/tests/sdk_test.cpp
@@ -708,6 +708,13 @@ bool SdkTest::waitForResponse(bool *responseReceived, unsigned int timeout)
     return true;    // response is received
 }
 
+bool SdkTest::synchronousCall(bool &responseFlag, std::function<void()> f, unsigned int timeout)
+{
+    responseFlag = false;
+    f();
+    return waitForResponse(&responseFlag, timeout);
+}
+
 void SdkTest::createFile(string filename, bool largeFile)
 {
     FILE *fp;
@@ -3952,35 +3959,33 @@ TEST_F(SdkTest, SdkRecentsTest)
 
     string filename1 = UPFILE;
     createFile(filename1, false);
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
-    megaApi[0]->startUpload(filename1.data(), rootnode);
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload a test file (error: " << lastError[0] << ")";
+    auto err = synchronousUpload(0, filename1.c_str(), rootnode);
+    ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload a test file (error: " << err << ")";
 
     ofstream f(filename1);
     f << "update";
     f.close();
-    megaApi[0]->startUpload(filename1.data(), rootnode);
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload an updated test file (error: " << lastError[0] << ")";
 
-    WaitMillisec(2000);  // make sure of different timestamp
+    err = synchronousUpload(0, filename1.c_str(), rootnode);
+    ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload an updated test file (error: " << err << ")";
+
+    synchronousCatchup(0);
 
     string filename2 = DOWNFILE;
     createFile(filename2, false);
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
-    megaApi[0]->startUpload(filename2.data(), rootnode);
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload a test file2 (error: " << lastError[0] << ")";
+    
+    err = synchronousUpload(0, filename2.c_str(), rootnode);
+    ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload a test file2 (error: " << err << ")";
 
     ofstream f2(filename2);
     f2 << "update";
     f2.close();
-    megaApi[0]->startUpload(filename2.data(), rootnode);
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload an updated test file2 (error: " << lastError[0] << ")";
 
-    WaitMillisec(4000);
+    err = synchronousUpload(0, filename2.c_str(), rootnode);
+    ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload an updated test file2 (error: " << err << ")";
+
+    synchronousCatchup(0);
+
 
     MegaRecentActionBucketList* buckets = megaApi[0]->getRecentActions(1, 10);
 
@@ -3998,7 +4003,7 @@ TEST_F(SdkTest, SdkRecentsTest)
     ASSERT_TRUE(buckets != nullptr);
     ASSERT_TRUE(buckets->size() > 0);
     ASSERT_TRUE(buckets->get(0)->getNodes()->size() > 1);
-    ASSERT_EQ(string(buckets->get(0)->getNodes()->get(0)->getName()), DOWNFILE);
-    ASSERT_EQ(string(buckets->get(0)->getNodes()->get(1)->getName()), UPFILE);
+    ASSERT_EQ(DOWNFILE, string(buckets->get(0)->getNodes()->get(0)->getName()));
+    ASSERT_EQ(UPFILE, string(buckets->get(0)->getNodes()->get(1)->getName()));
 }
 

--- a/tests/sdk_test.h
+++ b/tests/sdk_test.h
@@ -152,7 +152,7 @@ public:
 
     // convenience functions - template args just make it easy to code, no need to copy all the exact argument types with listener defaults etc. To add a new one, just copy a line and change the flag and the function called.
     template<typename ... uploadArgs> int synchronousUpload(int apiIndex, uploadArgs... args) { synchronousCall(transferFlags[apiIndex][MegaTransfer::TYPE_UPLOAD], [this, apiIndex, args...]() { megaApi[apiIndex]->startUpload(args...); }); return lastError[apiIndex]; }
-    template<typename ... uploadArgs> int synchronousCatchup(int apiIndex, uploadArgs... args) { synchronousCall(requestFlags[apiIndex][MegaRequest::TYPE_CATCHUP], [this, apiIndex]() { megaApi[apiIndex]->catchup(args...); }); return lastError[apiIndex]; }
+    template<typename ... uploadArgs> int synchronousCatchup(int apiIndex, uploadArgs... args) { synchronousCall(requestFlags[apiIndex][MegaRequest::TYPE_CATCHUP], [this, apiIndex, args...]() { megaApi[apiIndex]->catchup(args...); }); return lastError[apiIndex]; }
 
     void createFile(string filename, bool largeFile = true);
     size_t getFilesize(string filename);

--- a/tests/sdk_test.h
+++ b/tests/sdk_test.h
@@ -148,6 +148,12 @@ public:
     void purgeTree(MegaNode *p);
     bool waitForResponse(bool *responseReceived, unsigned int timeout = maxTimeout);
 
+    bool synchronousCall(bool &responseFlag, std::function<void()> f, unsigned int timeout = maxTimeout);
+
+    // convenience functions - template args just make it easy to code, no need to copy all the exact argument types with listener defaults etc. To add a new one, just copy a line and change the flag and the function called.
+    template<typename ... uploadArgs> int synchronousUpload(int apiIndex, uploadArgs... args) { synchronousCall(transferFlags[apiIndex][MegaTransfer::TYPE_UPLOAD], [this, apiIndex, args...]() { megaApi[apiIndex]->startUpload(args...); }); return lastError[apiIndex]; }
+    template<typename ... uploadArgs> int synchronousCatchup(int apiIndex, uploadArgs... args) { synchronousCall(requestFlags[apiIndex][MegaRequest::TYPE_CATCHUP], [this, apiIndex]() { megaApi[apiIndex]->catchup(args...); }); return lastError[apiIndex]; }
+
     void createFile(string filename, bool largeFile = true);
     size_t getFilesize(string filename);
     void deleteFile(string filename);


### PR DESCRIPTION
Also, made it easy to code synchronous calls to a particular api instance.