### PR TITLE
Allow to cancel ongoing searches

### DIFF
--- a/bindings/ios/MEGACancelToken.h
+++ b/bindings/ios/MEGACancelToken.h
@@ -1,0 +1,41 @@
+/**
+ * @file MEGACancelToken.h
+ * @brief Cancel MEGASdk methods.
+ *
+ * (c) 2019- by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MEGACancelToken : NSObject
+
+/**
+ * @brief The state of the flag
+ */
+@property (nonatomic, readonly, getter=isCancelled) BOOL cancelled;
+
+/**
+ * @brief Allows to set the value of the flag
+ * @param newValue YES to force the cancelation of the processing. NO to reset.
+ */
+- (void)cancelWithNewValue:(BOOL)newValue;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/bindings/ios/MEGACancelToken.mm
+++ b/bindings/ios/MEGACancelToken.mm
@@ -1,0 +1,60 @@
+/**
+ * @file MEGACancelToken.m
+ * @brief Cancel MEGASdk methods.
+ *
+ * (c) 2019- by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+#import "MEGACancelToken.h"
+#import "megaapi.h"
+#import "MEGACancelToken+init.h"
+
+@interface MEGACancelToken ()
+
+@property (nonatomic) mega::MegaCancelToken *megaCancelToken;
+
+@end
+
+@implementation MEGACancelToken
+
+- (instancetype)init {
+    self = [super init];
+    
+    if (self) {
+        _megaCancelToken = mega::MegaCancelToken::createInstance();
+    }
+    
+    return self;
+}
+
+- (void)dealloc {
+    delete _megaCancelToken;
+}
+
+- (mega::MegaCancelToken *)getCPtr {
+    return self.megaCancelToken;
+}
+
+- (BOOL)isCancelled {
+    return self.megaCancelToken->isCancelled();
+}
+
+- (void)cancelWithNewValue:(BOOL)newValue {
+    self.megaCancelToken->cancel(newValue);
+}
+
+@end

--- a/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
+++ b/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		A8827A5C1F178A0D0097B5DE /* DelegateMEGATreeProcessorListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = A8827A5B1F178A0D0097B5DE /* DelegateMEGATreeProcessorListener.mm */; };
 		A88722DC1FFE6A8B00E3F443 /* mediafileattribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A88722DB1FFE6A8A00E3F443 /* mediafileattribute.cpp */; };
 		A8A86BD51F559EDA00C214DA /* mega_zxcvbn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A86BD41F559EDA00C214DA /* mega_zxcvbn.cpp */; };
+		A8FD7334230ABA400070A5E8 /* MEGACancelToken.mm in Sources */ = {isa = PBXBuildFile; fileRef = A8FD7333230ABA400070A5E8 /* MEGACancelToken.mm */; };
 		A8FD7B641E93B40E0031FC50 /* osxutils.mm in Sources */ = {isa = PBXBuildFile; fileRef = A8FD7B631E93B40E0031FC50 /* osxutils.mm */; };
 		B6657E9C225C2B6200EF8D91 /* raid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6657E9B225C2B6200EF8D91 /* raid.cpp */; };
 		B698890D2198CCE300D0EE89 /* MEGAFileInputStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = B698890B2198CCE300D0EE89 /* MEGAFileInputStream.mm */; };
@@ -306,6 +307,9 @@
 		A8A86BD31F559C0100C214DA /* mega_zxcvbn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mega_zxcvbn.h; sourceTree = "<group>"; };
 		A8A86BD41F559EDA00C214DA /* mega_zxcvbn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mega_zxcvbn.cpp; path = ../../src/mega_zxcvbn.cpp; sourceTree = "<group>"; };
 		A8EBFDD21EFAE14C00DF89DA /* MEGAEvent+init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MEGAEvent+init.h"; sourceTree = "<group>"; };
+		A8FD7332230ABA400070A5E8 /* MEGACancelToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MEGACancelToken.h; sourceTree = "<group>"; };
+		A8FD7333230ABA400070A5E8 /* MEGACancelToken.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MEGACancelToken.mm; sourceTree = "<group>"; };
+		A8FD7335230AC42B0070A5E8 /* MEGACancelToken+init.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MEGACancelToken+init.h"; sourceTree = "<group>"; };
 		A8FD7B611E93B3ED0031FC50 /* osxutils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = osxutils.h; path = osx/osxutils.h; sourceTree = "<group>"; };
 		A8FD7B631E93B40E0031FC50 /* osxutils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = osxutils.mm; path = ../../src/osx/osxutils.mm; sourceTree = "<group>"; };
 		B622FC762174261F00CF707C /* MEGABackgroundMediaUpload+init.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MEGABackgroundMediaUpload+init.h"; sourceTree = "<group>"; };
@@ -495,6 +499,8 @@
 				5B1D7CE121F1E07200B0215E /* MEGARecentActionBucket.mm */,
 				B6A6CB642170125A009032C9 /* MEGABackgroundMediaUpload.h */,
 				B6A6CB652170125A009032C9 /* MEGABackgroundMediaUpload.mm */,
