### PR TITLE
#13380. Open files just once during fingerprinting.

### DIFF
--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -115,7 +115,7 @@ struct MEGA_API FileAccess
     bool fread(string *, unsigned, unsigned, m_off_t);
 
     // absolute position read to byte buffer
-    bool frawread(byte *, unsigned, m_off_t);
+    bool frawread(byte *, unsigned, m_off_t, bool skipopen = false, bool keepopen = false);
 
     // non-locking ops: open/close temporary hFile
     bool openf();

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -94,15 +94,15 @@ struct MEGA_API FileAccess
     int errorcode;
 
     // for files "opened" in nonblocking mode, the current local filename
-    string localname;
+    string nonblocking_localname;
 
     // waiter to notify on filesystem events
     Waiter *waiter;
 
-    // open for reading, writing or reading and writing
+    // blocking mode: open for reading, writing or reading and writing.  This one really does open the file, and openf(), closef() will have no effect
     virtual bool fopen(string*, bool, bool) = 0;
 
-    // Only prepares for opening.  Actually stats the file/folder, getting mtime, size, type.  Call openf() afterwards to actually open it if required.  For folders, retunrs false with type==FOLDERNODE.
+    // nonblocking open: Only prepares for opening.  Actually stats the file/folder, getting mtime, size, type.  Call openf() afterwards to actually open it if required.  For folders, retunrs false with type==FOLDERNODE.
     bool fopen(string*);
 
     // check if a local path is a folder
@@ -115,9 +115,9 @@ struct MEGA_API FileAccess
     bool fread(string *, unsigned, unsigned, m_off_t);
 
     // absolute position read to byte buffer
-    bool frawread(byte *, unsigned, m_off_t, bool skipopen = false, bool keepopen = false);
+    bool frawread(byte *, unsigned, m_off_t, bool caller_opened = false);
 
-    // After a successful fopen(), call fopen() to really open the file (by localname) (this is a lazy-type approach in case we don't actually need to open the file after finding out type/size/mtime).  If the size or mtime changed, it will fail.
+    // After a successful nonblocking fopen(), call openf() to really open the file (by localname) (this is a lazy-type approach in case we don't actually need to open the file after finding out type/size/mtime).  If the size or mtime changed, it will fail.
     bool openf();
 
     // After calling openf(), make sure to close the file again quickly with closef().

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -99,10 +99,12 @@ struct MEGA_API FileAccess
     // waiter to notify on filesystem events
     Waiter *waiter;
 
-    // blocking mode: open for reading, writing or reading and writing.  This one really does open the file, and openf(), closef() will have no effect
+    // blocking mode: open for reading, writing or reading and writing.
+    // This one really does open the file, and openf(), closef() will have no effect
     virtual bool fopen(string*, bool, bool) = 0;
 
-    // nonblocking open: Only prepares for opening.  Actually stats the file/folder, getting mtime, size, type.  Call openf() afterwards to actually open it if required.  For folders, retunrs false with type==FOLDERNODE.
+    // nonblocking open: Only prepares for opening.  Actually stats the file/folder, getting mtime, size, type.
+    // Call openf() afterwards to actually open it if required.  For folders, returns false with type==FOLDERNODE.
     bool fopen(string*);
 
     // check if a local path is a folder
@@ -117,7 +119,9 @@ struct MEGA_API FileAccess
     // absolute position read to byte buffer
     bool frawread(byte *, unsigned, m_off_t, bool caller_opened = false);
 
-    // After a successful nonblocking fopen(), call openf() to really open the file (by localname) (this is a lazy-type approach in case we don't actually need to open the file after finding out type/size/mtime).  If the size or mtime changed, it will fail.
+    // After a successful nonblocking fopen(), call openf() to really open the file (by localname)
+    // (this is a lazy-type approach in case we don't actually need to open the file after finding out type/size/mtime).
+    // If the size or mtime changed, it will fail.
     bool openf();
 
     // After calling openf(), make sure to close the file again quickly with closef().

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -133,8 +133,10 @@ struct MEGA_API PosixAsyncIOContext : public AsyncIOContext
 
 class MEGA_API PosixFileAccess : public FileAccess
 {
-public:
+private:
     int fd;
+public:
+    int stealFileDescriptor();
     int defaultfilepermissions;
 
 #ifndef HAVE_FDOPENDIR

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -139,12 +139,19 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
         changed = true;
     }
 
