### PR TITLE
#13381. Optional code timings enabled by MEGA_MEASURE_CODE

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2682,7 +2682,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_find, sequence(text("find"), text("raided")));
 
 #ifdef MEGA_MEASURE_CODE
-    p->Add(exec_deferRequests, sequence(text("deferreqeusts"), repeat(either(flag("-putnodes")))));
+    p->Add(exec_deferRequests, sequence(text("deferrequests"), repeat(either(flag("-putnodes")))));
     p->Add(exec_sendDeferred, sequence(text("senddeferred"), opt(flag("-reset"))));
     p->Add(exec_codeTimings, sequence(text("codetimings"), opt(flag("-reset"))));
 #endif

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -75,6 +75,8 @@ using std::dec;
 MegaClient* client;
 MegaClient* clientFolder;
 
+bool gVerboseMode = false;
+
 
 // new account signup e-mail address and name
 static string signupemail, signupname;
@@ -291,22 +293,28 @@ void DemoApp::transfer_failed(Transfer* t, error e, dstime)
 
 void DemoApp::transfer_complete(Transfer* t)
 {
-    displaytransferdetails(t, "completed, ");
+    if (gVerboseMode)
+    {
+        displaytransferdetails(t, "completed, ");
 
-    if (t->slot)
-    {
-        cout << t->slot->progressreported * 10 / (1024 * (Waiter::ds - t->slot->starttime + 1)) << " KB/s" << endl;
-    }
-    else
-    {
-        cout << "delayed" << endl;
+        if (t->slot)
+        {
+            cout << t->slot->progressreported * 10 / (1024 * (Waiter::ds - t->slot->starttime + 1)) << " KB/s" << endl;
+        }
+        else
+        {
+            cout << "delayed" << endl;
+        }
     }
 }
 
 // transfer about to start - make final preparations (determine localfilename, create thumbnail for image upload)
 void DemoApp::transfer_prepare(Transfer* t)
 {
-    displaytransferdetails(t, "starting\n");
+    if (gVerboseMode)
+    {
+        displaytransferdetails(t, "starting\n");
+    }
 
     if (t->type == GET)
     {
@@ -1193,13 +1201,16 @@ void DemoApp::getua_result(byte* data, unsigned l, attr_t type)
         return;
     }
 
-    cout << "Received " << l << " byte(s) of user attribute: ";
-    fwrite(data, 1, l, stdout);
-    cout << endl;
-
-    if (type == ATTR_ED25519_PUBK)
+    if (gVerboseMode)
     {
-        cout << "Credentials: " << AuthRing::fingerprint(string((const char*)data, l), true) << endl;
+        cout << "Received " << l << " byte(s) of user attribute: ";
+        fwrite(data, 1, l, stdout);
+        cout << endl;
+
+        if (type == ATTR_ED25519_PUBK)
+        {
+            cout << "Credentials: " << AuthRing::fingerprint(string((const char*)data, l), true) << endl;
+        }
     }
 }
 
@@ -1214,7 +1225,7 @@ void DemoApp::getua_result(TLVstore *tlv, attr_t type)
     {
         cout << "Error getting private user attribute" << endl;
     }
-    else
+    else if (!gVerboseMode)
     {
         cout << "Received a TLV with " << tlv->size() << " item(s) of user attribute: " << endl;
 
@@ -2339,6 +2350,42 @@ Node* nodeFromRemotePath(const string& s)
     return n;
 }
 
+#ifdef MEGA_MEASURE_CODE
+
+void exec_deferRequests(autocomplete::ACState& s)
+{
+    // cause all the API requests of this type to be gathered up so they will be sent in a single batch, for timing purposes
+    bool putnodes = s.extractflag("-putnodes");
+    bool movenode = s.extractflag("-movenode");
+    bool delnode = s.extractflag("-delnode");
+
+    client->reqs.deferRequests =    [=](Command* c)
+                                    { 
+                                        return  (putnodes && dynamic_cast<CommandPutNodes*>(c)) ||
+                                                (movenode && dynamic_cast<CommandMoveNode*>(c)) ||
+                                                (delnode && dynamic_cast<CommandDelNode*>(c));
+                                    };
+}
+
+void exec_sendDeferred(autocomplete::ACState& s)
+{
+    // send those gathered up commands, and optionally reset the gathering 
+    client->reqs.sendDeferred();
+    
+    if (s.extractflag("-reset"))
+    {
+        client->reqs.deferRequests = nullptr;
+    }
+}
+
+void exec_codeTimings(autocomplete::ACState& s)
+{
+    bool reset = s.extractflag("-reset");
+    cout << client->performanceStats.report(reset, client->httpio, client->waiter) << flush;
+}
+
+#endif
+
 #ifdef USE_FILESYSTEM
 fs::path pathFromLocalPath(const string& s, bool mustexist)
 {
@@ -2360,6 +2407,58 @@ void exec_treecompare(autocomplete::ACState& s)
         recursiveCompare(n, p);
     }
 }
