### PR TITLE
#13471 For putnodes, applykeys() just for those new nodes as we go.

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1298,7 +1298,7 @@ public:
     dstime disconnecttimestamp;
 
     // process object arrays by the API server
-    int readnodes(JSON*, int, putsource_t = PUTNODES_APP, NewNode* = NULL, int = 0, int = 0);
+    int readnodes(JSON*, int, putsource_t = PUTNODES_APP, NewNode* = NULL, int = 0, int = 0, bool applykeys = false);
 
     void readok(JSON*);
     void readokelement(JSON*);
@@ -1400,7 +1400,10 @@ public:
     string clientname;
 
     // apply keys
-    int applykeys();
+    void applykeys();
+
+    // send andy key rewrites prepared when keys were applied
+    void sendkeyrewrites();
 
     // symmetric password challenge
     int checktsid(byte* sidbuf, unsigned len);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1204,7 +1204,7 @@ void CommandPutNodes::procresult()
         {
             case 'f':
                 empty = !memcmp(client->json.pos, "[]", 2);
-                if (client->readnodes(&client->json, 1, source, nn, nnsize, tag))
+                if (client->readnodes(&client->json, 1, source, nn, nnsize, tag, true))  // do apply keys to received nodes only as we go for command response, much much faster for many small responses
                 {
                     e = API_OK;
                 }
@@ -1217,7 +1217,7 @@ void CommandPutNodes::procresult()
                 break;
 
             case MAKENAMEID2('f', '2'):
-                if (!client->readnodes(&client->json, 1))
+                if (!client->readnodes(&client->json, 1, PUTNODES_APP, NULL, 0, 0, true))  // do apply keys to received nodes only as we go for command response, much much faster for many small responses
                 {
                     LOG_err << "Parse error (readversions)";
                     e = API_EINTERNAL;
@@ -1241,7 +1241,7 @@ void CommandPutNodes::procresult()
         }
     }
 
-    client->applykeys();
+    client->sendkeyrewrites();
 
 #ifdef ENABLE_SYNC
     if (source == PUTNODES_SYNC)


### PR DESCRIPTION
Previously it iterated the whole node map for each putnodes.  For large accounts, and lots of uploads of small files, each of which causes one putnodes, that was quite slow.