### PR TITLE
Adjust contact-link query to use B64

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -6869,8 +6869,8 @@ void DemoApp::contactlinkquery_result(error e, handle h, string *email, string *
         cout << "Contact link created successfully: " << endl;
         cout << "\tUserhandle: " << LOG_HANDLE(h) << endl;
         cout << "\tEmail: " << *email << endl;
-        cout << "\tFirstname: " << *fn << endl;
-        cout << "\tLastname: " << *ln << endl;
+        cout << "\tFirstname: " << Base64::atob(*fn) << endl;
+        cout << "\tLastname: " << Base64::atob(*ln) << endl;
     }
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6942,6 +6942,8 @@ CommandContactLinkQuery::CommandContactLinkQuery(MegaClient *client, handle h)
 {
     cmd("clg");
     arg("cl", (byte*)&h, MegaClient::CONTACTLINKHANDLE);
+
+    arg("b", 1);    // return firstname/lastname in B64
     
     tag = client->reqtag;
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14945,8 +14945,8 @@ void MegaApiImpl::contactlinkquery_result(error e, handle h, string *email, stri
     {
         request->setParentHandle(h);
         request->setEmail(email->c_str());
-        request->setName(firstname->c_str());
-        request->setText(lastname->c_str());
+        request->setName(Base64::atob(*firstname).c_str());
+        request->setText(Base64::atob(*lastname).c_str());
         request->setFile(avatar->c_str());
     }
     fireOnRequestFinish(request, e);


### PR DESCRIPTION
Firstname and lastname, without B64 encoding, has issues with UTF8 characters. Need B64 for proper displaying.