### PR TITLE
#12636. Uploads were resetting back to 0 progress much more easily than they …

### DIFF
--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -115,7 +115,7 @@ struct MEGA_API TransferSlot
     bool retrying;
     BackoffTimer retrybt;
 
-    // transfer failure flag
+    // transfer failure flag. MegaClient will increment the transfer->errorcount when it sees this set.
     bool failure;
     
     TransferSlot(Transfer*);

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -946,12 +946,17 @@ void TransferSlot::doio(MegaClient* client)
 
                         return transfer->failed(API_EOVERQUOTA, backoff);
                     }
-                    else if (reqs[i]->httpstatus == 403 || reqs[i]->httpstatus == 404 || reqs[i]->httpstatus == 0)
+                    else if (reqs[i]->httpstatus == 403 || reqs[i]->httpstatus == 404)
                     {
                         if (!tryRaidRecoveryFromHttpGetError(i))
                         {
                             return transfer->failed(API_EAGAIN);
                         }
+                    }
+                    else if (reqs[i]->httpstatus == 0 && tryRaidRecoveryFromHttpGetError(i))
+                    {
+                        // status 0 indicates network error or timeout; no headers recevied.
+                        // tryRaidRecoveryFromHttpGetError has switched to loading a different part instead of this one.
                     }
                     else
                     {


### PR DESCRIPTION
…used to.

Uploads should retry until the count gets to 4, however the check added with cloudraid for REQ_FAILURE with reqs[i]->httpstatus == 0 had short-circuited that mechanism for uploads under some circumstances.
This change restores that functionality while retaining the change intended with cloudraid.