+				A8FD7332230ABA400070A5E8 /* MEGACancelToken.h */,
+				A8FD7333230ABA400070A5E8 /* MEGACancelToken.mm */,
 			);
 			name = bindings;
 			sourceTree = "<group>";
@@ -654,6 +660,7 @@
 				A808E4862158DAC400BDCE82 /* MEGATimeZoneDetails+init.h */,
 				5B0670CD21F5BABD00AD9F99 /* MEGARecentActionBucket+init.h */,
 				B622FC762174261F00CF707C /* MEGABackgroundMediaUpload+init.h */,
+				A8FD7335230AC42B0070A5E8 /* MEGACancelToken+init.h */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -805,6 +812,7 @@
 				940BEFBA19ED92C2007E7FA2 /* command.cpp in Sources */,
 				940BEFD019ED92C2007E7FA2 /* transfer.cpp in Sources */,
 				5B72A14D20D3B3FB007FE4FD /* mega_ccronexpr.cpp in Sources */,
+				A8FD7334230ABA400070A5E8 /* MEGACancelToken.mm in Sources */,
 				41AD7A7E1A1E10F900D66856 /* DelegateMEGALoggerListener.mm in Sources */,
 				41A990731A5D305700B2094A /* mega_utf8proc.cpp in Sources */,
 				A81790101EFACE6400110E91 /* MEGAHandleList.mm in Sources */,

