### PR TITLE
Fix de-serialization of the plink's node handle

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -269,6 +269,7 @@ Node* Node::unserialize(MegaClient* client, string* d, node_vector* dp)
         ph = UNDEF;
     }
 
+    u = 0;
     memcpy((char*)&u, ptr, MegaClient::USERHANDLE);
     ptr += MegaClient::USERHANDLE;
 
@@ -394,7 +395,7 @@ Node* Node::unserialize(MegaClient* client, string* d, node_vector* dp)
             return NULL;
         }
 
-        handle ph;
+        handle ph = 0;
         memcpy((char*)&ph, ptr, MegaClient::NODEHANDLE);
         ptr += MegaClient::NODEHANDLE;
         m_time_t ets = MemAccess::get<m_time_t>(ptr);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -394,7 +394,8 @@ Node* Node::unserialize(MegaClient* client, string* d, node_vector* dp)
             return NULL;
         }
 
-        handle ph = MemAccess::get<handle>(ptr);
+        handle ph;
+        memcpy((char*)&ph, ptr, MegaClient::NODEHANDLE);
         ptr += MegaClient::NODEHANDLE;
         m_time_t ets = MemAccess::get<m_time_t>(ptr);
         ptr += sizeof(ets);


### PR DESCRIPTION
This ensures that, when `Node` is de-serialized, the node handle that `plink` carries is correctly de-serialized. Previously, the code may generate the wrong node handle as it would read 8 instead of 6 bytes.
