### PR TITLE
Update string for EMASTERONLY error.

### DIFF
--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1341,7 +1341,7 @@ const char* MegaError::getErrorString(int errorCode, ErrorContexts context)
         case API_EMFAREQUIRED:
             return "Multi-factor authentication required";
         case API_EMASTERONLY:
-            return "Access denied for sub-users";
+            return "Access denied for users";
         case API_EBUSINESSPASTDUE:
             return "Business account has expired";
         case PAYMENT_ECARD:


### PR DESCRIPTION
We shouldn't use the term sub-users for things displayed in the clients, they are just referred to as users (as opposed to admins)