### PR TITLE
#13258. Trigger authentication of contact keys upon load authrings...

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -6264,8 +6264,14 @@ void DemoApp::exportnode_result(handle h, handle ph)
             return;
         }
 
-        const char *key = (n->type == FILENODE) ? Base64Str<FILENODEKEYLENGTH>((const byte*)n->nodekey.data()) : Base64Str<FOLDERNODEKEYLENGTH>(n->sharekey->key);
-        cout << MegaClient::getPublicLink(client->mNewLinkFormat, n->type, ph, key) << endl;
+        if (n->type == FILENODE)
+        {
+            cout << MegaClient::getPublicLink(client->mNewLinkFormat, n->type, ph, Base64Str<FILENODEKEYLENGTH>((const byte*)n->nodekey.data())) << endl;
+        }
+        else
+        {
+            cout << MegaClient::getPublicLink(client->mNewLinkFormat, n->type, ph, Base64Str<FOLDERNODEKEYLENGTH>(n->sharekey->key)) << endl;
+        }
     }
     else
     {

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1373,6 +1373,9 @@ public:
     // used during initialization to accumulate required updates to authring (to send them all atomically)
     AuthRingsMap mAuthRingsTemp;
 
+    // true while authrings are being fetched
+    bool mFetchingAuthrings;
+
     // actual state of keys
     bool fetchingkeys;
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2511,13 +2511,13 @@ class MegaApiImpl : public MegaApp
         void enableGeolocation(MegaRequestListener *listener = NULL);
         void isGeolocationEnabled(MegaRequestListener *listener = NULL);
         bool isChatNotifiable(MegaHandle chatid);
+#endif
         void setMyChatFilesFolder(MegaHandle nodehandle, MegaRequestListener *listener = NULL);
         void getMyChatFilesFolder(MegaRequestListener *listener = NULL);
         void setCameraUploadsFolder(MegaHandle nodehandle, MegaRequestListener *listener = NULL);
         void getCameraUploadsFolder(MegaRequestListener *listener = NULL);
         void getUserAlias(MegaHandle uh, MegaRequestListener *listener = NULL);
         void setUserAlias(MegaHandle uh, const char *alias, MegaRequestListener *listener = NULL);
-#endif
 
         void getPushNotificationSettings(MegaRequestListener *listener = NULL);
         void setPushNotificationSettings(MegaPushNotificationSettings *settings, MegaRequestListener *listener = NULL);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2914,6 +2914,12 @@ void CommandGetUA::procresult()
                 // authring not created yet, will do it upon retrieval of public keys
                 client->mAuthRings.erase(at);
                 client->mAuthRings.emplace(at, AuthRing(at, TLVstore()));
+
+                if (client->mFetchingAuthrings && client->mAuthRings.size() == 3)
+                {
+                    client->mFetchingAuthrings = false;
+                    client->fetchContactsKeys();
+                }
             }
         }
 
@@ -3040,6 +3046,12 @@ void CommandGetUA::procresult()
                             {
                                 client->mAuthRings.erase(at);
                                 client->mAuthRings.emplace(at, AuthRing(at, *tlvRecords));
+
+                                if (client->mFetchingAuthrings && client->mAuthRings.size() == 3)
+                                {
+                                    client->mFetchingAuthrings = false;
+                                    client->fetchContactsKeys();
+                                }
                             }
 
                             delete tlvRecords;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1121,6 +1121,7 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
     ststatus = STORAGE_UNKNOWN;
     looprequested = false;
 
+    mFetchingAuthrings = false;
     fetchingkeys = false;
     signkey = NULL;
     chatkey = NULL;
@@ -3725,6 +3726,7 @@ void MegaClient::locallogout()
 
     mAuthRings.clear();
     mAuthRingsTemp.clear();
+    mFetchingAuthrings = false;
 
     init();
 
@@ -4016,9 +4018,6 @@ bool MegaClient::procsc()
                             // now that we have loaded cached state, and caught up actionpackets since that state
                             // (or just fetched everything if there was no cache), our next sc request can be for useralerts
                             useralerts.begincatchup = true;
-
-                            // now that we know all contacts, fetch public keys and check authentication
-                            fetchContactsKeys();
                         }
                     }
                     app->catchup_result();
@@ -5364,6 +5363,7 @@ void MegaClient::sc_userattr()
                                     case ATTR_AUTHCU255:    // fall-through
                                     case ATTR_AUTHRSA:
                                     {
+                                        LOG_debug << User::attr2string(type) << " has changed externally. Fetching...";
                                         mAuthRings.erase(type);
                                         getua(u, type, 0);
                                         break;
@@ -11081,6 +11081,8 @@ void MegaClient::initializekeys()
 
 void MegaClient::loadAuthrings()
 {
+    mFetchingAuthrings = true;
+
     std::set<attr_t> attrs { ATTR_AUTHRING, ATTR_AUTHCU255, ATTR_AUTHRSA };
     for (auto at : attrs)
     {
@@ -11094,7 +11096,7 @@ void MegaClient::loadAuthrings()
                 if (tlvRecords)
                 {
                     mAuthRings.emplace(at, AuthRing(at, *tlvRecords));
-                    LOG_info << "Authring succesfully loaded: " << User::attr2string(at);
+                    LOG_info << "Authring succesfully loaded from cache: " << User::attr2string(at);
                 }
                 else
                 {
@@ -11114,6 +11116,13 @@ void MegaClient::loadAuthrings()
         }
 
         getua(ownUser, at, 0);
+    }
+
+    // if all authrings were loaded from cache...
+    if (mAuthRings.size() == attrs.size())
+    {
+        mFetchingAuthrings = false;
+        fetchContactsKeys();
     }
 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -11143,9 +11143,13 @@ void MegaClient::fetchContactsKeys()
 
 void MegaClient::fetchContactKeys(User *user)
 {
-    getua(user, ATTR_ED25519_PUBK);
-    getua(user, ATTR_CU25519_PUBK);
+    getua(user, ATTR_ED25519_PUBK, 0);
+    getua(user, ATTR_CU25519_PUBK, 0);
+
+    int creqtag = reqtag;
+    reqtag = 0;
     getpubkey(user->uid.c_str());
+    reqtag = creqtag;
 }
 
 error MegaClient::trackKey(attr_t keyType, handle uh, const std::string &pubKey)


### PR DESCRIPTION
...instead of the previous location: when up-to-date though APs

Risk area/s:
 - Resume a session created without support for authrings in a client with support for them.