### PR TITLE
Enable SDK clients to lock the sdkMutex for performance reasons

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6627,6 +6627,43 @@ public:
 class MegaApiImpl;
 
 /**
+ * @brief Allows calling many synchronous operations on MegaApi without being blocked by SDK activity.
+ *
+ * Call MegaApi::getMegaApiLock() to get an instance of this class to use.
+ */
+class MegaApiLock
+{
+    MegaApiImpl* api;
+    bool locked = false;
+    MegaApiLock(MegaApiImpl*, bool lock);
+    friend class MegaApi;
+
+public:
+    /**
+     * @brief Lock the MegaApi if this instance does not currently have a lock on it yet.
+     * 
+     * There is no harm in calling this more than once, the MegaApi will only be locked 
+     * once, and the first unlock() call will release it.
+     */
+    void lockOnce();
+
+    /**
+     * @brief Release the lock on the MegaApi if one is still held by this instance
+     *
+     * The MegaApi will be unable to continue work until all MegaApiLock objects release
+     * their locks.  Only use multiple of these if you need nested locking.  The destructor
+     * of the object will release the lock, so it is sufficient to delete it when finished.
+     * However, when using it from a garbage collected language it may be prudent to call unlock() directly.
+     */
+    void unlock();
+    
+    /**
+     * @brief Destructor.  This will call unlock() if the MegaApi is still locked by this instance.
+     */
+    ~MegaApiLock();
+};
+
+/**
  * @brief Allows to control a MEGA account or a shared folder
  *
  * You must provide an appKey to use this SDK. You can generate an appKey for your app for free here:
@@ -15593,7 +15630,25 @@ class MegaApi
          */
         void getPublicLinkInformation(const char *megaFolderLink, MegaRequestListener *listener = NULL);
 