+
+
+bool buildLocalFolders(fs::path targetfolder, const string& prefix, int foldersperfolder, int recurselevel, int filesperfolder, int filesize, int& totalfilecount, int& totalfoldercount)
+{
+    fs::path p = targetfolder / fs::u8path(prefix);
+    if (!fs::create_directory(p))
+        return false;
+    ++totalfoldercount;
+
+    for (int i = 0; i < filesperfolder; ++i)
+    {
+        string filename = prefix + "_file_" + std::to_string(++totalfilecount);
+        fs::path fp = p / fs::u8path(filename);
+        ofstream fs(fp.u8string(), std::ios::binary);
+        
+        for (unsigned j = filesize / sizeof(int); j--; )
+        {
+            fs.write((char*)&totalfilecount, sizeof(int));
+        }
+        fs.write((char*)&totalfilecount, filesize % sizeof(int));
+    }
+
+    if (recurselevel > 1)
+    {
+        for (int i = 0; i < foldersperfolder; ++i)
+        {
+            if (!buildLocalFolders(p, prefix + "_" + std::to_string(i), foldersperfolder, recurselevel - 1, filesperfolder, filesize, totalfilecount, totalfoldercount))
+                return false;
+        }
+    }
+    return true;
+}
+
+void exec_generatetestfilesfolders(autocomplete::ACState& s)
+{
+    string param, nameprefix = "test";
+    int folderdepth = 1, folderwidth = 1, filecount = 100, filesize = 1024;
+    if (s.extractflagparam("-folderdepth", param)) folderdepth = atoi(param.c_str());
+    if (s.extractflagparam("-folderwidth", param)) folderwidth = atoi(param.c_str());
+    if (s.extractflagparam("-filecount", param)) filecount = atoi(param.c_str());
+    if (s.extractflagparam("-filesize", param)) filesize = atoi(param.c_str());
+    if (s.extractflagparam("-nameprefix", param)) nameprefix = param;
+
+    fs::path p = pathFromLocalPath(s.words[1].s, true);
+    if (!p.empty())
+    {
+        int totalfilecount = 0, totalfoldercount = 0;
+        buildLocalFolders(p, nameprefix, folderwidth, folderdepth, filecount, filesize, totalfilecount, totalfoldercount);
+        cout << "created " << totalfilecount << " files and " << totalfoldercount << " folders";
+    }
+}
+
 #endif
 
 void exec_getcloudstorageused(autocomplete::ACState& s)
@@ -2496,7 +2595,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_smsverify, sequence(text("smsverify"), either(sequence(text("send"), param("phonenumber"), opt(param("reverifywhitelisted"))), sequence(text("code"), param("verificationcode")))));
     p->Add(exec_verifiedphonenumber, sequence(text("verifiedphone")));
     p->Add(exec_mkdir, sequence(text("mkdir"), remoteFSFolder(client, &cwd)));
-    p->Add(exec_rm, sequence(text("rm"), remoteFSPath(client, &cwd)));
+    p->Add(exec_rm, sequence(text("rm"), remoteFSPath(client, &cwd), opt(sequence(flag("-regexchild"), param("regex")))));
     p->Add(exec_mv, sequence(text("mv"), remoteFSPath(client, &cwd, "src"), remoteFSPath(client, &cwd, "dst")));
     p->Add(exec_cp, sequence(text("cp"), remoteFSPath(client, &cwd, "src"), either(remoteFSPath(client, &cwd, "dst"), param("dstemail"))));
     p->Add(exec_du, sequence(text("du"), remoteFSPath(client, &cwd)));
