### PR TITLE
Syncdown required only if not business error

### DIFF
--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -421,7 +421,7 @@ void Transfer::failed(error e, dstime timeleft)
         for (file_list::iterator it = files.begin(); it != files.end(); it++)
         {
 #ifdef ENABLE_SYNC
-            if((*it)->syncxfer)
+            if((*it)->syncxfer && e != API_EBUSINESSPASTDUE)
             {
                 client->syncdownrequired = true;
             }


### PR DESCRIPTION
In case of business errors not produce a sync down required, because it will fall again.