--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -6154,6 +6154,14 @@ typedef NS_ENUM(NSInteger, BusinessStatus) {
 - (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString;
 
 /**
+ * @brief Allows to cancel an ongoing search
+ *
+ * Since searches are blocking, if the user refines the search string, the current search
+ * can be discarded to not wait for the results and finish it immediately.
+ */
+- (void)cancelSearch;
+
+/**
  * @brief Return an array of buckets, each bucket containing a list of recently added/modified nodes
  *
  * Each bucket contains files that were added/modified in a set, by a single user.

--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -46,6 +46,7 @@
 #import "MEGAUser.h"
 #import "MEGAUserList.h"
 #import "MEGABackgroundMediaUpload.h"
+#import "MEGACancelToken.h"
 
 typedef NS_ENUM (NSInteger, MEGASortOrderType) {
     MEGASortOrderTypeNone,
@@ -6148,18 +6149,25 @@ typedef NS_ENUM(NSInteger, BusinessStatus) {
  *
  * @param node The parent node of the tree to explore.
  * @param searchString Search string. The search is case-insensitive.
+ * @param cancelToken MEGACancelToken to be able to cancel the processing at any time.
+ * @param recursive YES if you want to seach recursively in the node tree.
+ * NO if you want to seach in the children of the node only
+ *
+ * @return List of nodes that contain the desired string in their name.
+ */
+- (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString cancelToken:(MEGACancelToken *)cancelToken recursive:(BOOL)recursive;
+
+/**
+ * @brief Search nodes containing a search string in their name.
+ *
+ * The search is case-insensitive.
+ *
+ * @param node The parent node of the tree to explore.
+ * @param searchString Search string. The search is case-insensitive.
  *
  * @return List of nodes that contain the desired string in their name.
  */
 - (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString;
-
-/**
- * @brief Allows to cancel an ongoing search
- *
- * Since searches are blocking, if the user refines the search string, the current search
- * can be discarded to not wait for the results and finish it immediately.
- */
-- (void)cancelSearch;
 
 /**
  * @brief Return an array of buckets, each bucket containing a list of recently added/modified nodes

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -43,6 +43,7 @@
 #import "DelegateMEGATreeProcessorListener.h"
 #import "MEGAFileInputStream.h"
 #import "MEGADataInputStream.h"
+#import "MEGACancelToken+init.h"
 
 #import <set>
 #import <pthread.h>
@@ -1868,12 +1869,12 @@ using namespace mega;
     return [[MEGANodeList alloc] initWithNodeList:self.megaApi->search((node != nil) ? [node getCPtr] : NULL, (searchString != nil) ? [searchString UTF8String] : NULL, recursive) cMemoryOwn:YES];
 }
 
-- (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString {
-    return [[MEGANodeList alloc] initWithNodeList:self.megaApi->search((node != nil) ? [node getCPtr] : NULL, (searchString != nil) ? [searchString UTF8String] : NULL, YES) cMemoryOwn:YES];
+- (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString cancelToken:(MEGACancelToken *)cancelToken recursive:(BOOL)recursive {
+    return [MEGANodeList.alloc initWithNodeList:self.megaApi->search(node ? [node getCPtr] : NULL, searchString.UTF8String, cancelToken ? [cancelToken getCPtr] : NULL, recursive) cMemoryOwn:YES];
 }
 
-- (void)cancelSearch {
-    self.megaApi->cancelSearch();
+- (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString {
+    return [[MEGANodeList alloc] initWithNodeList:self.megaApi->search((node != nil) ? [node getCPtr] : NULL, (searchString != nil) ? [searchString UTF8String] : NULL, YES) cMemoryOwn:YES];
 }
 
 - (NSMutableArray *)recentActions {

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -1872,6 +1872,10 @@ using namespace mega;
     return [[MEGANodeList alloc] initWithNodeList:self.megaApi->search((node != nil) ? [node getCPtr] : NULL, (searchString != nil) ? [searchString UTF8String] : NULL, YES) cMemoryOwn:YES];
 }
 
+- (void)cancelSearch {
+    self.megaApi->cancelSearch();
+}
+
 - (NSMutableArray *)recentActions {
     MegaRecentActionBucketList *megaRecentActionBucketList = self.megaApi->getRecentActions();
     int count = megaRecentActionBucketList->size();

--- a/bindings/ios/Private/MEGACancelToken+init.h
+++ b/bindings/ios/Private/MEGACancelToken+init.h
@@ -1,0 +1,33 @@
+/**
+ * @file MEGACancelToken+init.h
+ * @brief Private functions of MEGACancelToken
+ *
+ * (c) 2019 - by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+#import "MEGACancelToken.h"
+#import "MegaApi.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MEGACancelToken (init)
+
+- (mega::MegaCancelToken *)getCPtr;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/bindings/java/nz/mega/sdk/MegaApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaApiJava.java
@@ -7176,6 +7176,17 @@ public class MegaApiJava {
     }
 
     /**
+     * Allows to cancel an ongoing search
+     *
+     * Since searches are blocking, if the user refines the search string, the current search
+     * can be discarded to not wait for the results and finish it immediately.
+     */
+    public void cancelSearch() {
+        megaApi.cancelSearch();
+    }
+
+
+    /**
      * Return a list of buckets, each bucket containing a list of recently added/modified nodes
      *
      * Each bucket contains files that were added/modified in a set, by a single user.

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -16251,11 +16251,10 @@ public:
 class MegaCancelToken
 {
 public:
-public:
 
     /**
      * @brief Creates an object which can be passed as parameter for some MegaApi methods in order to
-     * cancel the processing associated to the function. @see MegaApi::search
+     * request the cancellation of the processing associated to the function. @see MegaApi::search
      *
      * You take ownership of the returned value.
      *

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -12957,7 +12957,8 @@ class MegaApi
          * You take the ownership of the returned value.
          *
          * This function allows to cancel the processing at any time by passing a MegaCancelToken and calling
-         * to MegaCancelToken::setCancelFlag(true).
+         * to MegaCancelToken::setCancelFlag(true). If a valid object is passed, it must be kept alive until
+         * this method returns.
          *
          * @param node The parent node of the tree to explore
          * @param searchString Search string. The search is case-insensitive
@@ -13068,7 +13069,8 @@ class MegaApi
          *  - Incoming shares from other users
          *
          * This function allows to cancel the processing at any time by passing a MegaCancelToken and calling
-         * to MegaCancelToken::setCancelFlag(true).
+         * to MegaCancelToken::setCancelFlag(true). If a valid object is passed, it must be kept alive until
+         * this method returns.
          *
          * You take the ownership of the returned value.
          *

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -13003,6 +13003,14 @@ class MegaApi
         MegaNodeList* search(const char* searchString, int order = ORDER_NONE);
 
         /**
+         * @brief Allows to cancel an ongoing search
+         *
+         * Since searches are blocking, if the user refines the search string, the current search
+         * can be discarded to not wait for the results and finish it immediately.
+         */
+        void cancelSearch();
+
+        /**
          * @brief Return a list of buckets, each bucket containing a list of recently added/modified nodes
          *
          * Each bucket contains files that were added/modified in a set, by a single user.

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -16275,7 +16275,7 @@ public:
      * @brief Returns the state of the flag
      * @return The state of the flag
      */
-    virtual bool isCancelled();
+    virtual bool isCancelled() const;
 };
 
 }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -80,6 +80,7 @@ class MegaFolderInfo;
 class MegaTimeZoneDetails;
 class MegaPushNotificationSettings;
 class MegaBackgroundMediaUpload;
+class MegaCancelToken;
 class MegaApi;
 
 class MegaSemaphore;
@@ -16141,6 +16142,36 @@ public:
      * @return The transfer achieved quota by this account as result of referrals
      */
     virtual long long currentTransferReferrals();
+};
+
+class MegaCancelToken
+{
+public:
+public:
+
+    /**
+     * @brief Creates an object which can be passed as parameter for some MegaApi methods in order to
+     * cancel the processing associated to the function. @see MegaApi::search
+     *
+     * You take ownership of the returned value.
+     *
+     * @return A pointer to an object that allows to cancel the processing of some functions.
+     */
+    static MegaCancelToken* createInstance();
+
+    virtual ~MegaCancelToken();
+
+    /**
+     * @brief Allows to set the value of the flag
+     * @param newValue True to force the cancelation of the processing. False to reset.
+     */
+    virtual void setCancelFlag(bool newValue = true);  // allows to reset also for reuse cases
+
+    /**
+     * @brief Returns the state of the flag
+     * @return The state of the flag
+     */
+    virtual bool getCancelFlag();
 };
 
 }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -12909,6 +12909,7 @@ class MegaApi
          * @param node The parent node of the tree to explore
          * @param searchString Search string. The search is case-insensitive
          * @param recursive True if you want to seach recursively in the node tree.
