### PR TITLE
#13326. Adjust prototype of `startUploadForChat()`

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10772,7 +10772,7 @@ class MegaApi
          * Use this parameter with caution. Set it to true only if you are sure about what are you doing.
          * @param listener MegaTransferListener to track this transfer
          */
-        void startUploadForChat(const char* localPath, MegaNode *parent, const char* appData, bool isSourceTemporary, MegaTransferListener *listener = nullptr);
+        void startUploadForChat(const char *localPath, MegaNode *parent, const char *appData, bool isSourceTemporary, MegaTransferListener *listener = nullptr);
 
         /**
          * @brief Download a file or a folder from MEGA

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10758,14 +10758,21 @@ class MegaApi
          * code MegaError::API_EBUSINESSPASTDUE. In this case, apps should show a warning message similar to
          * "Your business account is overdue, please contact your administrator."
          *
-         * @param localPath Local path of the file
-         * @param parent Parent node for the file in the MEGA account
+         * @param localPath Local path of the file or folder
+         * @param parent Parent node for the file or folder in the MEGA account
+         * @param appData Custom app data to save in the MegaTransfer object
+         * The data in this parameter can be accessed using MegaTransfer::getAppData in callbacks
+         * related to the transfer. If a transfer is started with exactly the same data
+         * (local path and target parent) as another one in the transfer queue, the new transfer
+         * fails with the error API_EEXISTS and the appData of the new transfer is appended to
+         * the appData of the old transfer, using a '!' separator if the old transfer had already
+         * appData.
+         * @param isSourceTemporary Pass the ownership of the file to the SDK, that will DELETE it when the upload finishes.
+         * This parameter is intended to automatically delete temporary files that are only created to be uploaded.
+         * Use this parameter with caution. Set it to true only if you are sure about what are you doing.
          * @param listener MegaTransferListener to track this transfer
-         *
-         * The custom modification time will be only applied for file transfers. If a folder
-         * is transferred using this function, the custom modification time won't have any effect
          */
-        void startUploadForChat(const char* localPath, MegaNode* parent, MegaTransferListener *listener = nullptr);
+        void startUploadForChat(const char* localPath, MegaNode *parent, const char* appData, bool isSourceTemporary, MegaTransferListener *listener = nullptr);
 
         /**
          * @brief Download a file or a folder from MEGA

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2914,9 +2914,9 @@ void MegaApi::startUpload(const char *localPath, MegaNode *parent, const char *f
     pImpl->startUpload(false, localPath, parent, fileName, mtime, 0, false, NULL, false, false, listener);
 }
 
-void MegaApi::startUploadForChat(const char *localPath, MegaNode *parent, MegaTransferListener *listener)
+void MegaApi::startUploadForChat(const char *localPath, MegaNode *parent, const char *appData, bool isSourceTemporary, MegaTransferListener *listener)
 {
-    pImpl->startUpload(false, localPath, parent, nullptr, -1, 0, false, nullptr, false, true, listener);
+    pImpl->startUpload(false, localPath, parent, nullptr, -1, 0, false, appData, isSourceTemporary, true, listener);
 }
 
 void MegaApi::startDownload(MegaNode *node, const char* localFolder, MegaTransferListener *listener)


### PR DESCRIPTION
**Area/s of risk:**
- Upload to chat when file already exists but preview/thumbnail are missing. It should upload it again setting the preview/thumbnail correctly, when appropriate.