### PR TITLE
#13198. Add target folder for secondary media upload

### DIFF
--- a/include/mega/base64.h
+++ b/include/mega/base64.h
@@ -33,9 +33,11 @@ class MEGA_API Base64
 
 public:
     static int btoa(const string&, string&);
-    static int btoa(const byte*, int, char*);
+    static string btoa(const string &in);   // use Base64Str<size> instead when `size` is known at compile time (more efficient)
+    static int btoa(const byte*, int, char*);   // deprecated
     static int atob(const string&, string&);
-    static int atob(const char*, byte*, int);
+    static string atob(const string&);
+    static int atob(const char*, byte*, int);   // deprecated
 
     static void itoa(int64_t, string *);
     static int64_t atoi(string *);

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -451,7 +451,7 @@ typedef enum {
     ATTR_LAST_PSA = 20,                     // private - char array
     ATTR_STORAGE_STATE = 21,                // private - non-encrypted - char array in B64 - non-versioned
     ATTR_GEOLOCATION = 22,                  // private - byte array - non-versioned
-    ATTR_CAMERA_UPLOADS_FOLDER = 23,        // private - byte array
+    ATTR_CAMERA_UPLOADS_FOLDER = 23,        // private - byte array - non-versioned
     ATTR_MY_CHAT_FILES_FOLDER = 24,         // private - byte array - non-versioned
     ATTR_PUSH_SETTINGS = 25,                // private - non-encripted - char array in B64 - non-versioned
     ATTR_UNSHAREABLE_KEY = 26,              // private - char array

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -451,7 +451,7 @@ typedef enum {
     ATTR_LAST_PSA = 20,                     // private - char array
     ATTR_STORAGE_STATE = 21,                // private - non-encrypted - char array in B64 - non-versioned
     ATTR_GEOLOCATION = 22,                  // private - byte array - non-versioned
-    ATTR_CAMERA_UPLOADS_FOLDER = 23,        // private - byte array - non-versioned
+    ATTR_CAMERA_UPLOADS_FOLDER = 23,        // private - byte array
     ATTR_MY_CHAT_FILES_FOLDER = 24,         // private - byte array - non-versioned
     ATTR_PUSH_SETTINGS = 25,                // private - non-encripted - char array in B64 - non-versioned
     ATTR_UNSHAREABLE_KEY = 26,              // private - char array

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -145,6 +145,9 @@ public:
     void resetTag();
 
     User(const char* = NULL);
+
+    // merges the new values in the given TLV. Returns true if TLV is changed.
+    static bool mergeUserAttribute(attr_t type, const MegaStringMap &newValuesMap, TLVstore &tlv);
 };
 
 class AuthRing

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -112,7 +112,7 @@ public:
     const string *getattrversion(attr_t at);
     void invalidateattr(attr_t at);
     bool isattrvalid(attr_t at);
-    void removeattr(attr_t at);
+    void removeattr(attr_t at, const string *version = nullptr);
 
     static string attr2string(attr_t at);
     static string attr2longname(attr_t at);

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -147,7 +147,7 @@ public:
     User(const char* = NULL);
 
     // merges the new values in the given TLV. Returns true if TLV is changed.
-    static bool mergeUserAttribute(attr_t type, const MegaStringMap &newValuesMap, TLVstore &tlv);
+    static bool mergeUserAttribute(attr_t type, const string_map &newValuesMap, TLVstore &tlv);
 };
 
 class AuthRing

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10187,6 +10187,8 @@ class MegaApi
          * is MegaError::API_OK:
          * - MegaRequest::getNodehandle - Returns the handle of the node where My Chat Files are stored
          *
+         * If the folder is not set, the request will fail with the error code MegaError::API_ENOENT.
+         *
          * @param listener MegaRequestListener to track this request
          */
         void getMyChatFilesFolder(MegaRequestListener *listener = NULL);
@@ -10231,6 +10233,8 @@ class MegaApi
          * is MegaError::API_OK:
          * - MegaRequest::getNodehandle - Returns the handle of the primary node where Camera Uploads files are stored
          *
+         * If the folder is not set, the request will fail with the error code MegaError::API_ENOENT.
+         *
          * @param listener MegaRequestListener to track this request
          */
         void getCameraUploadsFolder(MegaRequestListener *listener = NULL);
@@ -10246,6 +10250,8 @@ class MegaApi
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
          * - MegaRequest::getNodehandle - Returns the handle of the secondary node where Camera Uploads files are stored