+         * False if you want to seach in the children of the node only
          * @param order Order for the returned list
          * Valid values for this parameter are:
          * - MegaApi::ORDER_NONE = 0
@@ -12944,11 +12945,63 @@ class MegaApi
          * - MegaApi::ORDER_ALPHABETICAL_DESC = 10
          * Sort in alphabetical order, descending
          *
-         * False if you want to seach in the children of the node only
-         *
          * @return List of nodes that contain the desired string in their name
          */
         MegaNodeList* search(MegaNode* node, const char* searchString, bool recursive = 1, int order = ORDER_NONE);
+
+        /**
+         * @brief Search nodes containing a search string in their name
+         *
+         * The search is case-insensitive.
+         *
+         * You take the ownership of the returned value.
+         *
+         * This function allows to cancel the processing at any time by passing a MegaCancelToken and calling
+         * to MegaCancelToken::setCancelFlag(true).
+         *
+         * @param node The parent node of the tree to explore
+         * @param searchString Search string. The search is case-insensitive
+         * @param cancelToken MegaCancelToken to be able to cancel the processing at any time.
+         * @param recursive True if you want to seach recursively in the node tree.
+         * False if you want to seach in the children of the node only
+         * @param order Order for the returned list
+         * Valid values for this parameter are:
+         * - MegaApi::ORDER_NONE = 0
+         * Undefined order
+         *
+         * - MegaApi::ORDER_DEFAULT_ASC = 1
+         * Folders first in alphabetical order, then files in the same order
+         *
+         * - MegaApi::ORDER_DEFAULT_DESC = 2
+         * Files first in reverse alphabetical order, then folders in the same order
+         *
+         * - MegaApi::ORDER_SIZE_ASC = 3
+         * Sort by size, ascending
+         *
+         * - MegaApi::ORDER_SIZE_DESC = 4
+         * Sort by size, descending
+         *
+         * - MegaApi::ORDER_CREATION_ASC = 5
+         * Sort by creation time in MEGA, ascending
+         *
+         * - MegaApi::ORDER_CREATION_DESC = 6
+         * Sort by creation time in MEGA, descending
+         *
+         * - MegaApi::ORDER_MODIFICATION_ASC = 7
+         * Sort by modification time of the original file, ascending
+         *
+         * - MegaApi::ORDER_MODIFICATION_DESC = 8
+         * Sort by modification time of the original file, descending
+         *
+         * - MegaApi::ORDER_ALPHABETICAL_ASC = 9
+         * Sort in alphabetical order, ascending
+         *
+         * - MegaApi::ORDER_ALPHABETICAL_DESC = 10
+         * Sort in alphabetical order, descending
+         *
+         * @return List of nodes that contain the desired string in their name
+         */
+        MegaNodeList* search(MegaNode* node, const char* searchString, MegaCancelToken *cancelToken, bool recursive = 1, int order = ORDER_NONE);
 
         /**
          * @brief Search nodes containing a search string in their name
@@ -13004,12 +13057,61 @@ class MegaApi
         MegaNodeList* search(const char* searchString, int order = ORDER_NONE);
 
         /**
-         * @brief Allows to cancel an ongoing search
+         * @brief Search nodes containing a search string in their name
          *
-         * Since searches are blocking, if the user refines the search string, the current search
-         * can be discarded to not wait for the results and finish it immediately.
+         * The search is case-insensitive.
+         *
+         * The search will consider every accessible node for the account:
+         *  - Cloud drive
+         *  - Inbox
+         *  - Rubbish bin
+         *  - Incoming shares from other users
+         *
+         * This function allows to cancel the processing at any time by passing a MegaCancelToken and calling
+         * to MegaCancelToken::setCancelFlag(true).
+         *
+         * You take the ownership of the returned value.
+         *
+         * @param searchString Search string. The search is case-insensitive
+         * @param cancelToken MegaCancelToken to be able to cancel the processing at any time.
+         * @param order Order for the returned list
+         * Valid values for this parameter are:
+         * - MegaApi::ORDER_NONE = 0
+         * Undefined order
+         *
+         * - MegaApi::ORDER_DEFAULT_ASC = 1
+         * Folders first in alphabetical order, then files in the same order
+         *
+         * - MegaApi::ORDER_DEFAULT_DESC = 2
+         * Files first in reverse alphabetical order, then folders in the same order
+         *
+         * - MegaApi::ORDER_SIZE_ASC = 3
+         * Sort by size, ascending
+         *
+         * - MegaApi::ORDER_SIZE_DESC = 4
+         * Sort by size, descending
+         *
+         * - MegaApi::ORDER_CREATION_ASC = 5
+         * Sort by creation time in MEGA, ascending
+         *
+         * - MegaApi::ORDER_CREATION_DESC = 6
+         * Sort by creation time in MEGA, descending
+         *
+         * - MegaApi::ORDER_MODIFICATION_ASC = 7
+         * Sort by modification time of the original file, ascending
+         *
+         * - MegaApi::ORDER_MODIFICATION_DESC = 8
+         * Sort by modification time of the original file, descending
+         *
+         * - MegaApi::ORDER_ALPHABETICAL_ASC = 9
+         * Sort in alphabetical order, ascending
+         *
+         * - MegaApi::ORDER_ALPHABETICAL_DESC = 10
+         * Sort in alphabetical order, descending
+         *
+         * @return List of nodes that contain the desired string in their name
          */
