### PR TITLE
#13214. Fix performance issues

### DIFF
--- a/include/mega/posix/megawaiter.h
+++ b/include/mega/posix/megawaiter.h
@@ -44,6 +44,8 @@ struct PosixWaiter : public Waiter
 
 protected:
     int m_pipe[2];
+    std::mutex mMutex;
+    bool alreadyNotified = false;
 };
 } // namespace
 


### PR DESCRIPTION
During some MEGAsync profiling, we've detected that some operations such us cancelTransfers, startUploads, etc produce a huge number of notify() events to the specific waiter for POSIX systems. This cause to reach the pipe capacity and block the call to `write`, producing the hang up of the UI and undesired effects.

As a solution, just notify once to the pipe avoiding unnecessary calls.

It could be fixed also setting nonblocking to the pipe, but this imply that will write until the pipe capacity (65536 bytes).