+    if (!fa->openf())
+    {
+        size = -1;
+        return true;
+    }
+
     if (size <= (m_off_t)sizeof crc)
     {
         // tiny file: read verbatim, NUL pad
         if (!fa->frawread((byte*)newcrc, static_cast<unsigned>(size), 0, true,  true))
         {
             size = -1;
+            fa->closef();
             return true;
         }
 
@@ -162,6 +169,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
         if (!fa->frawread(buf, static_cast<unsigned>(size), 0, true,  true))
         {
             size = -1;
+            fa->closef();
             return true;
         }
 
@@ -193,6 +201,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
                                   / (sizeof crc / sizeof *crc * blocks - 1), true,  true))
                 {
                     size = -1;
+                    fa->closef();
                     return true;
                 }
 
@@ -216,6 +225,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
         changed = true;
     }
 
+    fa->closef();
     return changed;
 }
 

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -190,7 +190,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
                 if (!fa->frawread(block, sizeof block,
                                   (size - sizeof block)
                                   * (i * blocks + j)
-                                  / (sizeof crc / sizeof *crc * blocks - 1)))
+                                  / (sizeof crc / sizeof *crc * blocks - 1), i || j, true))
                 {
                     size = -1;
                     return true;
@@ -202,6 +202,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
             crc32.get((byte*)&crcval);
             newcrc[i] = htonl(crcval);
         }
