### PR TITLE
#12958. Prevent useralerts for files added by others (via share)

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -4803,7 +4803,7 @@ void exec_whoami(autocomplete::ACState& s)
 
         if ((u = client->finduser(client->me)))
         {
-            cout << "Account e-mail: " << u->email << endl;
+            cout << "Account e-mail: " << u->email << " handle: " << Base64Str<MegaClient::USERHANDLE>(client->me) << endl;
 #ifdef ENABLE_CHAT
             if (client->signkey)
             {

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -823,7 +823,7 @@ private:
     // server-client command processing
     void sc_updatenode();
     Node* sc_deltree();
-    void sc_newnodes();
+    handle sc_newnodes();
     void sc_contacts();
     void sc_keys();
     void sc_fileattr();

--- a/include/mega/useralerts.h
+++ b/include/mega/useralerts.h
@@ -291,7 +291,7 @@ public:
     // keep track of incoming nodes in shares, and convert to a notification
     void beginNotingSharedNodes();
     void noteSharedNode(handle user, int type, m_time_t timestamp, Node* n);
-    void convertNotedSharedNodes(bool added);
+    void convertNotedSharedNodes(bool added, handle actinguser);
     void ignoreNextSharedNodesUnder(handle h);
 
     // enter provisional mode, added items will be checked for suitability before actually adding 

--- a/include/mega/useralerts.h
+++ b/include/mega/useralerts.h
@@ -291,7 +291,7 @@ public:
     // keep track of incoming nodes in shares, and convert to a notification
     void beginNotingSharedNodes();
     void noteSharedNode(handle user, int type, m_time_t timestamp, Node* n);
-    void convertNotedSharedNodes(bool added, handle actinguser);
+    void convertNotedSharedNodes(bool added, handle originatingUser);
     void ignoreNextSharedNodesUnder(handle h);
 
     // enter provisional mode, added items will be checked for suitability before actually adding 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4068,9 +4068,9 @@ bool MegaClient::procsc()
                                 // node addition
                                 {
                                     useralerts.beginNotingSharedNodes();
-                                    handle actinguser = sc_newnodes();
+                                    handle originatingUser = sc_newnodes();
                                     mergenewshares(1);
-                                    useralerts.convertNotedSharedNodes(true, actinguser);
+                                    useralerts.convertNotedSharedNodes(true, originatingUser);
                                 }
 
 #ifdef ENABLE_SYNC
@@ -4853,7 +4853,7 @@ void MegaClient::readtree(JSON* j)
 // server-client newnodes processing
 handle MegaClient::sc_newnodes()
 {
-    handle actinguser = UNDEF;
+    handle originatingUser = UNDEF;
     for (;;)
     {
         switch (jsonsc.getnameid())
@@ -4867,16 +4867,16 @@ handle MegaClient::sc_newnodes()
                 break;
 
             case MAKENAMEID2('o', 'u'):
-                actinguser = jsonsc.gethandle(USERHANDLE);
+                originatingUser = jsonsc.gethandle(USERHANDLE);
                 break;
 
             case EOO:
-                return actinguser;
+                return originatingUser;
 
             default:
                 if (!jsonsc.storeobject())
                 {
-                    return actinguser;
+                    return originatingUser;
                 }
         }
     }
@@ -6511,7 +6511,7 @@ Node* MegaClient::nodebyhandle(handle h)
 Node* MegaClient::sc_deltree()
 {
     Node* n = NULL;
-    handle actinguser = UNDEF;
+    handle originatingUser = UNDEF;
 
     for (;;)
     {
@@ -6527,7 +6527,7 @@ Node* MegaClient::sc_deltree()
                 break;
 
             case MAKENAMEID2('o', 'u'):
-                actinguser = jsonsc.gethandle(USERHANDLE);
+                originatingUser = jsonsc.gethandle(USERHANDLE);
                 break;
 
             case EOO:
@@ -6541,7 +6541,7 @@ Node* MegaClient::sc_deltree()
                     proctree(n, &td);
                     reqtag = creqtag;
                     
-                    useralerts.convertNotedSharedNodes(false, actinguser);
+                    useralerts.convertNotedSharedNodes(false, originatingUser);
                 }
                 return n;
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4866,6 +4866,10 @@ handle MegaClient::sc_newnodes()
                 readusers(&jsonsc, true);
                 break;
 
+            case MAKENAMEID2('o', 'u'):
+                actinguser = jsonsc.gethandle(USERHANDLE);
+                break;
+
             case EOO:
                 return actinguser;
 
@@ -6522,7 +6526,7 @@ Node* MegaClient::sc_deltree()
                 }
                 break;
 
-            case 'ou':
+            case MAKENAMEID2('o', 'u'):
                 actinguser = jsonsc.gethandle(USERHANDLE);
                 break;
 

--- a/src/useralerts.cpp
+++ b/src/useralerts.cpp
@@ -933,9 +933,9 @@ void UserAlerts::noteSharedNode(handle user, int type, m_time_t ts, Node* n)
 }
 
 // make a notification out of the shared nodes noted
-void UserAlerts::convertNotedSharedNodes(bool added)
+void UserAlerts::convertNotedSharedNodes(bool added, handle actinguser)
 {
-    if (catchupdone && notingSharedNodes)
+    if (catchupdone && notingSharedNodes && actinguser != mc.me)
     {
         using namespace UserAlert;
         for (map<pair<handle, handle>, ff>::iterator i = notedSharedNodes.begin(); i != notedSharedNodes.end(); ++i)


### PR DESCRIPTION
Prevent useralerts for files added by others (via share) but deleted by this user in another client.