-        void cancelSearch();
+        MegaNodeList* search(const char* searchString, MegaCancelToken *cancelToken, int order = ORDER_NONE);
 
         /**
          * @brief Return a list of buckets, each bucket containing a list of recently added/modified nodes
@@ -16165,13 +16267,13 @@ public:
      * @brief Allows to set the value of the flag
      * @param newValue True to force the cancelation of the processing. False to reset.
      */
-    virtual void setCancelFlag(bool newValue = true);  // allows to reset also for reuse cases
+    virtual void cancel(bool newValue = true);
 
     /**
      * @brief Returns the state of the flag
      * @return The state of the flag
      */
-    virtual bool getCancelFlag();
+    virtual bool isCancelled();
 };
 
 }

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2940,7 +2940,7 @@ protected:
         Node* getNodeByFingerprintInternal(const char *fingerprint);
         Node *getNodeByFingerprintInternal(const char *fingerprint, Node *parent);
 
-        bool processTree(Node* node, TreeProcessor* processor, bool recursive = 1, MegaCancelTokenPrivate *cancelToken = nullptr);
+        bool processTree(Node* node, TreeProcessor* processor, bool recursive = 1, MegaCancelToken* cancelToken = nullptr);
         void getNodeAttribute(MegaNode* node, int type, const char *dstFilePath, MegaRequestListener *listener = NULL);
 		    void cancelGetNodeAttribute(MegaNode *node, int type, MegaRequestListener *listener = NULL);
         void setNodeAttribute(MegaNode* node, int type, const char *srcFilePath, MegaHandle attributehandle, MegaRequestListener *listener = NULL);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1375,14 +1375,14 @@ private:
 
 class MegaCancelTokenPrivate : public MegaCancelToken
 {
-private:
-    std::atomic_bool cancelFlag { false };
-
 public:
     ~MegaCancelTokenPrivate() override;
 
     void cancel(bool newValue = true) override;
-    bool isCancelled() override;
+    bool isCancelled() const override;
+
+private:
+    std::atomic_bool cancelFlag { false };
 };
 
 #ifdef ENABLE_CHAT

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1381,8 +1381,8 @@ private:
 public:
     ~MegaCancelTokenPrivate() override;
 
-    void setCancelFlag(bool newValue = true) override;
-    bool getCancelFlag() override;
+    void cancel(bool newValue = true) override;
+    bool isCancelled() override;
 };
 
 #ifdef ENABLE_CHAT
@@ -2312,10 +2312,9 @@ class MegaApiImpl : public MegaApp
 
         MegaRecentActionBucketList* getRecentActions(unsigned days = 90, unsigned maxnodes = 10000);
 
-        MegaNodeList* search(MegaNode* node, const char* searchString, bool recursive = 1, int order = MegaApi::ORDER_NONE);
+        MegaNodeList* search(MegaNode* node, const char* searchString, MegaCancelToken *cancelToken, bool recursive = 1, int order = MegaApi::ORDER_NONE);
         bool processMegaTree(MegaNode* node, MegaTreeProcessor* processor, bool recursive = 1);
