### PR TITLE
#12555. Stop sc requests upon error

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -732,6 +732,7 @@ private:
     // server-client command trigger connection
     HttpReq* pendingsc;
     BackoffTimer btsc;
+    bool stopsc = false;
 
     // badhost report
     HttpReq* badhostcs;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1030,6 +1030,7 @@ void MegaClient::init()
 
     delete pendingsc;
     pendingsc = NULL;
+    stopsc = false;
 
     btcs.reset();
     btsc.reset();


### PR DESCRIPTION
When a folder link is takendown or deleted, sc channel will not provide more actionpackets, but error (-9). In that case, it is futile to keep retrying the wsc.