### PR TITLE
Xcode compilation fails when building for release configuration

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -6150,21 +6150,6 @@ typedef NS_ENUM(NSInteger, BusinessStatus) {
 - (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString recursive:(BOOL)recursive;
 
 /**
- * @brief Search nodes containing a search string in their name.
- *
- * The search is case-insensitive.
- *
- * @param node The parent node of the tree to explore.
- * @param searchString Search string. The search is case-insensitive.
- * @param cancelToken MEGACancelToken to be able to cancel the processing at any time.
- * @param recursive YES if you want to seach recursively in the node tree.
- * NO if you want to seach in the children of the node only
- *
- * @return List of nodes that contain the desired string in their name.
- */
-- (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString cancelToken:(MEGACancelToken *)cancelToken recursive:(BOOL)recursive;
-
-/**
 * @brief Search nodes containing a search string in their name.
 *
 * The search is case-insensitive.

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -1855,10 +1855,6 @@ using namespace mega;
     return [[MEGANodeList alloc] initWithNodeList:self.megaApi->search((node != nil) ? [node getCPtr] : NULL, (searchString != nil) ? [searchString UTF8String] : NULL, recursive) cMemoryOwn:YES];
 }
 
-- (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString cancelToken:(MEGACancelToken *)cancelToken recursive:(BOOL)recursive {
-    return [MEGANodeList.alloc initWithNodeList:self.megaApi->search(node ? [node getCPtr] : NULL, searchString.UTF8String, cancelToken ? [cancelToken getCPtr] : NULL, recursive) cMemoryOwn:YES];
-}
-
 - (MEGANodeList *)nodeListSearchForNode:(MEGANode *)node searchString:(NSString *)searchString cancelToken:(MEGACancelToken *)cancelToken recursive:(BOOL)recursive order:(MEGASortOrderType)order {
     return [MEGANodeList.alloc initWithNodeList:self.megaApi->search(node ? [node getCPtr] : NULL, searchString.UTF8String, cancelToken ? [cancelToken getCPtr] : NULL, recursive, (int)order) cMemoryOwn:YES];
 }


### PR DESCRIPTION
Call to member function 'search' is ambiguous

Candidate function not viable: requires at most 3 arguments, but 4 were provided
Candidate function not viable: requires at most 2 arguments, but 4 were provided