-        MegaNodeList* search(const char* searchString, int order = MegaApi::ORDER_NONE);
-        void cancelSearch();
+        MegaNodeList* search(const char* searchString, MegaCancelToken *cancelToken, int order = MegaApi::ORDER_NONE);
 
         MegaNode *createForeignFileNode(MegaHandle handle, const char *key, const char *name, m_off_t size, m_off_t mtime,
                                        MegaHandle parentHandle, const char *privateauth, const char *publicauth, const char *chatauth);
@@ -2661,7 +2660,6 @@ protected:
         MegaUserAlertList *activeUserAlerts;
         MegaContactRequestList *activeContactRequests;
         string appKey;
-        std::atomic_bool mCancelSearch = {false};
 
         MegaPushNotificationSettings *mPushSettings; // stores lastest-seen settings (to be able to filter notifications)
         MegaTimeZoneDetails *mTimezones;
@@ -2942,8 +2940,7 @@ protected:
         Node* getNodeByFingerprintInternal(const char *fingerprint);
         Node *getNodeByFingerprintInternal(const char *fingerprint, Node *parent);
 
-        bool processTree(Node* node, TreeProcessor* processor, bool recursive = 1);
-        MegaNodeList* search(Node* node, const char* searchString, bool recursive = 1);
+        bool processTree(Node* node, TreeProcessor* processor, bool recursive = 1, MegaCancelTokenPrivate *cancelToken = nullptr);
         void getNodeAttribute(MegaNode* node, int type, const char *dstFilePath, MegaRequestListener *listener = NULL);
 		    void cancelGetNodeAttribute(MegaNode *node, int type, MegaRequestListener *listener = NULL);
         void setNodeAttribute(MegaNode* node, int type, const char *srcFilePath, MegaHandle attributehandle, MegaRequestListener *listener = NULL);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1373,6 +1373,18 @@ private:
     AchievementsDetails details;
 };
 
+class MegaCancelTokenPrivate : public MegaCancelToken
+{
+private:
+    std::atomic_bool cancelFlag { false };
+
+public:
+    ~MegaCancelTokenPrivate() override;
+
+    void setCancelFlag(bool newValue = true) override;
+    bool getCancelFlag() override;
+};
+
 #ifdef ENABLE_CHAT
 class MegaTextChatPeerListPrivate : public MegaTextChatPeerList
 {

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2303,6 +2303,7 @@ class MegaApiImpl : public MegaApp
         MegaNodeList* search(MegaNode* node, const char* searchString, bool recursive = 1, int order = MegaApi::ORDER_NONE);
         bool processMegaTree(MegaNode* node, MegaTreeProcessor* processor, bool recursive = 1);
         MegaNodeList* search(const char* searchString, int order = MegaApi::ORDER_NONE);
+        void cancelSearch();
 
         MegaNode *createForeignFileNode(MegaHandle handle, const char *key, const char *name, m_off_t size, m_off_t mtime,
                                        MegaHandle parentHandle, const char *privateauth, const char *publicauth, const char *chatauth);
@@ -2597,7 +2598,6 @@ protected:
         int ftpServerMaxOutputSize;
         int ftpServerRestrictedMode;
         set<MegaTransferListener *> ftpServerListeners;
-
 #endif
 		
         map<int, MegaBackupController *> backupsMap;
@@ -2649,6 +2649,7 @@ protected:
         MegaUserAlertList *activeUserAlerts;
         MegaContactRequestList *activeContactRequests;
         string appKey;
+        std::atomic_bool mCancelSearch = {false};
 
         MegaPushNotificationSettings *mPushSettings; // stores lastest-seen settings (to be able to filter notifications)
         MegaTimeZoneDetails *mTimezones;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -6263,4 +6263,24 @@ MegaPushNotificationSettings::MegaPushNotificationSettings()
 
 }
 
+MegaCancelToken *MegaCancelToken::createInstance()
+{
+    return new MegaCancelTokenPrivate;
+}
+
+MegaCancelToken::~MegaCancelToken()
+{
+
+}
+
+void MegaCancelToken::setCancelFlag(bool)
+{
+
+}
+
+bool MegaCancelToken::getCancelFlag()
+{
+    return false;
+}
+
 }

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3522,17 +3522,22 @@ char *MegaApi::base32ToBase64(const char *base32)
 
 MegaNodeList* MegaApi::search(MegaNode* n, const char* searchString, bool recursive, int order)
 {
-    return pImpl->search(n, searchString, recursive, order);
+    return pImpl->search(n, searchString, nullptr, recursive, order);
+}
+
+MegaNodeList *MegaApi::search(MegaNode *n, const char *searchString, MegaCancelToken *cancelToken, bool recursive, int order)
+{
+    return pImpl->search(n, searchString, cancelToken, recursive, order);
 }
 
 MegaNodeList *MegaApi::search(const char *searchString, int order)
 {
-    return pImpl->search(searchString, order);
+    return pImpl->search(searchString, nullptr, order);
 }
 
