### PR TITLE
Address some warnings

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -6139,11 +6139,12 @@ void DemoApp::cancelsignup_result(error)
     signupname.clear();
 }
 
-void DemoApp::whyamiblocked_result(error code)
+void DemoApp::whyamiblocked_result(int code)
 {
     if (code < 0)
     {
-        cout << "Why am I blocked failed: " << errorstring(code) << endl;
+        error e = (error) code;
+        cout << "Why am I blocked failed: " << errorstring(e) << endl;
     }
     else if (code == 0)
     {

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -100,7 +100,7 @@ struct DemoApp : public MegaApp
     void ephemeral_result(handle, const byte*) override;
     void cancelsignup_result(error) override;
 
-    void whyamiblocked_result(error) override;
+    void whyamiblocked_result(int) override;
 
     void sendsignuplink_result(error) override;
     void querysignuplink_result(error) override;

--- a/include/mega/http.h
+++ b/include/mega/http.h
@@ -368,7 +368,7 @@ class MEGA_API EncryptBufferByChunks : public EncryptByChunks
     // specialisation for encrypting a whole contiguous buffer by chunks
     byte *chunkstart;
 
-    virtual byte* nextbuffer(unsigned bufsize) override;
+    byte* nextbuffer(unsigned bufsize) override;
 
 public:
     EncryptBufferByChunks(byte* b, SymmCipher* k, chunkmac_map* m, uint64_t iv);

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -55,7 +55,7 @@ struct MEGA_API MegaApp
     virtual void cancelsignup_result(error) { }
 
     // check the reason of being blocked result
-    virtual void whyamiblocked_result(error) { }
+    virtual void whyamiblocked_result(int) { }
 
     // account creation
     virtual void sendsignuplink_result(error) { }

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2854,7 +2854,7 @@ protected:
         void http_result(error, int, byte *, int) override;
 
         // notify about a business account status change
-        virtual void notify_business_status(BizStatus status) override;
+        void notify_business_status(BizStatus status) override;
 
         // notify about a finished timer
         void timer_result(error) override;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -406,7 +406,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
         MegaHandle getPublicHandle() override;
         MegaNode* getPublicNode() override;
         char *getPublicLink(bool includeKey = true) override;
-        int64_t getPublicLinkCreationTime();
+        virtual int64_t getPublicLinkCreationTime() override;
         bool isFile() override;
         bool isFolder() override;
         bool isRemoved() override;
@@ -2627,7 +2627,7 @@ protected:
         void cancelsignup_result(error) override;
 
         // check the reason of being blocked
-        void whyamiblocked_result(error) override;
+        void whyamiblocked_result(int) override;
 
         // contact link management
         void contactlinkcreate_result(error, handle) override;
@@ -2854,7 +2854,7 @@ protected:
         void http_result(error, int, byte *, int) override;
 
         // notify about a business account status change
-        virtual void notify_business_status(BizStatus status);
+        virtual void notify_business_status(BizStatus status) override;
 
         // notify about a finished timer
         void timer_result(error) override;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -379,7 +379,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
         int getType() override;
         const char* getName() override;
         const char* getFingerprint() override;
-        virtual const char* getOriginalFingerprint() override;
+        const char* getOriginalFingerprint() override;
         bool hasCustomAttrs() override;
         MegaStringList *getCustomAttrNames() override;
         const char *getCustomAttr(const char* attrName) override;
@@ -406,7 +406,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
         MegaHandle getPublicHandle() override;
         MegaNode* getPublicNode() override;
         char *getPublicLink(bool includeKey = true) override;
-        virtual int64_t getPublicLinkCreationTime() override;
+        int64_t getPublicLinkCreationTime() override;
         bool isFile() override;
         bool isFolder() override;
         bool isRemoved() override;
@@ -815,7 +815,7 @@ public:
     bool isValid() const;
 
     virtual ~MegaPushNotificationSettingsPrivate();
-    virtual MegaPushNotificationSettings *copy() const override;
+    MegaPushNotificationSettings *copy() const override;
 
 private:
     m_time_t mGlobalDND = -1;        // defaults to -1 if not defined
@@ -1165,9 +1165,9 @@ public:
     virtual ~MegaEventPrivate();
     MegaEvent *copy() override;
 
-    virtual int getType() const override;
-    virtual const char *getText() const override;
-    virtual int64_t getNumber() const override;
+    int getType() const override;
+    const char *getText() const override;
+    int64_t getNumber() const override;
 
     void setText(const char* text);
     void setNumber(int64_t number);
@@ -1496,11 +1496,11 @@ class MegaNodeListPrivate : public MegaNodeList
         MegaNodeListPrivate(Node** newlist, int size);
         MegaNodeListPrivate(const MegaNodeListPrivate *nodeList, bool copyChildren = false);
         virtual ~MegaNodeListPrivate();
-        virtual MegaNodeList *copy() const override;
-        virtual MegaNode* get(int i) const override;
-        virtual int size() const override;
+        MegaNodeList *copy() const override;
+        MegaNode* get(int i) const override;
+        int size() const override;
 
-        virtual void addNode(MegaNode* node) override;
+        void addNode(MegaNode* node) override;
 	
 	protected:
 		MegaNode** list;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4506,7 +4506,7 @@ void CommandWhyAmIblocked::procresult()
 {
     if (client->json.isnumeric())
     {
-        return client->app->whyamiblocked_result(error(client->json.getint()));
+        return client->app->whyamiblocked_result(int(client->json.getint()));
     }
 
     client->json.storeobject();

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14397,7 +14397,7 @@ void MegaApiImpl::cancelsignup_result(error e)
     fireOnRequestFinish(request, MegaError(e));
 }
 
-void MegaApiImpl::whyamiblocked_result(error code)
+void MegaApiImpl::whyamiblocked_result(int code)
 {
     if (requestMap.find(client->restag) == requestMap.end())
     {


### PR DESCRIPTION
Override
Result of comparison of constant xxx with expression of type 'mega::error' (aka 'mega::ErrorCodes') is always false