### PR TITLE
#13281. Check link format when not logged in

### DIFF
--- a/bindings/java/nz/mega/sdk/MegaApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaApiJava.java
@@ -506,6 +506,10 @@ public class MegaApiJava {
 
     /**
      * Check if server-side Rubbish Bin autopurging is enabled for the current account
+     *
+     * Before using this function, it's needed to:
+     *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+     *
      * @return True if this feature is enabled. Otherwise false.
      */
     public boolean serverSideRubbishBinAutopurgeEnabled(){
@@ -513,10 +517,24 @@ public class MegaApiJava {
     }
 
     /**
+     * Check if the new format for public links is enabled
+     *
+     * Before using this function, it's needed to:
+     *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+     *  - If you are not logged-in: call to MegaApi::getMiscFlags.
+     *
+     * @return True if this feature is enabled. Otherwise, false.
+     */
+    public boolean newLinkFormatEnabled() {
+        return megaApi.newLinkFormatEnabled();
+    }
+
+    /**
      * Check if multi-factor authentication can be enabled for the current account.
      *
-     * It's needed to be logged into an account and with the nodes loaded (login + fetchNodes) before
-     * using this function. Otherwise it will always return false.
+     * Before using this function, it's needed to:
+     *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+     *  - If you are not logged-in: call to MegaApi::getMiscFlags.
      *
      * @return True if multi-factor authentication can be enabled for the current account, otherwise false.
      */
@@ -1103,6 +1121,42 @@ public class MegaApiJava {
      */
     public void getUserData(String user) {
         megaApi.getUserData(user);
+    }
+
+    /**
+     * Fetch miscellaneous flags when not logged in
+     *
+     * The associated request type with this request is MegaRequest::TYPE_GET_MISC_FLAGS.
+     *
+     * When onRequestFinish is called with MegaError::API_OK, the global flags are available.
+     * If you are logged in into an account, the error code provided in onRequestFinish is
+     * MegaError::API_EACCESS.
+     *
+     * @see MegaApi::multiFactorAuthAvailable
+     * @see MegaApi::newLinkFormatEnabled
+     * @see MegaApi::smsAllowedState
+     *
+     * @param listener MegaRequestListener to track this request
+     */
+    public void getMiscFlags(MegaRequestListenerInterface listener) {
+        megaApi.getMiscFlags(createDelegateRequestListener(listener));
+    }
+
+    /**
+     * Fetch miscellaneous flags when not logged in
+     *
+     * The associated request type with this request is MegaRequest::TYPE_GET_MISC_FLAGS.
+     *
+     * When onRequestFinish is called with MegaError::API_OK, the global flags are available.
+     * If you are logged in into an account, the error code provided in onRequestFinish is
+     * MegaError::API_EACCESS.
+     *
+     * @see MegaApi::multiFactorAuthAvailable
+     * @see MegaApi::newLinkFormatEnabled
+     * @see MegaApi::smsAllowedState
+     */
+    public void getMiscFlags() {
+        megaApi.getMiscFlags();
     }
 
     /**

--- a/bindings/java/nz/mega/sdk/MegaGlobalListenerInterface.java
+++ b/bindings/java/nz/mega/sdk/MegaGlobalListenerInterface.java
@@ -179,15 +179,33 @@ public interface MegaGlobalListenerInterface {
      *
      * - MegaEvent::EVENT_MEDIA_INFO_READY: when codec-mappings have been received
      *
+     * - MegaEvent::EVENT_STORAGE_SUM_CHANGED: when the storage sum has changed.
+     *
+     * For this event type, MegaEvent::getNumber provides the new storage sum.
+     *
      * - MegaEvent::EVENT_BUSINESS_STATUS: when the status of a business account has changed.
      *
      * For this event type, MegaEvent::getNumber provides the new business status.
      *
      * The posible values are:
-     *  - MegaApi::BUSINESS_STATUS_EXPIRED = -1
+     *  - BUSINESS_STATUS_EXPIRED = -1
      *  - BUSINESS_STATUS_INACTIVE = 0
      *  - BUSINESS_STATUS_ACTIVE = 1
      *  - BUSINESS_STATUS_GRACE_PERIOD = 2
+     *
+     * - MegaEvent::EVENT_KEY_MODIFIED: when the key of a user has changed.
+     *
+     * For this event type, MegaEvent::getHandle provides the handle of the user whose key has been modified.
+     * For this event type, MegaEvent::getNumber provides type of key that has been modified.
+     *
+     * The possible values are:
+     *  - Public chat key (Cu25519)     = 0
+     *  - Public signing key (Ed25519)  = 1
+     *  - Public RSA key                = 2
+     *  - Signature of chat key         = 3
+     *  - Signature of RSA key          = 4
+     *
+     * - MegaEvent::EVENT_GLOBAL_FLAGS_READY: when the global flags are available/updated.
      *
      * @param api MegaApi object connected to the account
      * @param event Details about the event

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -379,6 +379,8 @@ struct MEGA_API MegaApp
     // result of get country calling codes command
     virtual void getcountrycallingcodes_result(error, map<string, vector<string>>*) { }
 
+    virtual void getmiscflags_result(error) { }
+
     virtual ~MegaApp() { }
 };
 } // namespace

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -300,6 +300,9 @@ public:
     // get user data
     void getuserdata();
 
+    // get miscelaneous flags
+    void getmiscflags();
+
     // get the public key of an user
     void getpubkey(const char* user);
 
@@ -1301,6 +1304,8 @@ public:
 
     void readipc(JSON*);
     void readopc(JSON*);
+
+    error readglobalflags(JSON*);
 
     void procph(JSON*);
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -221,6 +221,9 @@ public:
     // Account has VOIP push enabled (only for Apple)
     bool aplvp_enabled;
 
+    // Use new format to generate Mega links
+    bool mNewLinkFormat = false;
+
     // 2 = Opt-in and unblock SMS allowed 1 = Only unblock SMS allowed 0 = No SMS allowed  -1 = flag was not received
     SmsVerificationState mSmsVerificationState;
 
@@ -229,9 +232,6 @@ public:
 	
     // pseudo-random number generator
     PrnGen rng;
-
-    // Use new format to generate Mega links
-    bool mNewLinkFormat = false;
 
     static string getPublicLink(bool newLinkFormat, nodetype_t type, handle ph, const char *key);
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1305,7 +1305,7 @@ public:
     void readipc(JSON*);
     void readopc(JSON*);
 
-    error readglobalflags(JSON*);
+    error readmiscflags(JSON*);
 
     void procph(JSON*);
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -2730,7 +2730,7 @@ class MegaRequest
             TYPE_GET_CLOUD_STORAGE_USED,
             TYPE_SEND_SMS_VERIFICATIONCODE, TYPE_CHECK_SMS_VERIFICATIONCODE,
             TYPE_GET_REGISTERED_CONTACTS, TYPE_GET_COUNTRY_CALLING_CODES,
-            TYPE_VERIFY_CREDENTIALS,
+            TYPE_VERIFY_CREDENTIALS, TYPE_GET_GLOBAL_FLAGS,
             TOTAL_OF_REQUEST_TYPES
         };
 
@@ -3434,7 +3434,7 @@ public:
         EVENT_STORAGE_SUM_CHANGED       = 8,
         EVENT_BUSINESS_STATUS           = 9,
         EVENT_KEY_MODIFIED              = 10,
-        EVENT_USER_FLAGS_READY          = 11,
+        EVENT_GLOBAL_FLAGS_READY          = 11,
     };
 
     virtual ~MegaEvent();
@@ -5951,7 +5951,7 @@ class MegaGlobalListener
          *  - Signature of chat key         = 3
          *  - Signature of RSA key          = 4
          *
-         * - MegaEvent::EVENT_USER_FLAGS_READY: when the user flags are available/updated.
+         * - MegaEvent::EVENT_GLOBAL_FLAGS_READY: when the global flags are available/updated.
          *
          * @param api MegaApi object connected to the account
          * @param event Details about the event
@@ -6437,7 +6437,7 @@ class MegaListener
          *  - Signature of chat key         = 3
          *  - Signature of RSA key          = 4
          *
-         * - MegaEvent::EVENT_USER_FLAGS_READY: when the user flags are available/updated.
+         * - MegaEvent::EVENT_GLOBAL_FLAGS_READY: when the global flags are available/updated.
          *
          * @param api MegaApi object connected to the account
          * @param event Details about the event
@@ -7227,6 +7227,12 @@ class MegaApi
         bool appleVoipPushEnabled();
 
         /**
+         * @brief Check if the new format for public links is enabled
+         * @return True if this feature is enabled. Otherwise, false.
+         */
+        bool newLinkFormatEnabled();
+
+        /**
          * @brief Check if the opt-in or account unblocking SMS is allowed
          *
          * The result indicated whether the MegaApi::sendSMSVerificationCode function can be used.
@@ -7536,6 +7542,21 @@ class MegaApi
          * @param listener MegaRequestListener to track this request
          */
         void getUserData(const char *user, MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Fetch global flags when not logged in
+         *
+         * The associated request type with this request is MegaRequest::TYPE_GET_GLOBAL_FLAGS.
+         *
+         * When onRequestFinish is called with MegaError::API_OK, the global flags are available.
+         *
+         * @see MegaApi::multiFactorAuthAvailable
+         * @see MegaApi::newLinkFormatEnabled
+         * @see MegaApi::smsAllowedState
+         *
+         * @param listener MegaRequestListener to track this request
+         */
+        void getGlobalFlags(MegaRequestListener *listener = NULL);
 
         /**
          * @brief Returns the current session key

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -7216,18 +7216,31 @@ class MegaApi
 
         /**
          * @brief Check if server-side Rubbish Bin autopurging is enabled for the current account
+         *
+         * Before using this function, it's needed to:
+         *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+         *
          * @return True if this feature is enabled. Otherwise false.
          */
         bool serverSideRubbishBinAutopurgeEnabled();
 
         /**
          * @brief Check if the account has VOIP push enabled
+         *
+         * Before using this function, it's needed to:
+         *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+         *
          * @return True if this feature is enabled. Otherwise false.
          */
         bool appleVoipPushEnabled();
 
         /**
          * @brief Check if the new format for public links is enabled
+         *
+         * Before using this function, it's needed to:
+         *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+         *  - If you are not logged-in: call to MegaApi::getGlobalFlags.
+         *
          * @return True if this feature is enabled. Otherwise, false.
          */
         bool newLinkFormatEnabled();
@@ -7236,6 +7249,10 @@ class MegaApi
          * @brief Check if the opt-in or account unblocking SMS is allowed
          *
          * The result indicated whether the MegaApi::sendSMSVerificationCode function can be used.
+         *
+         * Before using this function, it's needed to:
+         *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+         *  - If you are not logged-in: call to MegaApi::getGlobalFlags.
          *
          * @return 2 = Opt-in and unblock SMS allowed.  1 = Only unblock SMS allowed.  0 = No SMS allowed
          */
@@ -7256,8 +7273,9 @@ class MegaApi
         /**
          * @brief Check if multi-factor authentication can be enabled for the current account.
          *
-         * It's needed to be logged into an account and with the nodes loaded (login + fetchNodes) before
-         * using this function. Otherwise it will always return false.
+         * Before using this function, it's needed to:
+         *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
+         *  - If you are not logged-in: call to MegaApi::getGlobalFlags.
          *
          * @return True if multi-factor authentication can be enabled for the current account, otherwise false.
          */

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -2730,7 +2730,7 @@ class MegaRequest
             TYPE_GET_CLOUD_STORAGE_USED,
             TYPE_SEND_SMS_VERIFICATIONCODE, TYPE_CHECK_SMS_VERIFICATIONCODE,
             TYPE_GET_REGISTERED_CONTACTS, TYPE_GET_COUNTRY_CALLING_CODES,
-            TYPE_VERIFY_CREDENTIALS, TYPE_GET_GLOBAL_FLAGS,
+            TYPE_VERIFY_CREDENTIALS, TYPE_GET_MISC_FLAGS,
             TOTAL_OF_REQUEST_TYPES
         };
 
@@ -7239,7 +7239,7 @@ class MegaApi
          *
          * Before using this function, it's needed to:
          *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
-         *  - If you are not logged-in: call to MegaApi::getGlobalFlags.
+         *  - If you are not logged-in: call to MegaApi::getMiscFlags.
          *
          * @return True if this feature is enabled. Otherwise, false.
          */
@@ -7252,7 +7252,7 @@ class MegaApi
          *
          * Before using this function, it's needed to:
          *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
-         *  - If you are not logged-in: call to MegaApi::getGlobalFlags.
+         *  - If you are not logged-in: call to MegaApi::getMiscFlags.
          *
          * @return 2 = Opt-in and unblock SMS allowed.  1 = Only unblock SMS allowed.  0 = No SMS allowed
          */
@@ -7275,7 +7275,7 @@ class MegaApi
          *
          * Before using this function, it's needed to:
          *  - If you are logged-in: call to MegaApi::login and MegaApi::fetchNodes.
-         *  - If you are not logged-in: call to MegaApi::getGlobalFlags.
+         *  - If you are not logged-in: call to MegaApi::getMiscFlags.
          *
          * @return True if multi-factor authentication can be enabled for the current account, otherwise false.
          */
@@ -7562,11 +7562,13 @@ class MegaApi
         void getUserData(const char *user, MegaRequestListener *listener = NULL);
 
         /**
-         * @brief Fetch global flags when not logged in
+         * @brief Fetch miscellaneous flags when not logged in
          *
-         * The associated request type with this request is MegaRequest::TYPE_GET_GLOBAL_FLAGS.
+         * The associated request type with this request is MegaRequest::TYPE_GET_MISC_FLAGS.
          *
          * When onRequestFinish is called with MegaError::API_OK, the global flags are available.
+         * If you are logged in into an account, the error code provided in onRequestFinish is
+         * MegaError::API_EACCESS.
          *
          * @see MegaApi::multiFactorAuthAvailable
          * @see MegaApi::newLinkFormatEnabled
@@ -7574,7 +7576,7 @@ class MegaApi
          *
          * @param listener MegaRequestListener to track this request
          */
-        void getGlobalFlags(MegaRequestListener *listener = NULL);
+        void getMiscFlags(MegaRequestListener *listener = NULL);
 
         /**
          * @brief Returns the current session key

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -3448,7 +3448,7 @@ public:
         EVENT_STORAGE_SUM_CHANGED       = 8,
         EVENT_BUSINESS_STATUS           = 9,
         EVENT_KEY_MODIFIED              = 10,
-        EVENT_GLOBAL_FLAGS_READY          = 11,
+        EVENT_MISC_FLAGS_READY          = 11,
     };
 
     virtual ~MegaEvent();
@@ -5965,7 +5965,7 @@ class MegaGlobalListener
          *  - Signature of chat key         = 3
          *  - Signature of RSA key          = 4
          *
-         * - MegaEvent::EVENT_GLOBAL_FLAGS_READY: when the global flags are available/updated.
+         * - MegaEvent::EVENT_MISC_FLAGS_READY: when the miscellaneous flags are available/updated.
          *
          * @param api MegaApi object connected to the account
          * @param event Details about the event
@@ -6451,7 +6451,7 @@ class MegaListener
          *  - Signature of chat key         = 3
          *  - Signature of RSA key          = 4
          *
-         * - MegaEvent::EVENT_GLOBAL_FLAGS_READY: when the global flags are available/updated.
+         * - MegaEvent::EVENT_MISC_FLAGS_READY: when the miscellaneous flags are available/updated.
          *
          * @param api MegaApi object connected to the account
          * @param event Details about the event
@@ -7583,7 +7583,7 @@ class MegaApi
          *
          * The associated request type with this request is MegaRequest::TYPE_GET_MISC_FLAGS.
          *
-         * When onRequestFinish is called with MegaError::API_OK, the global flags are available.
+         * When onRequestFinish is called with MegaError::API_OK, the miscellaneous flags are available.
          * If you are logged in into an account, the error code provided in onRequestFinish is
          * MegaError::API_EACCESS.
          *

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2016,7 +2016,7 @@ class MegaApiImpl : public MegaApp
         void getUserData(MegaRequestListener *listener = NULL);
         void getUserData(MegaUser *user, MegaRequestListener *listener = NULL);
         void getUserData(const char *user, MegaRequestListener *listener = NULL);
-        void getGlobalFlags(MegaRequestListener *listener = NULL);
+        void getMiscFlags(MegaRequestListener *listener = NULL);
         void getCloudStorageUsed(MegaRequestListener *listener = NULL); 
         void getAccountDetails(bool storage, bool transfer, bool pro, bool sessions, bool purchases, bool transactions, int source = -1, MegaRequestListener *listener = NULL);
         void queryTransferQuota(long long size, MegaRequestListener *listener = NULL);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1987,6 +1987,7 @@ class MegaApiImpl : public MegaApp
 
         bool serverSideRubbishBinAutopurgeEnabled();
         bool appleVoipPushEnabled();
+        bool newLinkFormatEnabled();
         int smsAllowedState();
         char* smsVerifiedPhoneNumber();
 
@@ -2015,6 +2016,7 @@ class MegaApiImpl : public MegaApp
         void getUserData(MegaRequestListener *listener = NULL);
         void getUserData(MegaUser *user, MegaRequestListener *listener = NULL);
         void getUserData(const char *user, MegaRequestListener *listener = NULL);
+        void getGlobalFlags(MegaRequestListener *listener = NULL);
         void getCloudStorageUsed(MegaRequestListener *listener = NULL); 
         void getAccountDetails(bool storage, bool transfer, bool pro, bool sessions, bool purchases, bool transactions, int source = -1, MegaRequestListener *listener = NULL);
         void queryTransferQuota(long long size, MegaRequestListener *listener = NULL);
@@ -2869,7 +2871,7 @@ protected:
         void backgrounduploadurl_result(error, string*) override;
         void mediadetection_ready() override;
         void storagesum_changed(int64_t newsum) override;
-
+        void getmiscflags_result(error) override;
 
 #ifdef ENABLE_CHAT
         // chat-related commandsresult

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -3578,7 +3578,7 @@ void CommandGetUserData::procresult()
         case MAKENAMEID5('f', 'l', 'a', 'g', 's'):
             if (client->json.enterobject())
             {
-                if (client->readglobalflags(&client->json) != API_OK)
+                if (client->readmiscflags(&client->json) != API_OK)
                 {
                     return client->app->userdata_result(NULL, NULL, NULL, API_EINTERNAL);
                 }
@@ -3817,7 +3817,7 @@ void CommandGetMiscFlags::procresult()
     }
     else
     {
-        e = client->readglobalflags(&client->json);
+        e = client->readmiscflags(&client->json);
     }
 
     client->app->getmiscflags_result(e);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5943,7 +5943,7 @@ MegaHandle MegaEvent::getHandle() const
 
 const char *MegaEvent::getEventString() const
 {
-    return MegaEvent::getEventString();
+    return NULL;
 }
 
 MegaHandleList *MegaHandleList::createInstance()

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2005,9 +2005,9 @@ void MegaApi::getUserData(const char *user, MegaRequestListener *listener)
     pImpl->getUserData(user, listener);
 }
 
-void MegaApi::getGlobalFlags(MegaRequestListener *listener)
+void MegaApi::getMiscFlags(MegaRequestListener *listener)
 {
-    pImpl->getGlobalFlags(listener);
+    pImpl->getMiscFlags(listener);
 }
 
 void MegaApi::login(const char *login, const char *password, MegaRequestListener *listener)

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1898,6 +1898,11 @@ bool MegaApi::appleVoipPushEnabled()
     return pImpl->appleVoipPushEnabled();
 }
 
+bool MegaApi::newLinkFormatEnabled()
+{
+    return pImpl->newLinkFormatEnabled();
+}
+
 int MegaApi::smsAllowedState()
 {
     return pImpl->smsAllowedState();
@@ -1998,6 +2003,11 @@ void MegaApi::getUserData(MegaUser *user, MegaRequestListener *listener)
 void MegaApi::getUserData(const char *user, MegaRequestListener *listener)
 {
     pImpl->getUserData(user, listener);
+}
+
+void MegaApi::getGlobalFlags(MegaRequestListener *listener)
+{
+    pImpl->getGlobalFlags(listener);
 }
 
 void MegaApi::login(const char *login, const char *password, MegaRequestListener *listener)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -12158,7 +12158,7 @@ void MegaApiImpl::getmiscflags_result(error e)
 {
     if (e == API_OK)
     {
-        MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_GLOBAL_FLAGS_READY);
+        MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_MISC_FLAGS_READY);
         fireOnEvent(event);
     }
 
@@ -13948,7 +13948,7 @@ void MegaApiImpl::userdata_result(string *name, string* pubk, string* privk, err
     // (note that usually the API command is triggered internally, so no request is associated)
     if (result == API_OK)
     {
-        MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_GLOBAL_FLAGS_READY);
+        MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_MISC_FLAGS_READY);
         fireOnEvent(event);
     }
 
@@ -30696,7 +30696,7 @@ const char *MegaEventPrivate::getEventString(int type)
         case MegaEvent::EVENT_STORAGE_SUM_CHANGED: return "EVENT_STORAGE_SUM_CHANGED";
         case MegaEvent::EVENT_BUSINESS_STATUS: return "BUSINESS_STATUS";
         case MegaEvent::EVENT_KEY_MODIFIED: return "KEY_MODIFIED";
-        case MegaEvent::EVENT_GLOBAL_FLAGS_READY: return "GLOBAL_FLAGS_READY";
+        case MegaEvent::EVENT_MISC_FLAGS_READY: return "MISC_FLAGS_READY";
     }
 
     return "UNKNOWN";

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -3804,7 +3804,7 @@ const char *MegaRequestPrivate::getRequestString() const
         case TYPE_GET_REGISTERED_CONTACTS: return "GET_REGISTERED_CONTACTS";
         case TYPE_GET_COUNTRY_CALLING_CODES: return "GET_COUNTRY_CALLING_CODES";
         case TYPE_VERIFY_CREDENTIALS: return "VERIFY_CREDENTIALS";
-        case TYPE_GET_GLOBAL_FLAGS: return "GET_GLOBAL_FLAGS";
+        case TYPE_GET_MISC_FLAGS: return "GET_MISC_FLAGS";
     }
     return "UNKNOWN";
 }
@@ -5790,9 +5790,9 @@ void MegaApiImpl::getUserData(const char *user, MegaRequestListener *listener)
     waiter->notify();
 }
 
-void MegaApiImpl::getGlobalFlags(MegaRequestListener *listener)
+void MegaApiImpl::getMiscFlags(MegaRequestListener *listener)
 {
-    MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_GET_GLOBAL_FLAGS, listener);
+    MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_GET_MISC_FLAGS, listener);
     requestQueue.push(request);
     waiter->notify();
 }
@@ -12164,7 +12164,7 @@ void MegaApiImpl::getmiscflags_result(error e)
 
     if (requestMap.find(client->restag) == requestMap.end()) return;
     MegaRequestPrivate* request = requestMap.at(client->restag);
-    if (!request || (request->getType() != MegaRequest::TYPE_GET_GLOBAL_FLAGS)) return;
+    if (!request || (request->getType() != MegaRequest::TYPE_GET_MISC_FLAGS)) return;
 
     fireOnRequestFinish(request, e);
 }
@@ -21342,7 +21342,7 @@ void MegaApiImpl::sendPendingRequests()
             client->reqs.add(new CommandGetCountryCallingCodes{client});
             break;
         }
-        case MegaRequest::TYPE_GET_GLOBAL_FLAGS:
+        case MegaRequest::TYPE_GET_MISC_FLAGS:
         {
             if (client->loggedin())
             {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -3804,6 +3804,7 @@ const char *MegaRequestPrivate::getRequestString() const
         case TYPE_GET_REGISTERED_CONTACTS: return "GET_REGISTERED_CONTACTS";
         case TYPE_GET_COUNTRY_CALLING_CODES: return "GET_COUNTRY_CALLING_CODES";
         case TYPE_VERIFY_CREDENTIALS: return "VERIFY_CREDENTIALS";
+        case TYPE_GET_GLOBAL_FLAGS: return "GET_GLOBAL_FLAGS";
     }
     return "UNKNOWN";
 }
@@ -5636,6 +5637,11 @@ bool MegaApiImpl::appleVoipPushEnabled()
     return client->aplvp_enabled;
 }
 
+bool MegaApiImpl::newLinkFormatEnabled()
+{
+    return client->mNewLinkFormat;
+}
+
 int MegaApiImpl::smsAllowedState()
 {
     return (client->mSmsVerificationState != SMS_STATE_UNKNOWN) ? client->mSmsVerificationState : 0;
@@ -5780,6 +5786,13 @@ void MegaApiImpl::getUserData(const char *user, MegaRequestListener *listener)
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_GET_USER_DATA, listener);
     request->setFlag(true);
     request->setEmail(user);
+    requestQueue.push(request);
+    waiter->notify();
+}
+
+void MegaApiImpl::getGlobalFlags(MegaRequestListener *listener)
+{
+    MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_GET_GLOBAL_FLAGS, listener);
     requestQueue.push(request);
     waiter->notify();
 }
@@ -12141,6 +12154,21 @@ void MegaApiImpl::storagesum_changed(int64_t newsum)
     fireOnEvent(event);
 }
 
+void MegaApiImpl::getmiscflags_result(error e)
+{
+    if (e == API_OK)
+    {
+        MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_GLOBAL_FLAGS_READY);
+        fireOnEvent(event);
+    }
+
+    if (requestMap.find(client->restag) == requestMap.end()) return;
+    MegaRequestPrivate* request = requestMap.at(client->restag);
+    if (!request || (request->getType() != MegaRequest::TYPE_GET_GLOBAL_FLAGS)) return;
+
+    fireOnRequestFinish(request, e);
+}
+
 #ifdef ENABLE_CHAT
 
 void MegaApiImpl::chatcreate_result(TextChat *chat, error e)
@@ -13920,7 +13948,7 @@ void MegaApiImpl::userdata_result(string *name, string* pubk, string* privk, err
     // (note that usually the API command is triggered internally, so no request is associated)
     if (result == API_OK)
     {
-        MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_USER_FLAGS_READY);
+        MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_GLOBAL_FLAGS_READY);
         fireOnEvent(event);
     }
 
@@ -21312,6 +21340,17 @@ void MegaApiImpl::sendPendingRequests()
         case MegaRequest::TYPE_GET_COUNTRY_CALLING_CODES:
         {
             client->reqs.add(new CommandGetCountryCallingCodes{client});
+            break;
+        }
+        case MegaRequest::TYPE_GET_GLOBAL_FLAGS:
+        {
+            if (client->loggedin())
+            {
+                // it only returns not-user-related flags (ie. server-sider-rubbish scheduler is missing)
+                e = API_EACCESS;
+                break;
+            }
+            client->getmiscflags();
             break;
         }
         default:
@@ -30657,7 +30696,7 @@ const char *MegaEventPrivate::getEventString(int type)
         case MegaEvent::EVENT_STORAGE_SUM_CHANGED: return "EVENT_STORAGE_SUM_CHANGED";
         case MegaEvent::EVENT_BUSINESS_STATUS: return "BUSINESS_STATUS";
         case MegaEvent::EVENT_KEY_MODIFIED: return "KEY_MODIFIED";
-        case MegaEvent::EVENT_USER_FLAGS_READY: return "USER_FLAGS_READY";
+        case MegaEvent::EVENT_GLOBAL_FLAGS_READY: return "GLOBAL_FLAGS_READY";
     }
 
     return "UNKNOWN";

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7694,13 +7694,13 @@ error MegaClient::readglobalflags(JSON *json)
         case MAKENAMEID4('m', 'f', 'a', 'e'):   // multi-factor authentication enabled
             gmfa_enabled = bool(json->getint());
             break;
-        case MAKENAMEID4('s', 's', 'r', 's'):   // server-side rubish-bin scheduler
+        case MAKENAMEID4('s', 's', 'r', 's'):   // server-side rubish-bin scheduler (only available when logged in)
             ssrs_enabled = bool(json->getint());
             break;
         case MAKENAMEID4('n', 's', 'r', 'e'):   // new secure registration enabled
             nsr_enabled = bool(json->getint());
             break;
-        case MAKENAMEID5('a', 'p', 'l', 'v', 'p'):   // apple VOIP push enabled
+        case MAKENAMEID5('a', 'p', 'l', 'v', 'p'):   // apple VOIP push enabled (only available when logged in)
             aplvp_enabled = bool(json->getint());
             break;
         case MAKENAMEID5('s', 'm', 's', 'v', 'e'):   // 2 = Opt-in and unblock SMS allowed 1 = Only unblock SMS allowed 0 = No SMS allowed

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7683,7 +7683,7 @@ void MegaClient::readopc(JSON *j)
     }
 }
 
-error MegaClient::readglobalflags(JSON *json)
+error MegaClient::readmiscflags(JSON *json)
 {
     while (1)
     {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3634,6 +3634,7 @@ void MegaClient::locallogout()
     ssrs_enabled = false;
     nsr_enabled = false;
     aplvp_enabled = false;
+    mNewLinkFormat = false;
     mSmsVerificationState = SMS_STATE_UNKNOWN;
     mSmsVerifiedPhone.clear();
     loggingout = 0;


### PR DESCRIPTION
- Parse global flags in a single place: `readflags()`
- Ability to fetch flags while logged out.
- Reset status of link-format flag.

Risk area/s: 
- Login into a blocked account.