@@ -2537,7 +2636,8 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_locallogout, sequence(text("locallogout")));
     p->Add(exec_symlink, sequence(text("symlink")));
     p->Add(exec_version, sequence(text("version")));
-    p->Add(exec_debug, sequence(text("debug")));
+    p->Add(exec_debug, sequence(text("debug"), opt(either(flag("-on"), flag("-off")))));
+    p->Add(exec_verbose, sequence(text("verbose"), opt(either(flag("-on"), flag("-off")))));
 #if defined(WIN32) && defined(NO_READLINE)
     p->Add(exec_clear, sequence(text("clear")));
     p->Add(exec_codepage, sequence(text("codepage"), opt(sequence(wholenumber(65001), opt(wholenumber(65001))))));
@@ -2580,8 +2680,20 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_quit, either(text("quit"), text("q"), text("exit")));
 
     p->Add(exec_find, sequence(text("find"), text("raided")));
+
+#ifdef MEGA_MEASURE_CODE
+    p->Add(exec_deferRequests, sequence(text("deferreqeusts"), repeat(either(flag("-putnodes")))));
+    p->Add(exec_sendDeferred, sequence(text("senddeferred"), opt(flag("-reset"))));
+    p->Add(exec_codeTimings, sequence(text("codetimings"), opt(flag("-reset"))));
+#endif
+
 #ifdef USE_FILESYSTEM
     p->Add(exec_treecompare, sequence(text("treecompare"), localFSPath(), remoteFSPath(client, &cwd)));
+    p->Add(exec_generatetestfilesfolders, sequence(text("generatetestfilesfolders"), repeat(either(sequence(flag("-folderdepth"), param("depth")), 
+                                                                                                   sequence(flag("-folderwidth"), param("width")), 
+                                                                                                   sequence(flag("-filecount"), param("count")), 
+                                                                                                   sequence(flag("-filesize"), param("size")), 
+                                                                                                   sequence(flag("-nameprefix"), param("prefix")))), localFSFolder("parent")));
 #endif
     p->Add(exec_querytransferquota, sequence(text("querytransferquota"), param("filesize")));
     p->Add(exec_getcloudstorageused, sequence(text("getcloudstorageused")));
