### PR TITLE
#13436: Converted newfileaccess() to return a unique_ptr to get compiler supp…

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -1911,19 +1911,14 @@ public:
 
 int loadfile(string* name, string* data)
 {
-    FileAccess* fa = client->fsaccess->newfileaccess();
+    auto fa = client->fsaccess->newfileaccess();
 
     if (fa->fopen(name, 1, 0))
     {
         data->resize(size_t(fa->size));
         fa->fread(data, unsigned(data->size()), 0, 0);
-        delete fa;
-
         return 1;
     }
-
-    delete fa;
-
     return 0;
 }
 
@@ -3576,11 +3571,11 @@ void exec_put(autocomplete::ACState& s)
 
             if (type == FILENODE)
             {
-                FileAccess *fa = client->fsaccess->newfileaccess();
+                auto fa = client->fsaccess->newfileaccess();
                 if (fa->fopen(&name, true, false))
                 {
                     FileFingerprint fp;
-                    fp.genfingerprint(fa);
+                    fp.genfingerprint(fa.get());
 
                     Node *previousNode = client->childnodebyname(n, name.c_str(), true);
                     if (previousNode && previousNode->type == type)
@@ -3588,12 +3583,11 @@ void exec_put(autocomplete::ACState& s)
                         if (fp.isvalid && previousNode->isvalid && fp == *((FileFingerprint *)previousNode))
                         {
                             cout << "Identical file already exist. Skipping transfer of " << name << endl;
-                            delete fa;
                             continue;
                         }
                     }
                 }
-                delete fa;
+                fa.reset();
 
                 f = new AppFilePut(&localname, target, targetuser.c_str());
                 f->appxfer_it = appxferq[PUT].insert(appxferq[PUT].end(), f);

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -238,7 +238,7 @@ struct MEGA_API FileSystemAccess : public EventTrigger
      * @param followSymLinks whether symlinks should be followed when opening a path (default: true)
      * @return
      */
-    virtual FileAccess* newfileaccess(bool followSymLinks = true) = 0;
+    virtual std::unique_ptr<FileAccess> newfileaccess(bool followSymLinks = true) = 0;
 
     // instantiate DirAccess object
     virtual DirAccess* newdiraccess() = 0;

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -80,7 +80,7 @@ public:
     int defaultfilepermissions;
     int defaultfolderpermissions;
 
-    FileAccess* newfileaccess(bool followSymLinks = true) override;
+    std::unique_ptr<FileAccess> newfileaccess(bool followSymLinks = true) override;
     DirAccess* newdiraccess() override;
     DirNotify* newdirnotify(string*, string*) override;
 

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -128,7 +128,7 @@ public:
     string debris, localdebris;
 
     // permanent lock on the debris/tmp folder
-    FileAccess* tmpfa;
+    std::unique_ptr<FileAccess> tmpfa;
 
     // state cache table
     DbTable* statecachetable;

--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -35,7 +35,7 @@ struct MEGA_API TransferSlot
     struct Transfer* transfer;
 
     // associated source/destination file
-    FileAccess* fa;
+    std::unique_ptr<FileAccess> fa;
 
     // command in flight to obtain temporary URL
     Command* pendingcmd;