-void MegaApi::cancelSearch()
+MegaNodeList *MegaApi::search(const char *searchString, MegaCancelToken *cancelToken, int order)
 {
-    pImpl->cancelSearch();
+    return pImpl->search(searchString, cancelToken, order);
 }
 
 long long MegaApi::getSize(MegaNode *n)
@@ -6273,12 +6278,12 @@ MegaCancelToken::~MegaCancelToken()
 
 }
 
-void MegaCancelToken::setCancelFlag(bool)
+void MegaCancelToken::cancel(bool)
 {
 
 }
 
-bool MegaCancelToken::getCancelFlag()
+bool MegaCancelToken::isCancelled()
 {
     return false;
 }

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3530,6 +3530,11 @@ MegaNodeList *MegaApi::search(const char *searchString, int order)
     return pImpl->search(searchString, order);
 }
 
+void MegaApi::cancelSearch()
+{
+    pImpl->cancelSearch();
+}
+
 long long MegaApi::getSize(MegaNode *n)
 {
     return pImpl->getSize(n);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -6283,7 +6283,7 @@ void MegaCancelToken::cancel(bool)
 
 }
 
-bool MegaCancelToken::isCancelled()
+bool MegaCancelToken::isCancelled() const
 {
     return false;
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10427,6 +10427,11 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, MegaCancelToken *can
         return new MegaNodeListPrivate();
     }
 
+    if (cancelToken && cancelToken->isCancelled())
+    {
+        return new MegaNodeListPrivate();
+    }
+
     SdkMutexGuard g(sdkMutex);
     if (cancelToken && cancelToken->isCancelled())
     {
@@ -10976,6 +10981,11 @@ bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursi
 MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, MegaCancelToken *cancelToken, bool recursive, int order)
 {
     if (!n || !searchString)
+    {
+        return new MegaNodeListPrivate();
+    }
+
+    if (cancelToken && cancelToken->isCancelled())
     {
         return new MegaNodeListPrivate();
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10433,6 +10433,7 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, MegaCancelToken *can
     }
 
     SdkMutexGuard g(sdkMutex);
+
     if (cancelToken && cancelToken->isCancelled())
     {
         return new MegaNodeListPrivate();
@@ -10442,7 +10443,8 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, MegaCancelToken *can
     Node *node;
 
     // rootnodes
-    for (unsigned int i = 0; i < (sizeof client->rootnodes / sizeof *client->rootnodes); i++)
+    for (unsigned int i = 0; i < (sizeof client->rootnodes / sizeof *client->rootnodes)
+          && !(cancelToken && cancelToken->isCancelled()); i++)
     {
         node = client->nodebyhandle(client->rootnodes[i]);
 
@@ -10455,7 +10457,7 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, MegaCancelToken *can
 
     // inshares
     MegaShareList *shares = getInSharesList();
-    for (int i = 0; i < shares->size(); i++)
+    for (int i = 0; i < shares->size() && !(cancelToken && cancelToken->isCancelled()); i++)
     {
         node = client->nodebyhandle(shares->get(i)->getNodeHandle());
 
@@ -11004,7 +11006,8 @@ MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, MegaCan
     }
 
     SearchTreeProcessor searchProcessor(searchString);
-    for (node_list::iterator it = node->children.begin(); it != node->children.end(); )
+    for (node_list::iterator it = node->children.begin(); it != node->children.end()
+         && !(cancelToken && cancelToken->isCancelled()); )
     {
         processTree(*it++, &searchProcessor, recursive, cancelToken);
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -31318,4 +31318,19 @@ void MegaPushNotificationSettingsPrivate::enableChats(bool enable)
     mGlobalChatsDND = enable ? -1 : 0;
 }
 
+MegaCancelTokenPrivate::~MegaCancelTokenPrivate()
+{
+
+}
+
+void MegaCancelTokenPrivate::setCancelFlag(bool newValue)
+{
+    cancelFlag = newValue;
+}
+
+bool MegaCancelTokenPrivate::getCancelFlag()
+{
+    return cancelFlag;
+}
+
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10931,7 +10931,7 @@ void MegaApiImpl::resumeActionPackets()
     sdkMutex.unlock();
 }
 
-bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursive, MegaCancelTokenPrivate *cancelToken)
+bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursive, MegaCancelToken *cancelToken)
 {
     if (!node)
     {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -31336,7 +31336,7 @@ void MegaCancelTokenPrivate::cancel(bool newValue)
     cancelFlag = newValue;
 }
 
-bool MegaCancelTokenPrivate::isCancelled()
+bool MegaCancelTokenPrivate::isCancelled() const
 {
     return cancelFlag;
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10428,7 +10428,7 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, MegaCancelToken *can
     }
 
     sdkMutex.lock();
-    if (cancelToken->isCancelled())
+    if (cancelToken && cancelToken->isCancelled())
     {
         return new MegaNodeListPrivate();
     }
@@ -10943,14 +10943,14 @@ bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursi
         return 0;
     }
 