@@ -2922,28 +3034,48 @@ void exec_cd(autocomplete::ACState& s)
 
 void exec_rm(autocomplete::ACState& s)
 {
-    if (s.words.size() > 1)
-    {
-        if (Node* n = nodebypath(s.words[1].s.c_str()))
-        {
-            if (client->checkaccess(n, FULL))
-            {
-                error e = client->unlink(n);
+    string childregexstring;
+    bool useregex = s.extractflagparam("-regexchild", childregexstring);
 
-                if (e)
-                {
-                    cout << s.words[1].s << ": Deletion failed (" << errorstring(e) << ")" << endl;
-                }
-            }
-            else
+    if (Node* n = nodebypath(s.words[1].s.c_str()))
+    {
+        vector<Node*> v;
+        if (useregex)
+        {
+            std::regex re(childregexstring);
+            for (Node* c : n->children)
             {
-                cout << s.words[1].s << ": Access denied" << endl;
+                if (std::regex_match(c->displayname(), re))
+                {
+                    v.push_back(c);
+                }
             }
         }
         else
         {
-            cout << s.words[1].s << ": No such file or directory" << endl;
+            v.push_back(n);
         }
+
+        for (auto d : v)
+        {
+            if (client->checkaccess(d, FULL))
+            {
+                error e = client->unlink(d);
+
+                if (e)
+                {
+                    cout << d->displaypath() << ": Deletion failed (" << errorstring(e) << ")" << endl;
+                }
+            }
+            else
+            {
+                cout << d->displaypath() << ": Access denied" << endl;
+            }
+        }
+    }
+    else
+    {
+        cout << s.words[1].s << ": No such file or directory" << endl;
     }
 }
 
@@ -3437,7 +3569,10 @@ void exec_put(autocomplete::ACState& s)
         while (da->dnext(NULL, &localname, true, &type))
         {
             client->fsaccess->local2path(&localname, &name);
-            cout << "Queueing " << name << "..." << endl;
+            if (gVerboseMode)
+            {
+                cout << "Queueing " << name << "..." << endl;
+            }
 
             if (type == FILENODE)
             {
@@ -4296,7 +4431,36 @@ void exec_pause(autocomplete::ACState& s)
 
 void exec_debug(autocomplete::ACState& s)
 {
-    cout << "Debug mode " << (client->toggledebug() ? "on" : "off") << endl;
+    bool turnon = s.extractflag("-on");
+    bool turnoff = s.extractflag("-off");
+
+    bool state = client->debugstate();
+    if ((turnon && !state) || (turnoff && state) || (!turnon && !turnoff))
+    {
+        client->toggledebug();
+    }
+
+    cout << "Debug mode " << (client->debugstate() ? "on" : "off") << endl;
+}
+
+void exec_verbose(autocomplete::ACState& s)
+{
+    bool turnon = s.extractflag("-on");
+    bool turnoff = s.extractflag("-off");
+
+    if (turnon)
+    {
+        gVerboseMode = true;
+    }
+    else if (turnoff)
+    {
+        gVerboseMode = false;
+    }
+    else
+    {
+        gVerboseMode = !gVerboseMode;
+    }
+    cout << "Verbose mode " << (gVerboseMode ? "on" : "off") << endl;
 }
 
 #if defined(WIN32) && defined(NO_READLINE)
@@ -7142,8 +7306,22 @@ void megacli()
             }
         }
 
+
+        auto puts = appxferq[PUT].size();
+        auto gets = appxferq[GET].size();
+
         // pass the CPU to the engine (nonblocking)
         client->exec();
+
+        if (puts && !appxferq[PUT].size())
+        {
+            cout << "Uploads complete" << endl;
+        }
+        if (gets && !appxferq[GET].size())
+        {
+            cout << "Downloads complete" << endl;
+        }
+
 
         if (clientFolder)
         {
@@ -7158,8 +7336,11 @@ public:
     void log(const char*, int loglevel, const char*, const char *message) override
     {
 #ifdef _WIN32
-        OutputDebugStringA(message);
-        OutputDebugStringA("\r\n");
+        string s;
+        s.reserve(1024);
+        s += message;
+        s += "\r\n";
+        OutputDebugStringA(s.c_str());
 #else
         if (loglevel >= SimpleLogger::logCurrentLevel)
         {

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -335,6 +335,7 @@ void exec_locallogout(autocomplete::ACState& s);
 void exec_symlink(autocomplete::ACState& s);
 void exec_version(autocomplete::ACState& s);
 void exec_debug(autocomplete::ACState& s);
+void exec_verbose(autocomplete::ACState& s);
 void exec_clear(autocomplete::ACState& s);
 void exec_codepage(autocomplete::ACState& s);
 void exec_log(autocomplete::ACState& s);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1531,6 +1531,28 @@ public:
     // -1: expired, 0: inactive (no business subscription), 1: active, 2: grace-period
     BizStatus mBizStatus;
 
+    // Keep track of high level operation counts and times, for performance analysis
+    struct PerformanceStats
+    {
+        CodeCounter::ScopeStats execFunction = { "MegaClient_exec" };
+        CodeCounter::ScopeStats transferslotDoio = { "TransferSlot_doio" };
+        CodeCounter::ScopeStats execdirectreads = { "execdirectreads" };
+        CodeCounter::ScopeStats transferComplete = { "transfer_complete" };
+        CodeCounter::ScopeStats prepareWait = { "MegaClient_prepareWait" };
+        CodeCounter::ScopeStats doWait = { "MegaClient_doWait" };
+        CodeCounter::ScopeStats checkEvents = { "MegaClient_checkEvents" };
+        CodeCounter::ScopeStats applyKeys = { "MegaClient_applyKeys" };
+        CodeCounter::ScopeStats dispatchTransfers = { "dispatchTransfers" };
+        CodeCounter::ScopeStats csResponseProcessingTime = { "cs batch response processing" };
+        CodeCounter::ScopeStats scProcessingTime = { "sc processing" };
+        uint64_t transferStarts = 0, transferFinishes = 0;
+        uint64_t transferTempErrors = 0, transferFails = 0;
+        uint64_t prepwaitImmediate = 0, prepwaitZero = 0, prepwaitHttpio = 0, prepwaitFsaccess = 0, nonzeroWait = 0;
+        CodeCounter::DurationSum csRequestWaitTime;
+        CodeCounter::DurationSum transfersActiveTime;
+        std::string report(bool reset, HttpIO* httpio, Waiter* waiter);
+    } performanceStats;
+
     MegaClient(MegaApp*, Waiter*, HttpIO*, FileSystemAccess*, DbAccess*, GfxProc*, const char*, const char*);
     ~MegaClient();
 };

--- a/include/mega/posix/meganet.h
+++ b/include/mega/posix/meganet.h
@@ -184,6 +184,12 @@ public:
 
     CurlHttpIO();
     ~CurlHttpIO();
+
+    CodeCounter::ScopeStats countCurlHttpIOAddevents = { "curl-httpio-addevents" };
+    CodeCounter::ScopeStats countAddAresEventsCode = { "ares-add-events" };
+    CodeCounter::ScopeStats countAddCurlEventsCode = { "curl-add-events" };
+    CodeCounter::ScopeStats countProcessAresEventsCode = { "ares-process-events" };
+    CodeCounter::ScopeStats countProcessCurlEventsCode = { "curl-process-events" };
 };
 
 struct MEGA_API CurlHttpContext

--- a/include/mega/request.h
+++ b/include/mega/request.h
@@ -88,6 +88,15 @@ public:
     void servererror(error, MegaClient*);
 
     void clear();
+
+#ifdef MEGA_MEASURE_CODE
+    Request deferredRequests;
+    std::function<bool(Command*)> deferRequests;
+    void sendDeferred();
+    uint64_t csRequestsSent = 0, csRequestsCompleted = 0;
+    uint64_t csBatchesSent = 0, csBatchesReceived = 0;
+#endif
+
 };
 
 } // namespace

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -74,6 +74,7 @@ typedef unsigned char byte;
 
 #include <memory>
 #include <string>
+#include <chrono>
 
 namespace mega {
 
@@ -585,6 +586,88 @@ template<class T, class... constructorArgs>
 unique_ptr<T> make_unique(constructorArgs&&... args)
 {
     return (unique_ptr<T>(new T(std::forward<constructorArgs>(args)...)));
+}
+
+//#define MEGA_MEASURE_CODE   // uncomment this to track time spent in major subsystems, and log it every 2 minutes, with extra control from megacli
+
+namespace CodeCounter
+{
+    // Some classes that allow us to easily measure the number of times a block of code is called, and the sum of the time it takes.
+    // Only enabled if MEGA_MEASURE_CODE is turned on.
+    // Usage generally doesn't need to be protected by the macro as the classes and methods will be empty when not enabled.
+
+    using namespace std::chrono;
+
+    struct ScopeStats
+    {
+#ifdef MEGA_MEASURE_CODE
+        uint64_t count = 0;
+        uint64_t starts = 0;
+        uint64_t finishes = 0;
+        high_resolution_clock::duration timeSpent{};
+        std::string name;
+        ScopeStats(std::string s) : name(std::move(s)) {}
+
+        inline string report(bool reset = false) 
+        { 
+            string s = " " + name + ": " + std::to_string(count) + " " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(timeSpent).count()); 
+            if (reset)
+            {
+                count = 0;
+                starts -= finishes;
+                finishes = 0;
+                timeSpent = high_resolution_clock::duration{};
+            }
+            return s;
+        }
+#else
+        ScopeStats(std::string s) {}
+#endif
+    };
+
+    struct DurationSum
+    {
+#ifdef MEGA_MEASURE_CODE
+        high_resolution_clock::duration sum{ 0 };
+        high_resolution_clock::time_point deltaStart;
+        bool started = false;
+        inline void start(bool b = true) { if (b && !started) { deltaStart = high_resolution_clock::now(); started = true; }  }
+        inline void stop(bool b = true) { if (b && started) { sum += high_resolution_clock::now() - deltaStart; started = false; } }
+        inline bool inprogress() { return started; }
+        inline string report(bool reset = false) 
+        { 
+            string s = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(sum).count()); 
+            if (reset) sum = high_resolution_clock::duration{ 0 };
+            return s;
+        }
+#else
+        inline void start(bool = true) {  }
+        inline void stop(bool = true) {  }
+#endif
+    };
+
+    struct ScopeTimer
+    {
+#ifdef MEGA_MEASURE_CODE
+        ScopeStats& scope;
+        high_resolution_clock::time_point blockStart;
+
+        ScopeTimer(ScopeStats& sm) : scope(sm), blockStart(high_resolution_clock::now())
+        {
+            ++scope.starts;
+        }
+        ~ScopeTimer()
+        {
+            ++scope.count;
+            ++scope.finishes;
+            scope.timeSpent += high_resolution_clock::now() - blockStart;
+        }
+#else
+        ScopeTimer(ScopeStats& sm)
+        {
+        }
+#endif
+    };
 }
 
 } // namespace