--- a/include/mega/win32/megafs.h
+++ b/include/mega/win32/megafs.h
@@ -44,7 +44,7 @@ struct MEGA_API WinDirNotify;
 class MEGA_API WinFileSystemAccess : public FileSystemAccess
 {
 public:
-    FileAccess* newfileaccess(bool followSymLinks = true) override;
+    std::unique_ptr<FileAccess> newfileaccess(bool followSymLinks = true) override;
     DirAccess* newdiraccess() override;
     DirNotify* newdirnotify(string*, string*) override;
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2924,6 +2924,10 @@ protected:
         bool sync_syncable(Sync *, const char*, string *, Node *) override;
         bool sync_syncable(Sync *, const char*, string *) override;
         void syncupdate_local_lockretry(bool) override;
+
+        // for the exclusive use of sync_syncable
+        unique_ptr<FileAccess> mSyncable_fa;
+        std::mutex mSyncable_fa_mutex;
 #endif
 
 protected:

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -3260,7 +3260,7 @@ public:
     std::string host;
     std::string destination;
     bool overwrite;
-    FileAccess *tmpFileAccess;
+    std::unique_ptr<FileAccess> tmpFileAccess;
     std::string tmpFileName;
     std::string newname; //newname for moved node
     MegaHandle nodeToMove; //node to be moved after delete
@@ -3532,7 +3532,7 @@ public:
     m_off_t rangeWritten;
 
     std::string tmpFileName;
-    FileAccess* tmpFileAccess;
+    std::unique_ptr<FileAccess> tmpFileAccess;
     size_t tmpFileSize;
 
     bool controlRespondedElsewhere;

--- a/src/db/sqlite.cpp
+++ b/src/db/sqlite.cpp
@@ -55,10 +55,10 @@ DbTable* SqliteDbAccess::open(PrnGen &rng, FileSystemAccess* fsaccess, string* n
     string currentdbpath = newoss.str();
 
     string locallegacydbpath;
-    FileAccess *fa = fsaccess->newfileaccess();
+    auto fa = fsaccess->newfileaccess();
     fsaccess->path2local(&legacydbpath, &locallegacydbpath);
     bool legacydbavailable = fa->fopen(&locallegacydbpath);
-    delete fa;
+    fa.reset();
 
     if (legacydbavailable)
     {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -504,8 +504,7 @@ void SyncFileGet::prepare()
             // back to the sync's root
             if (i < 0)
             {
-                delete sync->tmpfa;
-                sync->tmpfa = NULL;
+                sync->tmpfa.reset();
             }
         }
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -217,7 +217,7 @@ void DirNotify::notify(notifyqueue q, LocalNode* l, const char* localpath, size_
             tmppath.append(path);
         }
         attr_map::iterator ait;
-        FileAccess *fa = sync->client->fsaccess->newfileaccess(false);
+        auto fa = sync->client->fsaccess->newfileaccess(false);
         bool success = fa->fopen(&tmppath, false, false);
         LocalNode *ll = sync->localnodebypath(l, &path);
         if ((!ll && !success && !fa->retry) // deleted file
@@ -229,10 +229,8 @@ void DirNotify::notify(notifyqueue q, LocalNode* l, const char* localpath, size_
                 && (ll->type != FILENODE || (ll->mtime == fa->mtime && ll->size == fa->size))))
         {
             LOG_debug << "Self filesystem notification skipped";
-            delete fa;
             return;
         }
-        delete fa;
     }
 
     if (q == DirNotify::DIREVENTS || q == DirNotify::EXTRA)

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -350,21 +350,18 @@ bool GfxProc::savefa(string *localfilepath, int width, int height, string *local
         return false;
     }
 
-    FileAccess *f = client->fsaccess->newfileaccess();
+    auto f = client->fsaccess->newfileaccess();
     client->fsaccess->unlinklocal(localdstpath);
     if (!f->fopen(localdstpath, false, true))
     {
-        delete f;
         return false;
     }
 
     if (!f->fwrite((const byte*)jpeg.data(), unsigned(jpeg.size()), 0))
     {
-        delete f;
         return false;
     }
 
-    delete f;
     return true;
 }
 

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -724,14 +724,13 @@ bool mediaInfoOpenFileWithLimits(MediaInfoLib::MediaInfo& mi, std::string filena
 
 void MediaProperties::extractMediaPropertyFileAttributes(const std::string& localFilename, FileSystemAccess* fsa)
 {
-    FileAccess* tmpfa = fsa->newfileaccess();
-    if (tmpfa)
+    if (auto tmpfa = fsa->newfileaccess())
     {
         try
         {
             MediaInfoLib::MediaInfo minfo;
 
-            if (mediaInfoOpenFileWithLimits(minfo, localFilename, tmpfa, 10485760, 3))  // we can read more off local disk
+            if (mediaInfoOpenFileWithLimits(minfo, localFilename, tmpfa.get(), 10485760, 3))  // we can read more off local disk
             {
                 if (!minfo.Count_Get(MediaInfoLib::Stream_General, 0))
                 {
@@ -815,7 +814,6 @@ void MediaProperties::extractMediaPropertyFileAttributes(const std::string& loca
         {
             LOG_err << "unknown excption caught reading media file attributes";
         }
-        delete tmpfa;
     }
 }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -27625,10 +27625,8 @@ MegaHTTPContext::MegaHTTPContext()
 MegaHTTPContext::~MegaHTTPContext()
 {
     delete node;
-    if (tmpFileAccess)
+    if (tmpFileName.size())
     {
-        delete tmpFileAccess;
-
         string localPath;
         server->fsAccess->path2local(&tmpFileName, &localPath);
         server->fsAccess->unlinklocal(&localPath);
@@ -30142,7 +30140,6 @@ MegaFTPDataContext::MegaFTPDataContext()
 MegaFTPDataContext::~MegaFTPDataContext()
 {
     delete transfer;
-    delete tmpFileAccess;
     delete node;
 }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -24429,6 +24429,7 @@ void MegaFolderDownloadController::downloadFolderNode(MegaNode *node, string *pa
     {
         if (!client->fsaccess->mkdirlocal(&localpath))
         {
+            da.reset();
             LOG_err << "Unable to create folder: " << *path;
 
             recursive--;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2471,14 +2471,13 @@ void MegaClient::exec()
                         {
                             // ... execute all pending deletions
                             string path;
-                            FileAccess *fa = fsaccess->newfileaccess();
+                            auto fa = fsaccess->newfileaccess();
                             while (localsyncnotseen.size())
                             {
                                 LocalNode* l = *localsyncnotseen.begin();
-                                unlinkifexists(l, fa, &path);
+                                unlinkifexists(l, fa.get(), &path);
                                 delete l;
                             }
-                            delete fa;
                         }
 
                         // process filesystem notifications for active syncs unless we
@@ -3380,7 +3379,7 @@ bool MegaClient::dispatch(direction_t d)
                         if (!gfxdisabled && gfx && gfx->isgfx(&nexttransfer->localfilename))
                         {
                             // we want all imagery to be safely tucked away before completing the upload, so we bump minfa
-                            nexttransfer->minfa += gfx->gendimensionsputfa(ts->fa, &nexttransfer->localfilename, nexttransfer->uploadhandle, nexttransfer->transfercipher(), -1, false);
+                            nexttransfer->minfa += gfx->gendimensionsputfa(ts->fa.get(), &nexttransfer->localfilename, nexttransfer->uploadhandle, nexttransfer->transfercipher(), -1, false);
                         }
                     }
                 }
@@ -11988,7 +11987,7 @@ error MegaClient::addsync(string* rootpath, const char* debris, string* localdeb
         return API_EFAILED;
     }
 
-    FileAccess* fa = fsaccess->newfileaccess();
+    auto fa = fsaccess->newfileaccess();
     if (fa->fopen(rootpath, true, false))
     {
         if (fa->type == FOLDERNODE)
@@ -12012,7 +12011,7 @@ error MegaClient::addsync(string* rootpath, const char* debris, string* localdeb
                 }
             }
 
-            if (sync->scan(rootpath, fa))
+            if (sync->scan(rootpath, fa.get()))
             {
                 syncsup = false;
                 e = API_OK;
@@ -12038,8 +12037,6 @@ error MegaClient::addsync(string* rootpath, const char* debris, string* localdeb
     {
         e = fa->retry ? API_ETEMPUNAVAIL : API_ENOENT;
     }
-
-    delete fa;
 
     return e;
 #else
@@ -12275,19 +12272,17 @@ bool MegaClient::syncdown(LocalNode* l, string* localpath, bool rubbish)
 
                 ll->getlocalpath(&tmplocalpath);
 
-                FileAccess* fa = fsaccess->newfileaccess(false);
+                auto fa = fsaccess->newfileaccess(false);
                 if (fa->fopen(&tmplocalpath, true, false))
                 {
                     FileFingerprint fp;
-                    fp.genfingerprint(fa);
+                    fp.genfingerprint(fa.get());
 
                     if (!(fp == *(FileFingerprint*)ll))
                     {
                         ll->deleted = false;
                     }
                 }
-
-                delete fa;
             }
 
             if (ll->deleted)
@@ -12384,7 +12379,7 @@ bool MegaClient::syncdown(LocalNode* l, string* localpath, bool rubbish)
             if (rit->second->type == FILENODE)
             {
                 bool download = true;
-                FileAccess *f = fsaccess->newfileaccess(false);
+                auto f = fsaccess->newfileaccess(false);
                 if (rit->second->localnode != (LocalNode*)~0
                         && (f->fopen(localpath) || f->type == FOLDERNODE))
                 {
@@ -12398,7 +12393,7 @@ bool MegaClient::syncdown(LocalNode* l, string* localpath, bool rubbish)
                         download = false;
                     }
                 }
-                delete f;
+                f.reset();
                 rit->second->localnode = NULL;
 
                 // start fetching this node, unless fetch is already in progress
@@ -12419,7 +12414,7 @@ bool MegaClient::syncdown(LocalNode* l, string* localpath, bool rubbish)
             else
             {
                 LOG_debug << "Creating local folder";
-                FileAccess *f = fsaccess->newfileaccess(false);
+                auto f = fsaccess->newfileaccess(false);
                 if (f->fopen(localpath) || f->type == FOLDERNODE)
                 {
                     LOG_debug << "Skipping folder creation over an unscanned file/folder, or the file/folder is not to be synced (special attributes)";
@@ -12457,7 +12452,6 @@ bool MegaClient::syncdown(LocalNode* l, string* localpath, bool rubbish)
                 {
                     LOG_debug << "Non transient error creating folder";
                 }
-                delete f;
             }
         }
 
@@ -12703,7 +12697,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                     if(ll->size == ll->node->size && !memcmp(ll->crc, ll->node->crc, sizeof(ll->crc)))
                     {
                         LOG_debug << "Modification time changed only";
-                        FileAccess *f = fsaccess->newfileaccess();
+                        auto f = fsaccess->newfileaccess();
                         string lpath;
                         ll->getlocalpath(&lpath);
                         string stream = lpath;
@@ -12728,7 +12722,6 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                                         ll->mtime = ll->node->mtime;
                                         ll->treestate(TREESTATE_SYNCED);
                                         RegCloseKey(hKey);
-                                        delete f;
                                         continue;
                                     }
                                 }
@@ -12740,11 +12733,8 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                         if (f->fopen(&lpath))
                         {
                             LOG_warn << "Windows Search detected";
-                            delete f;
                             continue;
                         }
-
-                        delete f;
                     }
 #endif
 
@@ -12871,7 +12861,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
 
                 string localpath;
                 bool t;
-                FileAccess* fa = fsaccess->newfileaccess(false);
+                auto fa = fsaccess->newfileaccess(false);
 
                 ll->getlocalpath(&localpath);
 
@@ -12882,7 +12872,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                     if (t)
                     {
                         ll->sync->localbytes -= ll->size;
-                        ll->genfingerprint(fa);
+                        ll->genfingerprint(fa.get());
                         ll->sync->localbytes += ll->size;                        
 
                         ll->sync->statecacheadd(ll);
@@ -12893,8 +12883,6 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                     LOG_debug << "Localnode not stable yet: " << ll->name << " " << t << " " << fa->size << " " << ll->size
                               << " " << fa->mtime << " " << ll->mtime << " " << ll->nagleds;
 
-                    delete fa;
-
                     if (ll->nagleds < *nds)
                     {
                         *nds = ll->nagleds;
@@ -12902,8 +12890,6 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
 
                     continue;
                 }
-
-                delete fa;
                 
                 ll->created = false;
             }
@@ -13477,14 +13463,12 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes, bool startfir
             if (!f->isvalid)    // (sync LocalNodes always have this set)
             {
                 // missing FileFingerprint for local file - generate
-                FileAccess* fa = fsaccess->newfileaccess();
+                auto fa = fsaccess->newfileaccess();
 
                 if (fa->fopen(&f->localname, d == PUT, d == GET))
                 {
-                    f->genfingerprint(fa);
+                    f->genfingerprint(fa.get());
                 }
-
-                delete fa;
             }
 
             // if we are unable to obtain a valid file FileFingerprint, don't proceed
@@ -13576,7 +13560,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes, bool startfir
                     }
                 }
 
-                FileAccess* fa = fsaccess->newfileaccess();
+                auto fa = fsaccess->newfileaccess();
                 if (!fa->fopen(&t->localfilename))
                 {
                     if (d == PUT)
@@ -13601,7 +13585,7 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes, bool startfir
                 {
                     if (d == PUT)
                     {
-                        if (f->genfingerprint(fa))
+                        if (f->genfingerprint(fa.get()))
                         {
                             LOG_warn << "The local file has been modified";
                             t->tempurls.clear();
@@ -13623,7 +13607,6 @@ bool MegaClient::startxfer(direction_t d, File* f, bool skipdupes, bool startfir
                         }
                     }
                 }
-                delete fa;
                 cachedtransfers[d].erase(it);
                 LOG_debug << "Transfer resumed";
             }

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -1814,9 +1814,9 @@ bool PosixDirNotify::fsstableids() const
 #endif
 }
 
-FileAccess* PosixFileSystemAccess::newfileaccess(bool followSymLinks)
+std::unique_ptr<FileAccess> PosixFileSystemAccess::newfileaccess(bool followSymLinks)
 {
-    return new PosixFileAccess(waiter, defaultfilepermissions, followSymLinks);
+    return std::unique_ptr<FileAccess>{new PosixFileAccess{waiter, defaultfilepermissions, followSymLinks}};
 }
 
 DirAccess* PosixFileSystemAccess::newdiraccess()

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -42,7 +42,7 @@ namespace {
 set<string> collectAllPathsInFolder(Sync& sync, MegaApp& app, FileSystemAccess& fsaccess, string localpath,
                                     const string& localdebris, const string& localseparator)
 {
-    auto fa = std::unique_ptr<FileAccess>{fsaccess.newfileaccess(false)};
+    auto fa = fsaccess.newfileaccess(false);
     if (!fa->fopen(&localpath, true, false))
     {
         LOG_err << "Unable to open path: " << localpath;
@@ -134,7 +134,7 @@ void combinedFingerprint(FileFingerprint& ffp, FileSystemAccess& fsaccess, const
     ffp.isvalid = false;
     for (const auto& path : paths)
     {
-        auto fa = std::unique_ptr<FileAccess>{fsaccess.newfileaccess(false)};
+        auto fa = fsaccess.newfileaccess(false);
         if (!fa->fopen(const_cast<string*>(&path), true, false))
         {
             LOG_err << "Unable to open path: " << path;
@@ -296,7 +296,7 @@ void assignFilesystemIdsImpl(bool& success, Sync& sync, MegaApp& app, handleloca
                              FileSystemAccess& fsaccess, string localpath, const string& localdebris,
                              const string& localseparator, FingerprintMap& fingerprints)
 {
-    auto fa = std::unique_ptr<FileAccess>{fsaccess.newfileaccess(false)};
+    auto fa = fsaccess.newfileaccess(false);
     if (!(success = fa->fopen(&localpath, true, false)))
     {
         LOG_err << "Unable to open path: " << localpath;
@@ -413,7 +413,7 @@ bool assignFilesystemIds(Sync& sync, MegaApp& app, FileSystemAccess& fsaccess, h
 {
     auto rootpath = sync.localroot.localname;
 
-    auto fa = std::unique_ptr<FileAccess>{fsaccess.newfileaccess(false)};
+    auto fa = fsaccess.newfileaccess(false);
     if (!fa->fopen(&rootpath, true, false))
     {
         LOG_err << "Unable to open rootpath";

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1219,6 +1219,8 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
 
                             statecacheadd(l);
 
+                            fa.reset();
+
                             if (isnetwork && l->type == FILENODE)
                             {
                                 LOG_debug << "Queueing extra fs notification for modified file";

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -555,9 +555,9 @@ void Transfer::complete()
                     if (syncxfer && (!badfp.isvalid || !(badfp == fingerprint)))
                     {
                         badfp = fingerprint;
+                        fa.reset();
                         chunkmacs.clear();
                         client->fsaccess->unlinklocal(&localfilename);
-                        fa.reset();
                         return failed(API_EWRITE);
                     }
                     else

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -1476,9 +1476,9 @@ WinDirNotify::~WinDirNotify()
 #endif
 }
 
-FileAccess* WinFileSystemAccess::newfileaccess(bool followSymLinks)
+std::unique_ptr<FileAccess> WinFileSystemAccess::newfileaccess(bool followSymLinks)
 {
-    return new WinFileAccess(waiter);
+    return std::unique_ptr<FileAccess>(new WinFileAccess(waiter));
 }
 
 DirAccess* WinFileSystemAccess::newdiraccess()

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -3210,10 +3210,9 @@ TEST_F(SdkTest, SdkTestFingerprint)
         {
             m_time_t mtime = 0;
             {
-                FileAccess* nfa = fsa.newfileaccess();
+                auto nfa = fsa.newfileaccess();
                 nfa->fopen(&localname);
                 mtime = nfa->mtime;
-                delete nfa;
             }
 
             myMIS mis(name.c_str());


### PR DESCRIPTION
…ort for making sure we always delete the object.

There were at least a couple of places that manual deletes were missed in the break; or continue; clauses of loops/switches.