-private:
+
+        /**
+         * @brief Get an object that can lock the MegaApi, allowing multple quick synchronous calls.
+         *
+         * This object must be used very carefully.  It is meant to be used  when the application is about 
+         * to make a burst of synchronous calls (that return data immediately, without using a listener)
+         * to the API over a very short time period, which could otherwise be blocked multple times
+         * interrupted by the MegaApi's operation.
+         *
+         * The MegaApiLock usual use is to request it already locked, and the caller must destroy it
+         * when its sequence of operations are complete, which will allow the MegaApi to continue again.
+         * However explicit lock and unlock calls can also be made on it, which are protected from 
+         * making more than one lock, and the destructor will make sure the lock is released.
+         * 
+         * You take ownership of the returned value, and you must delete it when the sequence is complete.
+         */
+        MegaApiLock* getMegaApiLock(bool lockNow);
+
+ private:
         MegaApiImpl *pImpl;
         friend class MegaApiImpl;
 };

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -6633,17 +6633,16 @@ class MegaApiImpl;
  */
 class MegaApiLock
 {
-    MegaApiImpl* api;
-    bool locked = false;
-    MegaApiLock(MegaApiImpl*, bool lock);
-    friend class MegaApi;
-
 public:
     /**
      * @brief Lock the MegaApi if this instance does not currently have a lock on it yet.
-     * 
-     * There is no harm in calling this more than once, the MegaApi will only be locked 
-     * once, and the first unlock() call will release it.
+     *
+     * There is no harm in calling this more than once, the MegaApi will only be locked
+     * once, and the first unlock() call will release it.    Sometimes it is useful eg.
+     * in a loop which may or may not need to use a locking function, or may need to use
+     * many, to call lockOnce() before any such usage, and know that the MegaApi will
+     * be locked once from that point, until the end of the loop (when unlockOnce() can
+     * be called, or the MegaApiLock destroyed.
      */
     void lockOnce();
 
@@ -6654,13 +6653,23 @@ public:
      * their locks.  Only use multiple of these if you need nested locking.  The destructor
      * of the object will release the lock, so it is sufficient to delete it when finished.
      * However, when using it from a garbage collected language it may be prudent to call unlock() directly.
+     *
+     * This function must be called from the same thread that called MegaApiLock::lockOnce().
      */
-    void unlock();
-    
+    void unlockOnce();
+
     /**
      * @brief Destructor.  This will call unlock() if the MegaApi is still locked by this instance.
      */
     ~MegaApiLock();
+
+private:
+    MegaApiImpl* api;
+    bool locked = false;
+    MegaApiLock(MegaApiImpl*, bool lock);
+    MegaApiLock(const MegaApiLock&) = delete;
+    void operator=(const MegaApiLock&) = delete;
+    friend class MegaApi;
 };
 
 /**

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2568,6 +2568,8 @@ class MegaApiImpl : public MegaApp
         void fireOnBackupTemporaryError(MegaBackupController *backup, MegaError e);
 
         void yield();
+        void lockMutex();
+        void unlockMutex();
 
 protected:
         static const unsigned int MAX_SESSION_LENGTH;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3930,6 +3930,11 @@ void MegaApi::getPublicLinkInformation(const char *megaFolderLink, MegaRequestLi
     pImpl->getPublicLinkInformation(megaFolderLink, listener);
 }
 
+MegaApiLock* MegaApi::getMegaApiLock(bool lockNow)
+{
+    return new MegaApiLock(pImpl, lockNow);
+}
+
 void MegaApi::sendSMSVerificationCode(const char* phoneNumber, MegaRequestListener *listener, bool reverifying_whitelisted)
 {
     pImpl->sendSMSVerificationCode(phoneNumber, listener, reverifying_whitelisted);
@@ -5705,6 +5710,38 @@ MegaInputStream::~MegaInputStream()
 {
 
 }
+
+MegaApiLock::MegaApiLock(MegaApiImpl* ptr, bool lock) : api(ptr)
+{
+    if (lock)
+    {
+        lockOnce();
+    }
+}
+
+MegaApiLock::~MegaApiLock()
+{
+    unlock();
+}
+
+void MegaApiLock::lockOnce()
+{
+    if (!locked)
+    {
+        api->lockMutex();
+        locked = true;
+    }
+}
+
+void MegaApiLock::unlock()
+{
+    if (locked)
+    {
+        api->unlockMutex();
+        locked = false;
+    }
+}
+
 
 #ifdef ENABLE_CHAT
 MegaTextChatPeerList * MegaTextChatPeerList::createInstance()

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5721,7 +5721,7 @@ MegaApiLock::MegaApiLock(MegaApiImpl* ptr, bool lock) : api(ptr)
 
 MegaApiLock::~MegaApiLock()
 {
-    unlock();
+    unlockOnce();
 }
 
 void MegaApiLock::lockOnce()
@@ -5733,7 +5733,7 @@ void MegaApiLock::lockOnce()
     }
 }
 
-void MegaApiLock::unlock()
+void MegaApiLock::unlockOnce()
 {
     if (locked)
     {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -21478,6 +21478,16 @@ int MegaApiImpl::areServersBusy()
     return isWaiting();
 }
 
+void MegaApiImpl::lockMutex()
+{
+    sdkMutex.lock();
+}
+
+void MegaApiImpl::unlockMutex()
+{
+    sdkMutex.unlock();
+}
+
 TreeProcCopy::TreeProcCopy()
 {
     nn = NULL;

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -1455,7 +1455,7 @@ WinDirNotify::~WinDirNotify()
 #endif
 }
 
-FileAccess* WinFileSystemAccess::newfileaccess(bool followSymLinks = true)
+FileAccess* WinFileSystemAccess::newfileaccess(bool followSymLinks)
 {
     return new WinFileAccess(waiter);
 }


### PR DESCRIPTION
Sometimes clients need to make many calls in a row that each lock the sdkMutex.  If the SDK is busy, many interruptions may occur in that sequence.   This allows that to occur all in one quick go.

MEGAsync in particular can benefit form this because it does a sequence of locking in its paint functions when transfers are first processed there.

The object returned manages the lock on the mutex, ensuring it is locked max once (at a time), and is unlocked on object destruction.