+        fa->closef();
     }
 
     if (memcmp(crc, newcrc, sizeof crc))

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -142,7 +142,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
     if (size <= (m_off_t)sizeof crc)
     {
         // tiny file: read verbatim, NUL pad
-        if (!fa->frawread((byte*)newcrc, static_cast<unsigned>(size), 0))
+        if (!fa->frawread((byte*)newcrc, static_cast<unsigned>(size), 0, true,  true))
         {
             size = -1;
             return true;
@@ -159,7 +159,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
         HashCRC32 crc32;
         byte buf[MAXFULL];
 
-        if (!fa->frawread(buf, static_cast<unsigned>(size), 0))
+        if (!fa->frawread(buf, static_cast<unsigned>(size), 0, true,  true))
         {
             size = -1;
             return true;
@@ -190,7 +190,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
                 if (!fa->frawread(block, sizeof block,
                                   (size - sizeof block)
                                   * (i * blocks + j)
-                                  / (sizeof crc / sizeof *crc * blocks - 1), i || j, true))
+                                  / (sizeof crc / sizeof *crc * blocks - 1), true,  true))
                 {
                     size = -1;
                     return true;
@@ -202,7 +202,6 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
             crc32.get((byte*)&crcval);
             newcrc[i] = htonl(crcval);
         }
-        fa->closef();
     }
 
     if (memcmp(crc, newcrc, sizeof crc))

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -148,7 +148,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
     if (size <= (m_off_t)sizeof crc)
     {
         // tiny file: read verbatim, NUL pad
-        if (!fa->frawread((byte*)newcrc, static_cast<unsigned>(size), 0, true,  true))
+        if (!fa->frawread((byte*)newcrc, static_cast<unsigned>(size), 0, true))
         {
             size = -1;
             fa->closef();
@@ -166,7 +166,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
         HashCRC32 crc32;
         byte buf[MAXFULL];
 
-        if (!fa->frawread(buf, static_cast<unsigned>(size), 0, true,  true))
+        if (!fa->frawread(buf, static_cast<unsigned>(size), 0, true))
         {
             size = -1;
             fa->closef();
@@ -198,7 +198,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
                 if (!fa->frawread(block, sizeof block,
                                   (size - sizeof block)
                                   * (i * blocks + j)
-                                  / (sizeof crc / sizeof *crc * blocks - 1), true,  true))
+                                  / (sizeof crc / sizeof *crc * blocks - 1), true))
                 {
                     size = -1;
                     fa->closef();

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -545,16 +545,19 @@ bool FileAccess::fread(string* dst, unsigned len, unsigned pad, m_off_t pos)
     return r;
 }
 
-bool FileAccess::frawread(byte* dst, unsigned len, m_off_t pos)
+bool FileAccess::frawread(byte* dst, unsigned len, m_off_t pos, bool skipopen, bool keepopen)
 {
-    if (!openf())
+    if (!skipopen && !openf())
     {
         return false;
     }
 
     bool r = sysread(dst, len, pos);
 
-    closef();
+    if (!keepopen)
+    {
+        closef();
+    }
 
     return r;
 }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -279,7 +279,7 @@ FileAccess::~FileAccess()
 // open file for reading
 bool FileAccess::fopen(string* name)
 {
-    localname.resize(1);
+    nonblocking_localname.resize(1);
     updatelocalname(name);
 
     return sysstat(&mtime, &size);
@@ -294,8 +294,9 @@ bool FileAccess::isfolder(string *name)
 // check if size and mtime are unchanged, then open for reading
 bool FileAccess::openf()
 {
-    if (!localname.size())
+    if (!nonblocking_localname.size())
     {
+        // file was not opened in nonblocking mode
         return true;
     }
 
@@ -322,7 +323,7 @@ bool FileAccess::openf()
 
 void FileAccess::closef()
 {
-    if (localname.size())
+    if (nonblocking_localname.size())
     {
         sysclose();
     }
@@ -339,7 +340,7 @@ void FileAccess::asyncopfinished(void *param)
 
 AsyncIOContext *FileAccess::asyncfopen(string *f)
 {
-    localname.resize(1);
+    nonblocking_localname.resize(1);
     updatelocalname(f);
 
     LOG_verbose << "Async open start";
@@ -365,7 +366,7 @@ AsyncIOContext *FileAccess::asyncfopen(string *f)
 bool FileAccess::asyncopenf()
 {
     numAsyncReads++;
-    if (!localname.size())
+    if (!nonblocking_localname.size())
     {
         return true;
     }
@@ -545,16 +546,16 @@ bool FileAccess::fread(string* dst, unsigned len, unsigned pad, m_off_t pos)
     return r;
 }
 
-bool FileAccess::frawread(byte* dst, unsigned len, m_off_t pos, bool skipopen, bool keepopen)
+bool FileAccess::frawread(byte* dst, unsigned len, m_off_t pos, bool caller_opened)
 {
-    if (!skipopen && !openf())
+    if (!caller_opened && !openf())
     {
         return false;
     }
 
     bool r = sysread(dst, len, pos);
 
-    if (!keepopen)
+    if (!caller_opened)
     {
         closef();
     }

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -670,7 +670,7 @@ bool mediaInfoOpenFileWithLimits(MediaInfoLib::MediaInfo& mi, std::string filena
             return false;
         }
 
-        if (!fa->frawread(buf, n, readpos))
+        if (!fa->frawread(buf, n, readpos, true,  true))
         {
             LOG_err << "could not read local file";
             mi.Open_Buffer_Finalize();

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -670,7 +670,7 @@ bool mediaInfoOpenFileWithLimits(MediaInfoLib::MediaInfo& mi, std::string filena
             return false;
         }
 
-        if (!fa->frawread(buf, n, readpos, true,  true))
+        if (!fa->frawread(buf, n, readpos, true))
         {
             LOG_err << "could not read local file";
             mi.Open_Buffer_Finalize();

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17428,6 +17428,7 @@ void MegaApiImpl::sendPendingTransfers()
                 if (!fa->fopen(&wLocalPath, true, false))
                 {
                     e = API_EREAD;
+                    delete fa;
                     break;
                 }
 
@@ -22949,7 +22950,7 @@ bool FileInputStream::read(byte *buffer, unsigned size)
         return false;
     }
 
-    if (fileAccess->sysread(buffer, size, offset))
+    if (fileAccess->frawread(buffer, size, offset, true, true))
     {
         offset += size;
         return true;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22950,7 +22950,7 @@ bool FileInputStream::read(byte *buffer, unsigned size)
         return false;
     }
 
-    if (fileAccess->frawread(buffer, size, offset, true, true))
+    if (fileAccess->frawread(buffer, size, offset, true))
     {
         offset += size;
         return true;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1721,7 +1721,7 @@ void LocalNode::prepare()
     getlocalpath(&transfer->localfilename, true);
 
     // is this transfer in progress? update file's filename.
-    if (transfer->slot && transfer->slot->fa && transfer->slot->fa->localname.size())
+    if (transfer->slot && transfer->slot->fa && transfer->slot->fa->nonblocking_localname.size())
     {
         transfer->slot->fa->updatelocalname(&transfer->localfilename);
     }

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -108,19 +108,19 @@ bool PosixFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
     retry = false;
 
 #ifdef USE_IOS
-    string localname = this->localname;
+    string nonblocking_localname = this->nonblocking_localname;
     if (PosixFileSystemAccess::appbasepath)
     {
-        if (localname.size() && localname.at(0) != '/')
+        if (nonblocking_localname.size() && nonblocking_localname.at(0) != '/')
         {
-            localname.insert(0, PosixFileSystemAccess::appbasepath);
+            nonblocking_localname.insert(0, PosixFileSystemAccess::appbasepath);
         }
     }
 #endif
 
     type = TYPE_UNKNOWN;
-    mIsSymLink = !lstat(localname.c_str(), &statbuf) && S_ISLNK(statbuf.st_mode);
-    if (!(mFollowSymLinks? stat(localname.c_str(), &statbuf) : lstat(localname.c_str(), &statbuf)))
+    mIsSymLink = !lstat(nonblocking_localname.c_str(), &statbuf) && S_ISLNK(statbuf.st_mode);
+    if (!(mFollowSymLinks? stat(nonblocking_localname.c_str(), &statbuf) : lstat(nonblocking_localname.c_str(), &statbuf)))
     {
         errorcode = 0;
         if (S_ISDIR(statbuf.st_mode))
@@ -145,24 +145,24 @@ bool PosixFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
 bool PosixFileAccess::sysopen(bool)
 {
 #ifdef USE_IOS
-    string localname = this->localname;
+    string nonblocking_localname = this->nonblocking_localname;
     if (PosixFileSystemAccess::appbasepath)
     {
-        if (localname.size() && localname.at(0) != '/')
+        if (nonblocking_localname.size() && nonblocking_localname.at(0) != '/')
         {
-            localname.insert(0, PosixFileSystemAccess::appbasepath);
+            nonblocking_localname.insert(0, PosixFileSystemAccess::appbasepath);
         }
     }
 #endif
 
     assert(fd < 0 && "There should be no opened file descriptor at this point");
     sysclose();
-    return (fd = open(localname.c_str(), O_RDONLY)) >= 0;
+    return (fd = open(nonblocking_localname.c_str(), O_RDONLY)) >= 0;
 }
 
 void PosixFileAccess::sysclose()
 {
-    assert(!localname.size() || fd >= 0);
+    assert(!nonblocking_localname.size() || fd >= 0);
     if (fd >= 0)
     {
         close(fd);
@@ -342,9 +342,9 @@ void PosixFileAccess::asyncsyswrite(AsyncIOContext *context)
 // update local name
 void PosixFileAccess::updatelocalname(string* name)
 {
-    if (localname.size())
+    if (nonblocking_localname.size())
     {
-        localname = *name;
+        nonblocking_localname = *name;
     }
 }
 

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -156,7 +156,15 @@ bool PosixFileAccess::sysopen(bool)
 #endif
 
     assert(fd < 0 && "There should be no opened file descriptor at this point");
-    sysclose();
+    if (fd >= 0)
+    {
+        sysclose();
+    }
+
+    assert(mFollowSymLinks); //Notice: symlinks are not considered here for the moment,
+    // this is ok: this is not called with mFollowSymLinks = false, but from transfers doio.
+    // When fully supporting symlinks, this might need to be reassessed
+
     return (fd = open(nonblocking_localname.c_str(), O_RDONLY)) >= 0;
 }
 

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -904,7 +904,6 @@ void Transfer::complete()
         for (file_list::iterator it = files.begin(); it != files.end(); )
         {
             File *f = (*it);
-            bool isOpen = true;
             FileAccess *fa = client->fsaccess->newfileaccess();
             string *localpath = &f->localname;
 
@@ -923,9 +922,9 @@ void Transfer::complete()
             }
 #endif
 
-            if (!fa->fopen(localpath))
+            bool isOpen = fa->fopen(localpath);
+            if (!isOpen)
             {
-                isOpen = false;
                 if (client->fsaccess->transient_error)
                 {
                     LOG_warn << "Retrying upload completion due to a transient error";

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -46,6 +46,7 @@ WinFileAccess::~WinFileAccess()
 bool WinFileAccess::sysread(byte* dst, unsigned len, m_off_t pos)
 {
     DWORD dwRead;
+    assert(hFile != INVALID_HANDLE_VALUE);
 
     if (!SetFilePointerEx(hFile, *(LARGE_INTEGER*)&pos, NULL, FILE_BEGIN))
     {
@@ -173,6 +174,8 @@ bool WinFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
 
 bool WinFileAccess::sysopen(bool async)
 {
+    assert(hFile == INVALID_HANDLE_VALUE);
+
 #ifdef WINDOWS_PHONE
     hFile = CreateFile2((LPCWSTR)localname.data(), GENERIC_READ,
                         FILE_SHARE_WRITE | FILE_SHARE_READ,
@@ -196,14 +199,13 @@ bool WinFileAccess::sysopen(bool async)
 
 void WinFileAccess::sysclose()
 {
-    if (localname.size())
+    assert(localname.size());
+    assert(hFile != INVALID_HANDLE_VALUE);
+
+    if (hFile != INVALID_HANDLE_VALUE)
     {
-        assert (hFile != INVALID_HANDLE_VALUE);
-        if (hFile != INVALID_HANDLE_VALUE)
-        {
-            CloseHandle(hFile);
-            hFile = INVALID_HANDLE_VALUE;
-        }
+        CloseHandle(hFile);
+        hFile = INVALID_HANDLE_VALUE;
     }
 }
 
@@ -427,6 +429,7 @@ bool WinFileAccess::fopen(string *name, bool read, bool write)
 bool WinFileAccess::fopen(string* name, bool read, bool write, bool async)
 {
     WIN32_FIND_DATA fad = { 0 };
+    assert(hFile == INVALID_HANDLE_VALUE);
 
 #ifdef WINDOWS_PHONE
     FILE_ID_INFO bhfi = { 0 };

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -132,10 +132,11 @@ m_time_t FileTime_to_POSIX(FILETIME* ft)
 
 bool WinFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
 {
+    assert(nonblocking_localname.size());
     WIN32_FILE_ATTRIBUTE_DATA fad;
 
     type = TYPE_UNKNOWN;
-    if (!GetFileAttributesExW((LPCWSTR)localname.data(), GetFileExInfoStandard, (LPVOID)&fad))
+    if (!GetFileAttributesExW((LPCWSTR)nonblocking_localname.data(), GetFileExInfoStandard, (LPVOID)&fad))
     {
         DWORD e = GetLastError();
         errorcode = e;
@@ -147,9 +148,9 @@ bool WinFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
     if (SimpleLogger::logCurrentLevel >= logDebug && skipattributes(fad.dwFileAttributes))
     {
         string utf8path;
-        utf8path.resize((localname.size() + 1) * 4 / sizeof(wchar_t));
-        utf8path.resize(WideCharToMultiByte(CP_UTF8, 0, (wchar_t*)localname.data(),
-                                         int(localname.size() / sizeof(wchar_t)),
+        utf8path.resize((nonblocking_localname.size() + 1) * 4 / sizeof(wchar_t));
+        utf8path.resize(WideCharToMultiByte(CP_UTF8, 0, (wchar_t*)nonblocking_localname.data(),
+                                         int(nonblocking_localname.size() / sizeof(wchar_t)),
                                          (char*)utf8path.data(),
                                          int(utf8path.size() + 1),
                                          NULL, NULL));
@@ -175,13 +176,14 @@ bool WinFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
 bool WinFileAccess::sysopen(bool async)
 {
     assert(hFile == INVALID_HANDLE_VALUE);
+    assert(nonblocking_localname.size());
 
 #ifdef WINDOWS_PHONE
     hFile = CreateFile2((LPCWSTR)localname.data(), GENERIC_READ,
                         FILE_SHARE_WRITE | FILE_SHARE_READ,
                         OPEN_EXISTING, NULL);
 #else
-    hFile = CreateFileW((LPCWSTR)localname.data(), GENERIC_READ,
+    hFile = CreateFileW((LPCWSTR)nonblocking_localname.data(), GENERIC_READ,
                         FILE_SHARE_WRITE | FILE_SHARE_READ,
                         NULL, OPEN_EXISTING, async ? FILE_FLAG_OVERLAPPED : 0, NULL);
 #endif
@@ -199,7 +201,7 @@ bool WinFileAccess::sysopen(bool async)
 
 void WinFileAccess::sysclose()
 {
-    assert(localname.size());
+    assert(nonblocking_localname.size());
     assert(hFile != INVALID_HANDLE_VALUE);
 
     if (hFile != INVALID_HANDLE_VALUE)
@@ -398,11 +400,11 @@ void WinFileAccess::asyncsyswrite(AsyncIOContext *context)
 // update local name
 void WinFileAccess::updatelocalname(string* name)
 {
-    if (localname.size())
+    if (nonblocking_localname.size())
     {
-        localname = *name;
-        WinFileSystemAccess::sanitizedriveletter(&localname);
-        localname.append("", 1);
+        nonblocking_localname = *name;
+        WinFileSystemAccess::sanitizedriveletter(&nonblocking_localname);
+        nonblocking_localname.append("", 1);
     }
 }
 

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -178,6 +178,11 @@ bool WinFileAccess::sysopen(bool async)
     assert(hFile == INVALID_HANDLE_VALUE);
     assert(nonblocking_localname.size());
 
+    if (hFile != INVALID_HANDLE_VALUE)
+    {
+        sysclose();
+    }
+
 #ifdef WINDOWS_PHONE
     hFile = CreateFile2((LPCWSTR)localname.data(), GENERIC_READ,
                         FILE_SHARE_WRITE | FILE_SHARE_READ,


### PR DESCRIPTION
Opening and closing them for each piece of the file read is much slower, on windows at least.