-    if (cancelToken->isCancelled())
+    if (cancelToken && cancelToken->isCancelled())
     {
         return 0;
     }
 
     sdkMutex.lock();
 
-    if (cancelToken->isCancelled()) // check before lock and after, in case it was cancelled while being locked
+    if (cancelToken && cancelToken->isCancelled()) // check before lock and after, in case it was cancelled while being locked
     {
         return 0;
     }
@@ -10986,7 +10986,8 @@ MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, MegaCan
     }
     
     sdkMutex.lock();
-    if (cancelToken->isCancelled())
+
+    if (cancelToken && cancelToken->isCancelled())
     {
         return new MegaNodeListPrivate();
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10427,7 +10427,7 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, MegaCancelToken *can
         return new MegaNodeListPrivate();
     }
 
-    sdkMutex.lock();
+    SdkMutexGuard g(sdkMutex);
     if (cancelToken && cancelToken->isCancelled())
     {
         return new MegaNodeListPrivate();
@@ -10483,8 +10483,6 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, MegaCancelToken *can
     }
     MegaNodeList *nodeList = new MegaNodeListPrivate(result.data(), int(result.size()));
     
-    sdkMutex.unlock();
-
     return nodeList;
 }
 
@@ -10948,7 +10946,7 @@ bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursi
         return 0;
     }
 
-    sdkMutex.lock();
+    SdkMutexGuard g(sdkMutex);
 
     if (cancelToken && cancelToken->isCancelled()) // check before lock and after, in case it was cancelled while being locked
     {
@@ -10958,7 +10956,6 @@ bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursi
     node = client->nodebyhandle(node->nodehandle);
     if (!node)
     {
-        sdkMutex.unlock();
         return 1;
     }
 
@@ -10968,13 +10965,11 @@ bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursi
         {
             if (!processTree(*it++, processor, recursive, cancelToken))
             {
-                sdkMutex.unlock();
                 return 0;
             }
         }
     }
     bool result = processor->processNode(node);
-    sdkMutex.unlock();
     return result;
 }
 
@@ -10985,7 +10980,7 @@ MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, MegaCan
         return new MegaNodeListPrivate();
     }
     
-    sdkMutex.lock();
+    SdkMutexGuard g(sdkMutex);
 
     if (cancelToken && cancelToken->isCancelled())
     {
@@ -10995,7 +10990,6 @@ MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, MegaCan
     Node *node = client->nodebyhandle(n->getHandle());
     if (!node)
     {
-        sdkMutex.unlock();
         return new MegaNodeListPrivate();
     }
 
@@ -11027,7 +11021,6 @@ MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, MegaCan
     }
 
     MegaNodeList *nodeList = new MegaNodeListPrivate(vNodes.data(), int(vNodes.size()));
-    sdkMutex.unlock();
     return nodeList;
 }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10428,6 +10428,7 @@ MegaNodeList *MegaApiImpl::search(const char *searchString, int order)
     }
 
     sdkMutex.lock();
+    mCancelSearch = false;
 
     node_vector result;
     Node *node;
@@ -10939,6 +10940,11 @@ bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursi
         return 0;
     }
 
+    if (mCancelSearch)
+    {
+        return 0;
+    }
+
     sdkMutex.lock();
     node = client->nodebyhandle(node->nodehandle);
     if (!node)
@@ -10963,6 +10969,11 @@ bool MegaApiImpl::processTree(Node* node, TreeProcessor* processor, bool recursi
     return result;
 }
 
+void MegaApiImpl::cancelSearch()
+{
+    mCancelSearch = true;
+}
+
 MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, bool recursive, int order)
 {
     if (!n || !searchString)
@@ -10971,6 +10982,7 @@ MegaNodeList* MegaApiImpl::search(MegaNode* n, const char* searchString, bool re
     }
     
     sdkMutex.lock();
+    mCancelSearch = false;
     
     Node *node = client->nodebyhandle(n->getHandle());
     if (!node)


### PR DESCRIPTION
Use a flag to abort ongoing searches, since for large accounts they can consume too much time and the results may become obsolete (a more accurate search is already launched or the user has moved to a different view).