### PR TITLE
#13445 temporarily disable fsid assign

### DIFF
--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -1803,7 +1803,7 @@ bool PosixDirNotify::fsstableids() const
         return true;
     }
 
-    LOG_info << "Filesystem type: 0x" << std::hex << statfsbuf.f_type;
+    LOG_info << "Filesystem type: " << statfsbuf.f_type;
 
 #ifdef __APPLE__
     return statfsbuf.f_type != 0x1c // FAT32

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -508,7 +508,7 @@ Sync::Sync(MegaClient* cclient, string* crootpath, const char* cdebris,
     }
 
     fsstableids = dirnotify->fsstableids();
-    LOG_info << "Filesystem IDs are stable: " << std::boolalpha << fsstableids;
+    LOG_info << "Filesystem IDs are stable: " << fsstableids;
     fsstableids = true; // TODO: Remove this once the fs ID assignment is working properly
 
     localroot.init(this, FOLDERNODE, NULL, crootpath);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -509,6 +509,7 @@ Sync::Sync(MegaClient* cclient, string* crootpath, const char* cdebris,
 
     fsstableids = dirnotify->fsstableids();
     LOG_info << "Filesystem IDs are stable: " << std::boolalpha << fsstableids;
+    fsstableids = true; // TODO: Remove this once the fs ID assignment is working properly
 
     localroot.init(this, FOLDERNODE, NULL, crootpath);
     localroot.setnode(remotenode);


### PR DESCRIPTION
This temporarily disables fs ID assignment until it's working properly. Also improves logging.