### PR TITLE
performance improvement: don't create and destroy a SymmCipher on eve…

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -179,6 +179,9 @@ if (WIN32)
 
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+    set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+    set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Zi")
+
 
     # for inet_ntoa (which is available in XP)
     add_definitions( -D_WINSOCK_DEPRECATED_NO_WARNINGS )

--- a/include/mega/gfx.h
+++ b/include/mega/gfx.h
@@ -75,6 +75,7 @@ class MEGA_API GfxProc
     WAIT_CLASS waiter;
     std::mutex mutex;
     THREAD_CLASS thread;
+    SymmCipher mCheckEventsKey;
     GfxJobQueue requests;
     GfxJobQueue responses;
     static void *threadEntryPoint(void *param);

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -179,7 +179,6 @@ int GfxProc::checkevents(Waiter *)
 
     GfxJob *job = NULL;
     bool needexec = false;
-    SymmCipher key;
     while ((job = responses.pop()))
     {
         for (unsigned i = 0; i < job->images.size(); i++)
@@ -191,10 +190,10 @@ int GfxProc::checkevents(Waiter *)
                 // store the file attribute data - it will be attached to the file
                 // immediately if the upload has already completed; otherwise, once
                 // the upload completes
-                key.setkey(job->key);
+                mCheckEventsKey.setkey(job->key);
                 int creqtag = client->reqtag;
                 client->reqtag = 0;
-                client->putfa(job->h, job->imagetypes[i], &key, job->images[i], job->flag);
+                client->putfa(job->h, job->imagetypes[i], &mCheckEventsKey, job->images[i], job->flag);
                 client->reqtag = creqtag;
             }
             else


### PR DESCRIPTION
…ry call, which can be very frequent

In a test downloading 2500 tiny files, the SymmCipher was not actually used, but took 18% CPU.
Moved the variable to the object where it can be reused, rather than creating on the stack every time.
Also updated the cmake project so the generated visual studio project doesn't have to be manually updated to enable profiling.