### PR TITLE
#13392. Hotfix UTF8 encoding support - v3.6.3

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1309,14 +1309,8 @@ TLVstore * TLVstore::containerToTLVrecords(const string *data)
         pos = data->find('\0', offset);
         typelen = pos - offset;
 
-        if (pos == string::npos)
-        {
-            LOG_warn << "Invalid record in the TLV";
-            return tlv;
-        }
-
         // if no valid TLV record in the container, but remaining bytes...
-        if (offset + typelen + 3 > datalen)
+        if (pos == string::npos || offset + typelen + 3 > datalen)
         {
             delete tlv;
             return NULL;


### PR DESCRIPTION
Empty TLVs should be detected earlier, at the decryption stage, by checking the size of the clear text