### PR TITLE
WIP: assure no fd are left open by PosixFileAccess

### DIFF
--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -133,8 +133,10 @@ struct MEGA_API PosixAsyncIOContext : public AsyncIOContext
 
 class MEGA_API PosixFileAccess : public FileAccess
 {
-public:
+private:
     int fd;
+public:
+    int stealFileDescriptor();
     int defaultfilepermissions;
 
 #ifndef HAVE_FDOPENDIR

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -142,7 +142,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
     if (size <= (m_off_t)sizeof crc)
     {
         // tiny file: read verbatim, NUL pad
-        if (!fa->frawread((byte*)newcrc, static_cast<unsigned>(size), 0))
+        if (!fa->frawread((byte*)newcrc, static_cast<unsigned>(size), 0, true,  true))
         {
             size = -1;
             return true;
@@ -159,7 +159,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
         HashCRC32 crc32;
         byte buf[MAXFULL];
 
-        if (!fa->frawread(buf, static_cast<unsigned>(size), 0))
+        if (!fa->frawread(buf, static_cast<unsigned>(size), 0, true,  true))
         {
             size = -1;
             return true;
@@ -190,7 +190,7 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
                 if (!fa->frawread(block, sizeof block,
                                   (size - sizeof block)
                                   * (i * blocks + j)
-                                  / (sizeof crc / sizeof *crc * blocks - 1), i || j, true))
+                                  / (sizeof crc / sizeof *crc * blocks - 1), true,  true))
                 {
                     size = -1;
                     return true;
@@ -202,7 +202,6 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
             crc32.get((byte*)&crcval);
             newcrc[i] = htonl(crcval);
         }
-        fa->closef();
     }
 
     if (memcmp(crc, newcrc, sizeof crc))

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -670,7 +670,7 @@ bool mediaInfoOpenFileWithLimits(MediaInfoLib::MediaInfo& mi, std::string filena
             return false;
         }
 
-        if (!fa->frawread(buf, n, readpos))
+        if (!fa->frawread(buf, n, readpos, true,  true))
         {
             LOG_err << "could not read local file";
             mi.Open_Buffer_Finalize();


### PR DESCRIPTION
The same should be applied to non posix filesystems

- sysclose does always close the fd (even if no localname)
- fd made private to ensure its not stealed without being reset to -1
- always close opened file descriptor before opening new ones
- genfingerprint does not open the file for every frawread and no longer
closes the file descriptor! (will be close upon FileAccess destructor)
- similar to mediafileattribute calls to frawread

Some asserts might fail while the execution might be correct. They are
intended to detect unrequired reopening of file descriptors for further
corrections