+         *
+         * If the secondary folder is not set, the request will fail with the error code MegaError::API_ENOENT.
          *
          * @param listener MegaRequestListener to track this request
          */

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10160,31 +10160,60 @@ class MegaApi
         void getMyChatFilesFolder(MegaRequestListener *listener = NULL);
 
         /**
-         * @brief Set Camera Uploads target folder.
+         * @brief Set Camera Uploads primary target folder.
          *
          * The associated request type with this request is MegaRequest::TYPE_SET_ATTR_USER
          * Valid data in the MegaRequest object received on callbacks:
          * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER
          *
-         * @param nodehandle MegaHandle of the node to be used as target folder
+         * @param nodehandle MegaHandle of the node to be used as primary target folder
          * @param listener MegaRequestListener to track this request
          */
         void setCameraUploadsFolder(MegaHandle nodehandle, MegaRequestListener *listener = NULL);
 
         /**
-         * @brief Gets Camera Uploads target folder.
+         * @brief Set Camera Uploads secondary target folder.
+         *
+         * The associated request type with this request is MegaRequest::TYPE_SET_ATTR_USER
+         * Valid data in the MegaRequest object received on callbacks:
+         * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER
+         *
+         * @param nodehandle MegaHandle of the node to be used as secondary target folder
+         * @param listener MegaRequestListener to track this request
+         */
+        void setCameraUploadsFolderSecondary(MegaHandle nodehandle, MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Gets Camera Uploads primary target folder.
          *
          * The associated request type with this request is MegaRequest::TYPE_GET_ATTR_USER
          * Valid data in the MegaRequest object received on callbacks:
          * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER
+         * - MegaRequest::getFlag - Returns false
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
-         * - MegaRequest::getNodehandle - Returns the handle of the node where Camera Uploads files are stored
+         * - MegaRequest::getNodehandle - Returns the handle of the primary node where Camera Uploads files are stored
          *
          * @param listener MegaRequestListener to track this request
          */
         void getCameraUploadsFolder(MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Gets Camera Uploads secondary target folder.
+         *
+         * The associated request type with this request is MegaRequest::TYPE_GET_ATTR_USER
+         * Valid data in the MegaRequest object received on callbacks:
+         * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER
+         * - MegaRequest::getFlag - Returns true
+         *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getNodehandle - Returns the handle of the secondary node where Camera Uploads files are stored
+         *
+         * @param listener MegaRequestListener to track this request
+         */
+        void getCameraUploadsFolderSecondary(MegaRequestListener *listener = NULL);
 
         /**
          * @brief Gets the alias for an user

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10262,7 +10262,7 @@ class MegaApi
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
-         * - MegaRequest::getName - user alias encoded in B64
+         * - MegaRequest::getName - Returns the user alias
          *
          * If the user alias doesn't exists the request will fail with the error code MegaError::API_ENOENT.
          *

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10197,6 +10197,8 @@ class MegaApi
          * The associated request type with this request is MegaRequest::TYPE_SET_ATTR_USER
          * Valid data in the MegaRequest object received on callbacks:
          * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER
+         * - MegaRequest::getFlag - Returns false
+         * - MegaRequest::getNodehandle - Returns the provided node handle
          *
          * @param nodehandle MegaHandle of the node to be used as primary target folder
          * @param listener MegaRequestListener to track this request
@@ -10209,6 +10211,8 @@ class MegaApi
          * The associated request type with this request is MegaRequest::TYPE_SET_ATTR_USER
          * Valid data in the MegaRequest object received on callbacks:
          * - MegaRequest::getParamType - Returns the attribute type MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER
+         * - MegaRequest::getFlag - Returns true
+         * - MegaRequest::getNodehandle - Returns the provided node handle
          *
          * @param nodehandle MegaHandle of the node to be used as secondary target folder
          * @param listener MegaRequestListener to track this request

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2513,8 +2513,8 @@ class MegaApiImpl : public MegaApp
         bool isChatNotifiable(MegaHandle chatid);
         void setMyChatFilesFolder(MegaHandle nodehandle, MegaRequestListener *listener = NULL);
         void getMyChatFilesFolder(MegaRequestListener *listener = NULL);
-        void setCameraUploadsFolder(MegaHandle nodehandle, MegaRequestListener *listener = NULL);
-        void getCameraUploadsFolder(MegaRequestListener *listener = NULL);
+        void setCameraUploadsFolder(MegaHandle nodehandle, bool secondary, MegaRequestListener *listener = NULL);
+        void getCameraUploadsFolder(bool secondary, MegaRequestListener *listener = NULL);
         void getUserAlias(MegaHandle uh, MegaRequestListener *listener = NULL);
         void setUserAlias(MegaHandle uh, const char *alias, MegaRequestListener *listener = NULL);
 #endif

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -89,6 +89,15 @@ int Base64::atob(const string &in, string &out)
     return (int)out.size();
 }
 
+std::string Base64::atob(const std::string &in)
+{
+    string out;
+    out.resize(in.size() * 3 / 4 + 3);
+    out.resize(Base64::atob(in.data(), (byte *) out.data(), (int)out.size()));
+
+    return out;
+}
+
 int Base64::atob(const char* a, byte* b, int blen)
 {
     byte c[4];
@@ -200,6 +209,15 @@ int Base64::btoa(const string &in, string &out)
     out.resize(Base64::btoa((const byte*) in.data(), (int)in.size(), (char *) out.data()));
 
     return (int)out.size();
+}
+
+std::string Base64::btoa(const string &in)
+{
+    string out;
+    out.resize(in.size() * 4 / 3 + 4);
+    out.resize(Base64::btoa((const byte*) in.data(), (int)in.size(), (char *) out.data()));
+
+    return out;
 }
 
 int Base64::btoa(const byte* b, int blen, char* a)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2895,6 +2895,12 @@ void CommandGetUA::procresult()
     if (client->json.isnumeric())
     {
         error e = (error)client->json.getint();
+
+        if (e == API_ENOENT && u)
+        {
+            u->removeattr(at);
+        }
+
         client->app->getua_result(e);
 
         if (isFromChatPreview())    // if `mcuga` was sent, no need to do anything else

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2736,7 +2736,7 @@ CommandPutUAVer::CommandPutUAVer(MegaClient* client, attr_t at, const byte* av, 
     }
 
     const string *attrv = client->ownuser()->getattrversion(at);
-    if (attrv)
+    if (client->ownuser()->isattrvalid(at) && attrv)
     {
         element(attrv->c_str());
     }

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2564,12 +2564,22 @@ void MegaApi::isGeolocationEnabled(MegaRequestListener *listener)
 
 void MegaApi::setCameraUploadsFolder(MegaHandle nodehandle, MegaRequestListener *listener)
 {
-    pImpl->setCameraUploadsFolder(nodehandle, listener);
+    pImpl->setCameraUploadsFolder(nodehandle, false, listener);
+}
+
+void MegaApi::setCameraUploadsFolderSecondary(MegaHandle nodehandle, MegaRequestListener *listener)
+{
+    pImpl->setCameraUploadsFolder(nodehandle, true, listener);
 }
 
 void MegaApi::getCameraUploadsFolder(MegaRequestListener *listener)
 {
-    pImpl->getCameraUploadsFolder(listener);
+    pImpl->getCameraUploadsFolder(false, listener);
+}
+
+void MegaApi::getCameraUploadsFolderSecondary(MegaRequestListener *listener)
+{
+    pImpl->getCameraUploadsFolder(true, listener);
 }
 
 void MegaApi::setMyChatFilesFolder(MegaHandle nodehandle, MegaRequestListener *listener)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14349,12 +14349,16 @@ void MegaApiImpl::getua_result(error e)
             attr_t type = static_cast<attr_t>(request->getParamType());
             TLVstore tlv;
             const char *key;
+            std::string value;
 
             std::unique_ptr<MegaStringList> keys(stringMap->getKeys());
             for (int i = 0; i < keys->size(); i++)
             {
+                // Decode from B64 the target folder to avoid a double B64 encoding
                 key = keys->get(i);
-                tlv.set(key, stringMap->get(key));
+                value.resize(int(MegaClient::NODEHANDLE));
+                value.resize(Base64::atob(stringMap->get(key), (byte *)value.data(), int(MegaClient::NODEHANDLE)));
+                tlv.set(key, value);
             }
 
             // serialize and encrypt the TLV container

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -9914,8 +9914,7 @@ void MegaApiImpl::setCameraUploadsFolder(MegaHandle nodehandle, bool secondary, 
 {
     MegaStringMapPrivate stringMap;
     const char *key = secondary ? "sh" : "h";
-    Base64Str<MegaClient::NODEHANDLE> value(nodehandle);
-    stringMap.set(key, value);
+    stringMap.set(key, Base64Str<MegaClient::NODEHANDLE> (nodehandle));
     setUserAttribute(MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER, &stringMap, listener);
 }
 
@@ -9929,12 +9928,9 @@ void MegaApiImpl::getMyChatFilesFolder(MegaRequestListener *listener)
 
 void MegaApiImpl::setMyChatFilesFolder(MegaHandle nodehandle, MegaRequestListener *listener)
 {
-    MegaStringMap *stringMap = new MegaStringMapPrivate();
-    char buffer[12];
-    Base64::btoa((byte*)&nodehandle, MegaClient::NODEHANDLE, buffer);
-    stringMap->set("h", buffer);
-    setUserAttribute(MegaApi::USER_ATTR_MY_CHAT_FILES_FOLDER, stringMap, listener);
-    delete stringMap;
+    MegaStringMapPrivate stringMap;
+    stringMap.set("h", Base64Str<MegaClient::NODEHANDLE> (nodehandle));
+    setUserAttribute(MegaApi::USER_ATTR_MY_CHAT_FILES_FOLDER, &stringMap, listener);
 }
 
 void MegaApiImpl::getUserAlias(MegaHandle uh, MegaRequestListener *listener)
@@ -9951,7 +9947,11 @@ void MegaApiImpl::setUserAlias(MegaHandle uh, const char *alias, MegaRequestList
 {
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_SET_ATTR_USER, listener);
     MegaStringMapPrivate stringMap;
-    stringMap.set(Base64Str<MegaClient::USERHANDLE>(uh), alias ? alias : "");
+    const char *aux = alias ? alias : "";
+    char *value = new char[strlen(aux)* 4 / 3 + 4];
+    Base64::btoa((byte*) aux, strlen(aux), value);
+    stringMap.set(Base64Str<MegaClient::USERHANDLE>(uh), value);
+    delete [] value;
     request->setMegaStringMap(&stringMap);
     request->setParamType(MegaApi::USER_ATTR_ALIAS);
     request->setNodeHandle(uh);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14665,29 +14665,24 @@ void MegaApiImpl::getua_result(TLVstore *tlv, attr_t type)
                 break;
             }
             case MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER:
+            case MegaApi::USER_ATTR_MY_CHAT_FILES_FOLDER:
             {
-                handle nodehandle = 0;  // make sure top two bytes are 0
-                const char *key = request->getFlag() ? "sh" : "h";
+                // If attr is CAMERA_UPLOADS_FOLDER determine if we want to retrieve primary or secondary folder
+                // If attr is MY_CHAT_FILES_FOLDER there's not exists secondary folder
+                const char *key = request->getParamType() == MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER
+                        && request->getFlag()
+                            ? "sh"
+                            : "h";
+
                 const char *value = stringMap->get(key);
                 if (value)
                 {
+                   handle nodehandle = 0;  // make sure top two bytes are 0
                    Base64::atob(value, (byte*) &nodehandle, MegaClient::NODEHANDLE);
                    request->setNodeHandle(nodehandle);
                 }
                 break;
             }
-            case MegaApi::USER_ATTR_MY_CHAT_FILES_FOLDER:
-            {
-                const char *value = stringMap->get("h");
-                if (value)
-                {
-                    handle nodehandle = 0;  // make sure top two bytes are 0
-                    Base64::atob(value, (byte*) &nodehandle, MegaClient::NODEHANDLE);
-                    request->setNodeHandle(nodehandle);
-                }
-                break;
-            }
-
             case MegaApi::USER_ATTR_ALIAS:
             {
                 // If a uh was set in the request we have to find it in the aliases map and return it
@@ -14700,7 +14695,12 @@ void MegaApiImpl::getua_result(TLVstore *tlv, attr_t type)
                         e = API_ENOENT;
                         break;
                     }
-                    request->setName(buf);
+                    else
+                    {
+                        char aux [strlen(buf) * 3 / 4 + 3];
+                        Base64::atob(buf, (byte*) aux, strlen(buf));
+                        request->setName(buf);
+                    }
                 }
                 break;
             }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14348,8 +14348,8 @@ void MegaApiImpl::getua_result(error e)
                 request->setFlag(true);
             }
         }
-        else if (((request->getParamType() == MegaApi::USER_ATTR_ALIAS)
-                  ||(request->getParamType() == MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER))
+        else if ((request->getParamType() == MegaApi::USER_ATTR_ALIAS
+                  || request->getParamType() == MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER)
                     && request->getType() == MegaRequest::TYPE_SET_ATTR_USER)
         {
             // The attribute doesn't exists so we have to create it

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14348,6 +14348,43 @@ void MegaApiImpl::getua_result(error e)
                 request->setFlag(true);
             }
         }
+        else if ((request->getParamType() == MegaApi::USER_ATTR_ALIAS
+                  || request->getParamType() == MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER)
+                    && request->getType() == MegaRequest::TYPE_SET_ATTR_USER)
+        {
+            // The attribute doesn't exists so we have to create it
+            MegaStringMap *stringMap = request->getMegaStringMap();
+            attr_t type = static_cast<attr_t>(request->getParamType());
+            TLVstore tlv;
+            const char *key;
+            std::unique_ptr<MegaStringList> keys(stringMap->getKeys());
+
+            if (request->getParamType() == MegaApi::USER_ATTR_ALIAS)
+            {
+                for (int i = 0; i < keys->size(); i++)
+                {
+                    key = keys->get(i);
+                    tlv.set(key, stringMap->get(key));
+                }
+            }
+            else
+            {
+                std::string value;
+                for (int i = 0; i < keys->size(); i++)
+                {
+                    // Decode from B64 the target folder to avoid a double B64 encoding
+                    key = keys->get(i);
+                    value.resize(int(MegaClient::NODEHANDLE));
+                    value.resize(Base64::atob(stringMap->get(key), (byte *)value.data(), int(MegaClient::NODEHANDLE)));
+                    tlv.set(key, value);
+                }
+            }
+
+            // serialize and encrypt the TLV container
+            std::unique_ptr<string> container(tlv.tlvRecordsToContainer(client->rng, &client->key));
+            client->putua(type, (byte *)container->data(), unsigned(container->size()));
+            return;
+        }
     }
 
     fireOnRequestFinish(request, megaError);
@@ -18970,11 +19007,10 @@ void MegaApiImpl::sendPendingRequests()
                     break;
                 }
 
-                User *ownUser = client->finduser(client->me);
-                if ((type == ATTR_ALIAS || type == ATTR_CAMERA_UPLOADS_FOLDER)
-                     && ownUser->isattrvalid(type))
+                if (type == ATTR_ALIAS || type == ATTR_CAMERA_UPLOADS_FOLDER)
                 {
                     // always get updated value before update it
+                    User *ownUser = client->finduser(client->me);
                     client->getua(ownUser, type);
                     break;
                 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14350,34 +14350,18 @@ void MegaApiImpl::getua_result(error e)
                     && request->getType() == MegaRequest::TYPE_SET_ATTR_USER)
         {
             // The attribute doesn't exists so we have to create it
-            MegaStringMap *stringMap = request->getMegaStringMap();
-            attr_t type = static_cast<attr_t>(request->getParamType());
             TLVstore tlv;
-            const char *key;
+            MegaStringMap *stringMap = request->getMegaStringMap();
             std::unique_ptr<MegaStringList> keys(stringMap->getKeys());
-
-            if (request->getParamType() == MegaApi::USER_ATTR_ALIAS)
+            const char *key;
+            for (int i = 0; i < keys->size(); i++)
             {
-                for (int i = 0; i < keys->size(); i++)
-                {
-                    key = keys->get(i);
-                    tlv.set(key, stringMap->get(key));
-                }
-            }
-            else
-            {
-                std::string value;
-                for (int i = 0; i < keys->size(); i++)
-                {
-                    // Decode from B64 the target folder to avoid a double B64 encoding
-                    key = keys->get(i);
-                    value.resize(int(MegaClient::NODEHANDLE));
-                    value.resize(Base64::atob(stringMap->get(key), (byte *)value.data(), int(MegaClient::NODEHANDLE)));
-                    tlv.set(key, value);
-                }
+                key = keys->get(i);
+                tlv.set(key, Base64::atob(stringMap->get(key)));
             }
 
             // serialize and encrypt the TLV container
+            attr_t type = static_cast<attr_t>(request->getParamType());
             std::unique_ptr<string> container(tlv.tlvRecordsToContainer(client->rng, &client->key));
             client->putua(type, (byte *)container->data(), unsigned(container->size()));
             return;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -9901,22 +9901,22 @@ bool MegaApiImpl::isChatNotifiable(MegaHandle chatid)
 
 #endif
 
-void MegaApiImpl::getCameraUploadsFolder(MegaRequestListener *listener)
+void MegaApiImpl::getCameraUploadsFolder(bool secondary, MegaRequestListener *listener)
 {
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_GET_ATTR_USER, listener);
     request->setParamType(MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER);
+    request->setFlag(secondary);
     requestQueue.push(request);
     waiter->notify();
 }
 
-void MegaApiImpl::setCameraUploadsFolder(MegaHandle nodehandle, MegaRequestListener *listener)
+void MegaApiImpl::setCameraUploadsFolder(MegaHandle nodehandle, bool secondary, MegaRequestListener *listener)
 {
-    MegaStringMap *stringMap = new MegaStringMapPrivate();
-    char buffer[12];
-    Base64::btoa((byte*)&nodehandle, MegaClient::NODEHANDLE, buffer);
-    stringMap->set("h", buffer);
-    setUserAttribute(MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER, stringMap, listener);
-    delete stringMap;
+    MegaStringMapPrivate stringMap;
+    const char *key = secondary ? "sh" : "h";
+    Base64Str<MegaClient::NODEHANDLE> value(nodehandle);
+    stringMap.set(key, value);
+    setUserAttribute(MegaApi::USER_ATTR_CAMERA_UPLOADS_FOLDER, &stringMap, listener);
 }
 
 void MegaApiImpl::getMyChatFilesFolder(MegaRequestListener *listener)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -11297,7 +11297,6 @@ error MegaClient::trackSignature(attr_t signatureType, handle uh, const std::str
     if (signatureType == ATTR_SIG_CU255_PUBK)
     {
         // retrieve public key whose signature wants to be verified, from cache
-        assert(user && user->isattrvalid(ATTR_CU25519_PUBK));
         if (!user || !user->isattrvalid(ATTR_CU25519_PUBK))
         {
             LOG_warn << "Failed to verify signature " << User::attr2string(signatureType) << " for user " << uid << ": CU25519 public key is not available";
@@ -11325,7 +11324,6 @@ error MegaClient::trackSignature(attr_t signatureType, handle uh, const std::str
     }
 
     // retrieve signing key from cache
-    assert(user->isattrvalid(ATTR_ED25519_PUBK));
     if (!user->isattrvalid(ATTR_ED25519_PUBK))
     {
         LOG_warn << "Failed to verify signature " << User::attr2string(signatureType) << " for user " << uid << ": signing public key is not available";

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5322,24 +5322,10 @@ void MegaClient::sc_userattr()
                 {
                     LOG_debug << "User attributes update for non-existing user";
                 }
-                // if no version received (very old actionpacket)...
-                else if ( !uavlist.size() )
-                {
-                    // ...invalidate all of the notified user attributes
-                    for (itua = ualist.begin(); itua != ualist.end(); itua++)
-                    {
-                        attr_t type = User::string2attr(itua->c_str());
-                        u->invalidateattr(type);
-                        if (type == ATTR_KEYRING)
-                        {
-                            resetKeyring();
-                        }
-                    }
-                    u->setTag(0);
-                    notifyuser(u);
-                }
                 else if (ualist.size() == uavlist.size())
                 {
+                    assert(ualist.size() && uavlist.size());
+
                     // invalidate only out-of-date attributes
                     for (itua = ualist.begin(), ituav = uavlist.begin();
                          itua != ualist.end();

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -353,7 +353,7 @@ const string * User::getattr(attr_t at)
 
 bool User::isattrvalid(attr_t at)
 {
-    return attrsv.count(at);
+    return attrs.count(at) && attrsv.count(at);
 }
 
 string User::attr2string(attr_t type)

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -434,7 +434,7 @@ string User::attr2string(attr_t type)
             break;
 
         case ATTR_CAMERA_UPLOADS_FOLDER:
-            attrname = "*cam";
+            attrname = "*!cam";
             break;
 
         case ATTR_MY_CHAT_FILES_FOLDER:
@@ -697,7 +697,7 @@ attr_t User::string2attr(const char* name)
     {
         return ATTR_GEOLOCATION;
     }
-    else if (!strcmp(name, "*cam"))
+    else if (!strcmp(name, "*!cam"))
     {
         return ATTR_CAMERA_UPLOADS_FOLDER;
     }

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -22,6 +22,7 @@
 #include "mega/user.h"
 #include "mega/megaclient.h"
 #include "mega/logging.h"
+#include "mega/base64.h"
 
 namespace mega {
 User::User(const char* cemail)
@@ -41,30 +42,29 @@ User::User(const char* cemail)
     memset(&changed, 0, sizeof(changed));
 }
 
-bool User::mergeUserAttribute(attr_t type, const MegaStringMap &newValuesMap, TLVstore &tlv)
+bool User::mergeUserAttribute(attr_t type, const string_map &newValuesMap, TLVstore &tlv)
 {
     bool modified = false;
 
-    std::unique_ptr<MegaStringList> keys(newValuesMap.getKeys());
-    for (int i = 0; i < keys->size(); i++)
+    for (const auto &it : newValuesMap)
     {
-        const char *key = keys->get(i);
-        string newValue = newValuesMap->get(key);
+        const char *key = it.first.c_str();
+        string newValue = it.second;
         string currentValue;
-        if (tlv->find(key))  // the key may not exist in the current user attribute
+        if (tlv.find(key))  // the key may not exist in the current user attribute
         {
-            Base64::btoa(tlv->get(key), currentValue);
+            Base64::btoa(tlv.get(key), currentValue);
         }
         if (newValue != currentValue)
         {
             if (type == ATTR_ALIAS && newValue[0] == '\0')
             {
                 // alias being removed
-                tlv->reset(key);
+                tlv.reset(key);
             }
             else
             {
-                tlv->set(key, Base64::atob(newValue));
+                tlv.set(key, Base64::atob(newValue));
             }
             modified = true;
         }

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -697,7 +697,7 @@ attr_t User::string2attr(const char* name)
     {
         return ATTR_GEOLOCATION;
     }
-    else if(!strcmp(name, "*cam"))
+    else if (!strcmp(name, "*cam"))
     {
         return ATTR_CAMERA_UPLOADS_FOLDER;
     }

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -434,7 +434,7 @@ string User::attr2string(attr_t type)
             break;
 
         case ATTR_CAMERA_UPLOADS_FOLDER:
-            attrname = "*!cam";
+            attrname = "*cam";
             break;
 
         case ATTR_MY_CHAT_FILES_FOLDER:
@@ -697,7 +697,7 @@ attr_t User::string2attr(const char* name)
     {
         return ATTR_GEOLOCATION;
     }
-    else if(!strcmp(name, "*!cam"))
+    else if(!strcmp(name, "*cam"))
     {
         return ATTR_CAMERA_UPLOADS_FOLDER;
     }
@@ -743,7 +743,6 @@ int User::needversioning(attr_t at)
         case ATTR_GEOLOCATION:
         case ATTR_MY_CHAT_FILES_FOLDER:
         case ATTR_PUSH_SETTINGS:
-        case ATTR_CAMERA_UPLOADS_FOLDER:
             return 0;
 
         case ATTR_LAST_INT:
@@ -757,6 +756,7 @@ int User::needversioning(attr_t at)
         case ATTR_AUTHCU255:
         case ATTR_CONTACT_LINK_VERIFICATION:
         case ATTR_ALIAS:
+        case ATTR_CAMERA_UPLOADS_FOLDER:
             return 1;
 
         case ATTR_STORAGE_STATE: //putua is forbidden for this attribute

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -336,7 +336,6 @@ void User::removeattr(attr_t at, const string *version)
     {
         attrsv.erase(at);
     }
-
 }
 
 // returns the value if there is value (even if it's invalid by now)

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -324,11 +324,19 @@ void User::invalidateattr(attr_t at)
     attrsv.erase(at);
 }
 
-void User::removeattr(attr_t at)
+void User::removeattr(attr_t at, const string *version)
 {
     setChanged(at);
     attrs.erase(at);
-    attrsv.erase(at);
+    if (version)
+    {
+        attrsv[at] = *version;
+    }
+    else
+    {
+        attrsv.erase(at);
+    }
+
 }
 
 // returns the value if there is value (even if it's invalid by now)


### PR DESCRIPTION
**Risk area/s:**
- Set and remove a nickname/alias.
- Set _My Chat Files_ folder.
- Set _Camera Uploads_ primary and secondary folders.