--- a/include/mega/win32/megaconsole.h
+++ b/include/mega/win32/megaconsole.h
@@ -62,7 +62,7 @@ struct MEGA_API ConsoleModel
     size_t insertPos = 0;
 
     // we can receive multiple newlines in a single key event. All these must be consumed before we check for more keypresses
-    unsigned newlinesBuffered = 0;
+    bool newlinesBuffered = false;
 
     // remember the last N commands executed 
     std::deque<std::wstring> inputHistory;

--- a/include/mega/win32/megawaiter.h
+++ b/include/mega/win32/megawaiter.h
@@ -43,6 +43,15 @@ public:
     WinWaiter();
     ~WinWaiter();
 
+#ifdef MEGA_MEASURE_CODE
+    struct PerformanceStats
+    {
+        uint64_t waitTimedoutNonzero = 0;
+        uint64_t waitTimedoutZero = 0;
+        uint64_t waitIOCompleted = 0;
+        uint64_t waitSignalled= 0;
+    } performanceStats;
+#endif
 
 protected:
     HANDLE externalEvent;

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -364,6 +364,7 @@ void CurlHttpIO::filterDNSservers()
 
 void CurlHttpIO::addaresevents(Waiter *waiter)
 {
+    CodeCounter::ScopeTimer ccst(countAddAresEventsCode);
     closearesevents();
 
     ares_socket_t socks[ARES_GETSOCK_MAXNUM];
@@ -433,6 +434,7 @@ void CurlHttpIO::addaresevents(Waiter *waiter)
 
 void CurlHttpIO::addcurlevents(Waiter *waiter, direction_t d)
 {
+    CodeCounter::ScopeTimer ccst(countAddCurlEventsCode);
     SockInfoMap &socketmap = curlsockets[d];
     for (SockInfoMap::iterator it = socketmap.begin(); it != socketmap.end(); it++)
     {
@@ -521,6 +523,7 @@ void CurlHttpIO::closecurlevents(direction_t d)
 
 void CurlHttpIO::processaresevents()
 {
+    CodeCounter::ScopeTimer ccst(countProcessAresEventsCode);
 #ifndef _WIN32
     fd_set *rfds = &((PosixWaiter *)waiter)->rfds;
     fd_set *wfds = &((PosixWaiter *)waiter)->wfds;
@@ -566,6 +569,8 @@ void CurlHttpIO::processaresevents()
 
 void CurlHttpIO::processcurlevents(direction_t d)
 {
+    CodeCounter::ScopeTimer ccst(countProcessCurlEventsCode);
+
 #ifndef _WIN32
     fd_set *rfds = &((PosixWaiter *)waiter)->rfds;
     fd_set *wfds = &((PosixWaiter *)waiter)->wfds;
@@ -785,6 +790,8 @@ m_off_t CurlHttpIO::getmaxuploadspeed()
 // wake up from cURL I/O
 void CurlHttpIO::addevents(Waiter* w, int)
 {
+    CodeCounter::ScopeTimer ccst(countCurlHttpIOAddevents);
+
     waiter = (WAIT_CLASS*)w;
     long curltimeoutms = -1;
 

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -362,6 +362,7 @@ void Transfer::failed(error e, dstime timeleft)
             state = TRANSFERSTATE_RETRYING;
             client->app->transfer_failed(this, e, timeleft);
             client->looprequested = true;
+            ++client->performanceStats.transferTempErrors;
         }
         else
         {
@@ -370,6 +371,7 @@ void Transfer::failed(error e, dstime timeleft)
             if (!slot)
             {
                 client->app->transfer_failed(this, e, timeleft);
+                ++client->performanceStats.transferTempErrors;
             }
         }
     }
@@ -429,6 +431,7 @@ void Transfer::failed(error e, dstime timeleft)
             client->app->file_removed(*it, e);
         }
         client->app->transfer_removed(this);
+        ++client->performanceStats.transferFails;
         delete this;
     }
 }
@@ -481,6 +484,8 @@ void Transfer::addAnyMissingMediaFileAttributes(Node* node, /*const*/ std::strin
 // fingerprint, notify app, notify files
 void Transfer::complete()
 {
+    CodeCounter::ScopeTimer ccst(client->performanceStats.transferComplete);
+
     state = TRANSFERSTATE_COMPLETING;
     client->app->transfer_update(this);
 

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -243,6 +243,7 @@ TransferSlot::~TransferSlot()
         }
 
         transfer->client->tslots.erase(slots_it);
+        transfer->client->performanceStats.transferFinishes += 1;
     }
 
     if (pendingcmd)
@@ -334,6 +335,8 @@ int64_t TransferSlot::macsmac(chunkmac_map* m)
 // file transfer state machine
 void TransferSlot::doio(MegaClient* client)
 {
+    CodeCounter::ScopeTimer pbt(client->performanceStats.transferslotDoio);
+
     if (!fa || (transfer->size && transfer->progresscompleted == transfer->size)
             || (transfer->type == PUT && transfer->ultoken))
     {
@@ -926,6 +929,7 @@ void TransferSlot::doio(MegaClient* client)
 
                             client->app->transfer_failed(transfer, API_EFAILED);
                             client->setchunkfailed(&reqs[i]->posturl);
+                            ++client->performanceStats.transferTempErrors;
 
                             if (changeport)
                             {
@@ -1159,6 +1163,7 @@ void TransferSlot::doio(MegaClient* client)
         {
             LOG_warn << "Chunk failed due to a timeout";
             client->app->transfer_failed(transfer, API_EFAILED);
+            ++client->performanceStats.transferTempErrors;
         }
     }
 

--- a/src/win32/waiter.cpp
+++ b/src/win32/waiter.cpp
@@ -109,6 +109,13 @@ int WinWaiter::wait()
         EnterCriticalSection(pcsHTTP);
     }
 
+#ifdef MEGA_MEASURE_CODE
+    if (dwWaitResult == WAIT_TIMEOUT && maxds > 0) ++performanceStats.waitTimedoutNonzero;
+    else if (dwWaitResult == WAIT_TIMEOUT && maxds == 0) ++performanceStats.waitTimedoutZero;
+    else if (dwWaitResult == WAIT_IO_COMPLETION) ++performanceStats.waitIOCompleted;
+    else if (dwWaitResult >= WAIT_OBJECT_0) ++performanceStats.waitSignalled;
+#endif
+
     if ((dwWaitResult == WAIT_TIMEOUT) || (dwWaitResult == WAIT_IO_COMPLETION) || maxds == 0)
     {
         r = NEEDEXEC;


### PR DESCRIPTION
Measures some high level items, and some details about the wait system.
Simple to output or reset data in megacli
Also for megacli:  verbose mode (default off), deferrable requests (to send all putnodes in one batch for example), generate test files/folders, selective bulk `rm` of items from one folder
Also updated console.cpp with a fix where it would get stuck on multiple newlines in its console buffer.