### PR TITLE
#13629. Prevent applykeys() taking CPU when all node keys are resolved.

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -1872,7 +1872,7 @@ public:
             // copy key (if file) or generate new key (if folder)
             if (n->type == FILENODE)
             {
-                t->nodekey = n->nodekey;
+                t->nodekey = n->nodekey();
             }
             else
             {
@@ -2058,7 +2058,7 @@ string showMediaInfo(Node* n, MediaFileInfo& /*mediaInfo*/, bool oneline)
 {
     if (n->hasfileattribute(fa_media))
     {
-        MediaProperties mp = MediaProperties::decodeMediaPropertiesAttributes(n->fileattrstring, (uint32_t*)(n->nodekey.data() + FILENODEKEYLENGTH / 2));
+        MediaProperties mp = MediaProperties::decodeMediaPropertiesAttributes(n->fileattrstring, (uint32_t*)(n->nodekey().data() + FILENODEKEYLENGTH / 2));
         return showMediaInfo(mp, client->mediaFileInfo, oneline);
     }
     return "The node has no mediainfo attribute";
@@ -2543,6 +2543,16 @@ void printAuthringInformation(handle userhandle)
     }
 }
 
+void exec_setmaxconnections(autocomplete::ACState& s)
+{
+    auto direction = s.words[1].s == "put" ? PUT : GET;
+    if (s.words.size() == 3)
+    {
+        client->setmaxconnections(direction, atoi(s.words[2].s.c_str()));
+    }
+    cout << "connections: " << (int)client->connections[direction] << endl;
+}
+
 autocomplete::ACN autocompleteSyntax()
 {
     using namespace autocomplete;
@@ -2691,6 +2701,8 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_getuserquota, sequence(text("getuserquota"), repeat(either(flag("-storage"), flag("-transfer"), flag("-pro")))));
 
     p->Add(exec_showattributes, sequence(text("showattributes"), remoteFSPath(client, &cwd)));
+
+    p->Add(exec_setmaxconnections, sequence(text("setmaxconnections"), either(text("put"), text("get")), opt(wholenumber(4))));
 
     return autocompleteTemplate = std::move(p);
 }
@@ -3256,7 +3268,7 @@ void exec_cp(autocomplete::ACState& s)
             unsigned nc;
             handle ovhandle = UNDEF;
 
-            if (!n->nodekey.size())
+            if (!n->keyApplied())
             {
                 cout << "Cannot copy a node without key" << endl;
                 return;
@@ -3494,7 +3506,7 @@ void exec_get(autocomplete::ACState& s)
                         f->pubauth = pubauth;
                         f->hprivate = true;
                         f->hforeign = true;
-                        memcpy(f->filekey, n->nodekey.data(), FILENODEKEYLENGTH);
+                        memcpy(f->filekey, n->nodekey().data(), FILENODEKEYLENGTH);
                     }
 
                     f->appxfer_it = appxferq[GET].insert(appxferq[GET].end(), f);
@@ -4215,7 +4227,7 @@ void exec_getfa(autocomplete::ACState& s)
         {
             if (n->hasfileattribute(type))
             {
-                client->getfa(n->nodehandle, &n->fileattrstring, &n->nodekey, type, cancel);
+                client->getfa(n->nodehandle, &n->fileattrstring, n->nodekey(), type, cancel);
                 c++;
             }
         }
@@ -4225,7 +4237,7 @@ void exec_getfa(autocomplete::ACState& s)
             {
                 if ((*it)->type == FILENODE && (*it)->hasfileattribute(type))
                 {
-                    client->getfa((*it)->nodehandle, &(*it)->fileattrstring, &(*it)->nodekey, type, cancel);
+                    client->getfa((*it)->nodehandle, &(*it)->fileattrstring, (*it)->nodekey(), type, cancel);
                     c++;
                 }
             }
@@ -6429,7 +6441,7 @@ void DemoApp::exportnode_result(handle h, handle ph)
 
         if (n->type == FILENODE)
         {
-            cout << MegaClient::getPublicLink(client->mNewLinkFormat, n->type, ph, Base64Str<FILENODEKEYLENGTH>((const byte*)n->nodekey.data())) << endl;
+            cout << MegaClient::getPublicLink(client->mNewLinkFormat, n->type, ph, Base64Str<FILENODEKEYLENGTH>((const byte*)n->nodekey().data())) << endl;
         }
         else
         {

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1101,7 +1101,7 @@ public:
     long long totalNodes;
 
     // tracks how many nodes have had a successful applykey()
-    long long mAppliedNodeKeyCount = 0;
+    long long mApplieKeyNodeCount = 0;
 
     // server-client request sequence number
     char scsn[12];

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1100,6 +1100,7 @@ public:
     // total number of Node objects
     long long totalNodes;
 
+    // tracks how many nodes have had a successful applykey()
     long long mAppliedNodeKeyCount = 0;
 
     // server-client request sequence number

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -462,7 +462,7 @@ public:
     void putfa(handle, fatype, SymmCipher*, string*, bool checkAccess = true);
 
     // queue file attribute retrieval
-    error getfa(handle h, string *fileattrstring, string *nodekey, fatype, int = 0);
+    error getfa(handle h, string *fileattrstring, const string &nodekey, fatype, int = 0);
     
     // notify delayed upload completion subsystem about new file attribute
     void checkfacompletion(handle, Transfer* = NULL);
@@ -1099,6 +1099,8 @@ public:
 
     // total number of Node objects
     long long totalNodes;
+
+    long long mAppliedNodeKeyCount = 0;
 
     // server-client request sequence number
     char scsn[12];

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1101,7 +1101,7 @@ public:
     long long totalNodes;
 
     // tracks how many nodes have had a successful applykey()
-    long long mApplieKeyNodeCount = 0;
+    long long mAppliedKeyNodeCount = 0;
 
     // server-client request sequence number
     char scsn[12];

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -1,3 +1,4 @@
+
 /**
  * @file mega/node.h
  * @brief Classes for accessing local and remote nodes
@@ -41,13 +42,9 @@ struct MEGA_API NodeCore
     // node type
     nodetype_t type;
 
-    // full folder/file key, symmetrically or asymmetrically encrypted
-    // node crypto keys (raw or cooked -
-    // cooked if size() == FOLDERNODEKEYLENGTH or FILEFOLDERNODEKEYLENGTH)
-    string nodekey;
-
     // node attributes
     string *attrstring;
+
 };
 
 // new node for putnodes()
@@ -55,6 +52,8 @@ struct MEGA_API NewNode : public NodeCore
 {
     static const int OLDUPLOADTOKENLEN = 27;
     static const int UPLOADTOKENLEN = 36;
+
+    string nodekey;
 
     newnodesource_t source;
 
@@ -111,6 +110,12 @@ private:
 struct MEGA_API Node : public NodeCore, FileFingerprint
 {
     MegaClient* client;
+
+    // supplies the nodekey (which is private to ensure we track changes to it)
+    const string& nodekey() const;
+
+    // check if the key is present and is the correct size for this node
+    bool keyApplied() const;
 
     // change parent node association
     bool setparent(Node*);
@@ -192,6 +197,8 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     
     void setkey(const byte* = NULL);
 
+    void setkeyfromjson(const char*);
+
     void setfingerprint();
 
     void faspec(string*);
@@ -244,7 +251,26 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
 
     Node(MegaClient*, vector<Node*>*, handle, handle, nodetype_t, m_off_t, handle, const char*, m_time_t);
     ~Node();
+
+private:
+
+    // full folder/file key, symmetrically or asymmetrically encrypted
+    // node crypto keys (raw or cooked -
+    // cooked if size() == FOLDERNODEKEYLENGTH or FILEFOLDERNODEKEYLENGTH)
+    string nodekeydata;
 };
+
+inline const string& Node::nodekey() const
+{
+    assert(keyApplied() || type == ROOTNODE || type == INCOMINGNODE || type == RUBBISHNODE);
+    return nodekeydata;
+}
+
+inline bool Node::keyApplied() const
+{
+    return nodekeydata.size() == size_t((type == FILENODE) ? FILENODEKEYLENGTH : FOLDERNODEKEYLENGTH);
+}
+
 
 #ifdef ENABLE_SYNC
 struct MEGA_API LocalNode : public File

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -114,6 +114,9 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     // supplies the nodekey (which is private to ensure we track changes to it)
     const string& nodekey() const;
 
+    // Also returns the key but does not assert that the key has been applied.  Only use it where we don't need the node to be readable.
+    const string& nodekeyUnchecked() const;
+
     // check if the key is present and is the correct size for this node
     bool keyApplied() const;
 
@@ -263,6 +266,11 @@ private:
 inline const string& Node::nodekey() const
 {
     assert(keyApplied() || type == ROOTNODE || type == INCOMINGNODE || type == RUBBISHNODE);
+    return nodekeydata;
+}
+
+inline const string& Node::nodekeyUnchecked() const
+{
     return nodekeydata;
 }
 

--- a/include/mega/sharenodekeys.h
+++ b/include/mega/sharenodekeys.h
@@ -36,7 +36,12 @@ class MEGA_API ShareNodeKeys
     int addshare(Node*);
 
 public:
+    // a convenience function for calling the full add() below when working with Node*
     void add(Node*, Node*, int);
+
+    // Adds keys needed for sharing the node (specifed wtih nodekey/nodehandle) to the `keys` and `items` collections.
+    // Each node may be in multiple shares so the parent chain is traversed and if this node is in multiple shares, then multiple keys are added.
+    // The result is suitable for sending all the collected keys for each share, per Node, to the API.
     void add(const string& nodekey, handle nodehandle, Node*, int, const byte* = NULL, int = 0);
 
     void get(Command*, bool skiphandles = false);

--- a/include/mega/sharenodekeys.h
+++ b/include/mega/sharenodekeys.h
@@ -37,7 +37,7 @@ class MEGA_API ShareNodeKeys
 
 public:
     void add(Node*, Node*, int);
-    void add(NodeCore*, Node*, int, const byte* = NULL, int = 0);
+    void add(const string& nodekey, handle nodehandle, Node*, int, const byte* = NULL, int = 0);
 
     void get(Command*, bool skiphandles = false);
 };

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1121,11 +1121,11 @@ CommandPutNodes::CommandPutNodes(MegaClient* client, handle th,
                 {
                     case NEW_PUBLIC:
                     case NEW_NODE:
-                        snk.add((nn + i)->nodekey, (nn + i)->nodehandle, tn, 0);
+                        snk.add(nn[i].nodekey, nn[i].nodehandle, tn, 0);
                         break;
 
                     case NEW_UPLOAD:
-                        snk.add((nn + i)->nodekey, (nn + i)->nodehandle, tn, 0, nn[i].uploadtoken, (int)sizeof nn->uploadtoken);
+                        snk.add(nn[i].nodekey, nn[i].nodehandle, tn, 0, nn[i].uploadtoken, (int)sizeof nn->uploadtoken);
                         break;
                 }
             }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1121,11 +1121,11 @@ CommandPutNodes::CommandPutNodes(MegaClient* client, handle th,
                 {
                     case NEW_PUBLIC:
                     case NEW_NODE:
-                        snk.add((NodeCore*)(nn + i), tn, 0);
+                        snk.add((nn + i)->nodekey, (nn + i)->nodehandle, tn, 0);
                         break;
 
                     case NEW_UPLOAD:
-                        snk.add((NodeCore*)(nn + i), tn, 0, nn[i].uploadtoken, (int)sizeof nn->uploadtoken);
+                        snk.add((nn + i)->nodekey, (nn + i)->nodehandle, tn, 0, nn[i].uploadtoken, (int)sizeof nn->uploadtoken);
                         break;
                 }
             }
@@ -3376,10 +3376,10 @@ CommandNodeKeyUpdate::CommandNodeKeyUpdate(MegaClient* client, handle_vector* v)
 
         if ((n = client->nodebyhandle(h)))
         {
-            client->key.ecb_encrypt((byte*)n->nodekey.data(), nodekey, n->nodekey.size());
+            client->key.ecb_encrypt((byte*)n->nodekey().data(), nodekey, n->nodekey().size());
 
             element(h, MegaClient::NODEHANDLE);
-            element(nodekey, int(n->nodekey.size()));
+            element(nodekey, int(n->nodekey().size()));
         }
     }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -387,7 +387,7 @@ MegaNodePrivate::MegaNodePrivate(Node *node)
         this->attrstring.assign(node->attrstring->data(), node->attrstring->size());
     }
     this->fileattrstring = node->fileattrstring;
-    this->nodekey.assign(node->nodekey().data(),node->nodekey().size());
+    this->nodekey = node->nodekeyUnchecked();
 
     this->changed = 0;
     if(node->changed.attrs)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -387,7 +387,7 @@ MegaNodePrivate::MegaNodePrivate(Node *node)
         this->attrstring.assign(node->attrstring->data(), node->attrstring->size());
     }
     this->fileattrstring = node->fileattrstring;
-    this->nodekey.assign(node->nodekey.data(),node->nodekey.size());
+    this->nodekey.assign(node->nodekey().data(),node->nodekey().size());
 
     this->changed = 0;
     if(node->changed.attrs)
@@ -4684,8 +4684,8 @@ MegaFileGet::MegaFileGet(MegaClient *client, Node *n, string dstPath) : MegaFile
     size = n->size;
     mtime = n->mtime;
 
-    if(n->nodekey.size()>=sizeof(filekey))
-        memcpy(filekey,n->nodekey.data(),sizeof filekey);
+    if(n->nodekey().size()>=sizeof(filekey))
+        memcpy(filekey,n->nodekey().data(),sizeof filekey);
 
     client->fsaccess->path2local(&finalPath, &localname);
     hprivate = true;
@@ -14052,9 +14052,9 @@ void MegaApiImpl::exportnode_result(handle h, handle ph)
         // the key
         if (n->type == FILENODE)
         {
-            if(n->nodekey.size() >= FILENODEKEYLENGTH)
+            if(n->nodekey().size() >= FILENODEKEYLENGTH)
             {
-                Base64::btoa((const byte*)n->nodekey.data(),FILENODEKEYLENGTH,key);
+                Base64::btoa((const byte*)n->nodekey().data(),FILENODEKEYLENGTH,key);
             }
             else
             {
@@ -17581,7 +17581,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                     if (!forceToUpload)
                     {
                         Node *samenode = client->nodebyfingerprint(&fp);
-                        if (samenode && samenode->nodekey.size() && !hasToForceUpload(*samenode, *transfer))
+                        if (samenode && samenode->nodekey().size() && !hasToForceUpload(*samenode, *transfer))
                         {
                             pendingUploads++;
                             transfer->setState(MegaTransfer::STATE_QUEUED);
@@ -18519,7 +18519,7 @@ void MegaApiImpl::sendPendingRequests()
                 unsigned nc;
                 TreeProcCopy tc;
 
-                if (!node->nodekey.size())
+                if (!node->nodekey().size())
                 {
                     e = API_EKEY;
                     break;
@@ -18642,11 +18642,11 @@ void MegaApiImpl::sendPendingRequests()
             newnode->nodehandle = version->nodehandle;
             newnode->parenthandle = UNDEF;
             newnode->ovhandle = current->nodehandle;
-            newnode->nodekey = version->nodekey;
+            newnode->nodekey = version->nodekey();
             newnode->attrstring = new string();
             if (newnode->nodekey.size())
             {
-                key.setkey((const byte*)version->nodekey.data(), version->type);
+                key.setkey((const byte*)version->nodekey().data(), version->type);
                 version->attrs.getjson(&attrstring);
                 client->makeattr(&key, newnode->attrstring, attrstring.c_str());
             }
@@ -18916,7 +18916,7 @@ void MegaApiImpl::sendPendingRequests()
             if (!fa)
             {
                 fileattrstring = node->fileattrstring;
-                key = node->nodekey;
+                key = node->nodekey();
             }
             else
             {
@@ -18930,7 +18930,7 @@ void MegaApiImpl::sendPendingRequests()
                 }
                 key.assign((const char *)nodekey, sizeof nodekey);
             }
-            e = client->getfa(h, &fileattrstring, &key, (fatype) type);
+            e = client->getfa(h, &fileattrstring, key, (fatype) type);
             if(e == API_EEXIST)
             {
                 e = API_OK;
@@ -21624,7 +21624,7 @@ void TreeProcCopy::proc(MegaClient* client, Node* n)
         t->parenthandle = n->parent ? n->parent->nodehandle : UNDEF;
 
         // copy key (if file) or generate new key (if folder)
-        if (n->type == FILENODE) t->nodekey = n->nodekey;
+        if (n->type == FILENODE) t->nodekey = n->nodekey();
         else
         {
             byte buf[FOLDERNODEKEYLENGTH];

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1026,7 +1026,7 @@ void MegaClient::init()
     chunkfailed = false;
     statecurrent = false;
     totalNodes = 0;
-    mAppliedNodeKeyCount = 0;
+    mApplieKeyNodeCount = 0;
     faretrying = false;
 
 #ifdef ENABLE_SYNC
@@ -7884,7 +7884,7 @@ void MegaClient::applykeys()
 
     int noKeyExpected = (rootnodes[0] != UNDEF) + (rootnodes[1] != UNDEF) + (rootnodes[2] != UNDEF);
 
-    if (nodes.size() > size_t(mAppliedNodeKeyCount + noKeyExpected))
+    if (nodes.size() > size_t(mApplieKeyNodeCount + noKeyExpected))
     {
         for (auto& it : nodes)
         {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1026,7 +1026,7 @@ void MegaClient::init()
     chunkfailed = false;
     statecurrent = false;
     totalNodes = 0;
-    mApplieKeyNodeCount = 0;
+    mAppliedKeyNodeCount = 0;
     faretrying = false;
 
 #ifdef ENABLE_SYNC
@@ -7884,7 +7884,7 @@ void MegaClient::applykeys()
 
     int noKeyExpected = (rootnodes[0] != UNDEF) + (rootnodes[1] != UNDEF) + (rootnodes[2] != UNDEF);
 
-    if (nodes.size() > size_t(mApplieKeyNodeCount + noKeyExpected))
+    if (nodes.size() > size_t(mAppliedKeyNodeCount + noKeyExpected))
     {
         for (auto& it : nodes)
         {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6476,7 +6476,7 @@ void MegaClient::notifypurge(void)
             Node* n = nodenotify[i];
             if (n->attrstring)
             {
-                LOG_err << "NO_KEY node: " << n->type << " " << n->size << " " << n->nodehandle << " " << n->nodekey().size();
+                LOG_err << "NO_KEY node: " << n->type << " " << n->size << " " << n->nodehandle << " " << n->nodekeyUnchecked().size();
 #ifdef ENABLE_SYNC
                 if (n->localnode)
                 {
@@ -7878,9 +7878,6 @@ void MegaClient::procph(JSON *j)
 void MegaClient::applykeys()
 {
     CodeCounter::ScopeTimer ccst(performanceStats.applyKeys);
-
-    // FIXME: rather than iterating through the whole node set, maintain subset
-    // with missing keys
 
     int noKeyExpected = (rootnodes[0] != UNDEF) + (rootnodes[1] != UNDEF) + (rootnodes[2] != UNDEF);
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7879,8 +7879,6 @@ void MegaClient::applykeys()
 {
     CodeCounter::ScopeTimer ccst(performanceStats.applyKeys);
 
-    int t = 0;
-
     // FIXME: rather than iterating through the whole node set, maintain subset
     // with missing keys
 
@@ -7888,12 +7886,9 @@ void MegaClient::applykeys()
 
     if (nodes.size() > size_t(mAppliedNodeKeyCount + noKeyExpected))
     {
-        for (node_map::iterator it = nodes.begin(); it != nodes.end(); it++)
+        for (auto& it : nodes)
         {
-            if (it->second->applykey())
-            {
-                t++;
-            }
+            it.second->applykey();
         }
     }
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -753,7 +753,7 @@ void Node::setfingerprint()
         // size and client timestamp instead
         if (!isvalid)
         {
-            memcpy(crc.data(), nodekey.data(), sizeof crc);
+            memcpy(crc.data(), nodekeydata.data(), sizeof crc);
             mtime = ctime;
         }
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -127,8 +127,8 @@ Node::~Node()
 {
     if (keyApplied())
     {
-        client->mAppliedNodeKeyCount--;
-        assert(client->mAppliedNodeKeyCount >= 0);
+        client->mApplieKeyNodeCount--;
+        assert(client->mApplieKeyNodeCount >= 0);
     }
 
     // abort pending direct reads
@@ -216,15 +216,10 @@ Node::~Node()
 
 void Node::setkeyfromjson(const char* k)
 {
-    int adjust = keyApplied() ? -1 : 0;
+    if (keyApplied()) --client->mApplieKeyNodeCount;
     Node::copystring(&nodekeydata, k);
-    adjust += keyApplied() ? 1 : 0;
-
-    if (adjust)
-    {
-        client->mAppliedNodeKeyCount += adjust;
-        assert(client->mAppliedNodeKeyCount >= 0);
-    }
+    if (keyApplied()) ++client->mApplieKeyNodeCount;
+    assert(client->mApplieKeyNodeCount >= 0);
 }
 
 // update node key and decrypt attributes
@@ -232,15 +227,10 @@ void Node::setkey(const byte* newkey)
 {
     if (newkey)
     {
-        int adjust = keyApplied() ? -1 : 0;
-        nodekeydata.assign((char*)newkey, (type == FILENODE) ? FILENODEKEYLENGTH + 0 : FOLDERNODEKEYLENGTH + 0);
-        adjust += keyApplied() ? 1 : 0;
-
-        if (adjust)
-        {
-            client->mAppliedNodeKeyCount += adjust;
-            assert(client->mAppliedNodeKeyCount >= 0);
-        }
+        if (keyApplied()) --client->mApplieKeyNodeCount;
+        nodekeydata.assign(reinterpret_cast<const char*>(newkey), (type == FILENODE) ? FILENODEKEYLENGTH : FOLDERNODEKEYLENGTH);
+        if (keyApplied()) ++client->mApplieKeyNodeCount;
+        assert(client->mApplieKeyNodeCount >= 0);
     }
 
     setattr();
@@ -308,7 +298,7 @@ Node* Node::unserialize(MegaClient* client, string* d, node_vector* dp)
 
     if ((t == FILENODE) || (t == FOLDERNODE))
     {
-        int keylen = ((t == FILENODE) ? FILENODEKEYLENGTH + 0 : FOLDERNODEKEYLENGTH + 0);
+        int keylen = ((t == FILENODE) ? FILENODEKEYLENGTH : FOLDERNODEKEYLENGTH);
 
         if (ptr + keylen + 8 + sizeof(short) > end)
         {
@@ -885,10 +875,6 @@ int Node::hasfileattribute(const string *fileattrstring, fatype t)
 // attempt to apply node key - sets nodekey to a raw key if successful
 bool Node::applykey()
 {
-    unsigned int keylength = (type == FILENODE)
-                   ? FILENODEKEYLENGTH + 0
-                   : FOLDERNODEKEYLENGTH + 0;
-
     if (type > FOLDERNODE)
     {
         //Root nodes contain an empty attrstring
@@ -896,7 +882,7 @@ bool Node::applykey()
         attrstring = NULL;
     }
 
-    if (nodekeydata.size() == keylength || !nodekeydata.size())
+    if (keyApplied() || !nodekeydata.size())
     {
         return false;
     }
@@ -964,14 +950,16 @@ bool Node::applykey()
     }
 
     byte key[FILENODEKEYLENGTH];
+    unsigned keylength = (type == FILENODE) ? FILENODEKEYLENGTH : FOLDERNODEKEYLENGTH;
 
     if (client->decryptkey(k, key, keylength, sc, 0, nodehandle))
     {
-        client->mAppliedNodeKeyCount++;
+        client->mApplieKeyNodeCount++;
         nodekeydata.assign((const char*)key, keylength);
         setattr();
     }
 
+    assert(keyApplied());
     return true;
 }
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -127,8 +127,8 @@ Node::~Node()
 {
     if (keyApplied())
     {
-        client->mApplieKeyNodeCount--;
-        assert(client->mApplieKeyNodeCount >= 0);
+        client->mAppliedKeyNodeCount--;
+        assert(client->mAppliedKeyNodeCount >= 0);
     }
 
     // abort pending direct reads
@@ -216,10 +216,10 @@ Node::~Node()
 
 void Node::setkeyfromjson(const char* k)
 {
-    if (keyApplied()) --client->mApplieKeyNodeCount;
+    if (keyApplied()) --client->mAppliedKeyNodeCount;
     Node::copystring(&nodekeydata, k);
-    if (keyApplied()) ++client->mApplieKeyNodeCount;
-    assert(client->mApplieKeyNodeCount >= 0);
+    if (keyApplied()) ++client->mAppliedKeyNodeCount;
+    assert(client->mAppliedKeyNodeCount >= 0);
 }
 
 // update node key and decrypt attributes
@@ -227,10 +227,10 @@ void Node::setkey(const byte* newkey)
 {
     if (newkey)
     {
-        if (keyApplied()) --client->mApplieKeyNodeCount;
+        if (keyApplied()) --client->mAppliedKeyNodeCount;
         nodekeydata.assign(reinterpret_cast<const char*>(newkey), (type == FILENODE) ? FILENODEKEYLENGTH : FOLDERNODEKEYLENGTH);
-        if (keyApplied()) ++client->mApplieKeyNodeCount;
-        assert(client->mApplieKeyNodeCount >= 0);
+        if (keyApplied()) ++client->mAppliedKeyNodeCount;
+        assert(client->mAppliedKeyNodeCount >= 0);
     }
 
     setattr();
@@ -954,7 +954,7 @@ bool Node::applykey()
 
     if (client->decryptkey(k, key, keylength, sc, 0, nodehandle))
     {
-        client->mApplieKeyNodeCount++;
+        client->mAppliedKeyNodeCount++;
         nodekeydata.assign((const char*)key, keylength);
         setattr();
     }

--- a/src/sharenodekeys.cpp
+++ b/src/sharenodekeys.cpp
@@ -49,7 +49,7 @@ void ShareNodeKeys::add(Node* n, Node* sn, int specific)
         sn = n;
     }
 
-    add(n->nodekey(), n->nodehandle, sn, specific, NULL, 0);
+    add(n->nodekey(), n->nodehandle, sn, specific);
 }
 
 // add a nodecore (!sn: all relevant shares, otherwise starting from sn, fixed: only sn)

--- a/src/sharenodekeys.cpp
+++ b/src/sharenodekeys.cpp
@@ -49,11 +49,11 @@ void ShareNodeKeys::add(Node* n, Node* sn, int specific)
         sn = n;
     }
 
-    add((NodeCore*)n, sn, specific);
+    add(n->nodekey(), n->nodehandle, sn, specific, NULL, 0);
 }
 
 // add a nodecore (!sn: all relevant shares, otherwise starting from sn, fixed: only sn)
-void ShareNodeKeys::add(NodeCore* n, Node* sn, int specific, const byte* item, int itemlen)
+void ShareNodeKeys::add(const string& nodekey, handle nodehandle, Node* sn, int specific, const byte* item, int itemlen)
 {
     char buf[96];
     char* ptr;
@@ -67,10 +67,10 @@ void ShareNodeKeys::add(NodeCore* n, Node* sn, int specific, const byte* item, i
         {
             sprintf(buf, ",%d,%d,\"", addshare(sn), (int)items.size());
 
-            sn->sharekey->ecb_encrypt((byte*)n->nodekey.data(), key, n->nodekey.size());
+            sn->sharekey->ecb_encrypt((byte*)nodekey.data(), key, nodekey.size());
 
             ptr = strchr(buf + 5, 0);
-            ptr += Base64::btoa(key, int(n->nodekey.size()), ptr);
+            ptr += Base64::btoa(key, int(nodekey.size()), ptr);
             *ptr++ = '"';
 
             keys.append(buf, ptr - buf);
@@ -88,7 +88,7 @@ void ShareNodeKeys::add(NodeCore* n, Node* sn, int specific, const byte* item, i
         }
         else
         {
-            items[items.size() - 1].assign((const char*)&n->nodehandle, MegaClient::NODEHANDLE);
+            items[items.size() - 1].assign((const char*)&nodehandle, MegaClient::NODEHANDLE);
         }
     }
 }

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -494,13 +494,13 @@ void Transfer::addAnyMissingMediaFileAttributes(Node* node, /*const*/ std::strin
 
 #ifdef USE_MEDIAINFO
     char ext[8];
-    if (((type == PUT && size >= 16) || (node && node->nodekey.size() == FILENODEKEYLENGTH && node->size >= 16)) &&
+    if (((type == PUT && size >= 16) || (node && node->nodekey().size() == FILENODEKEYLENGTH && node->size >= 16)) &&
         client->fsaccess->getextension(&localpath, ext, sizeof(ext)) &&
         MediaProperties::isMediaFilenameExt(ext) &&
         !client->mediaFileInfo.mediaCodecsFailed)
     {
         // for upload, the key is in the transfer.  for download, the key is in the node.
-        uint32_t* attrKey = fileAttributeKeyPtr((type == PUT) ? filekey : (byte*)node->nodekey.data());
+        uint32_t* attrKey = fileAttributeKeyPtr((type == PUT) ? filekey : (byte*)node->nodekey().data());
 
         if (type == PUT || !node->hasfileattribute(fa_media) || client->mediaFileInfo.timeToRetryMediaPropertyExtraction(node->fileattrstring, attrKey))
         {
@@ -831,10 +831,10 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
                     if ((*it)->hprivate && !(*it)->hforeign && (n = client->nodebyhandle((*it)->h)))
                     {
                         if (!client->gfxdisabled && client->gfx && client->gfx->isgfx(&localname) &&
-                                keys.find(n->nodekey) == keys.end() &&    // this file hasn't been processed yet
+                                keys.find(n->nodekey()) == keys.end() &&    // this file hasn't been processed yet
                                 client->checkaccess(n, OWNER))
                         {
-                            keys.insert(n->nodekey);
+                            keys.insert(n->nodekey());
 
                             // check if restoration of missing attributes failed in the past (no access)
                             if (n->attrs.map.find('f') == n->attrs.map.end() || n->attrs.map['f'] != me64)

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -733,12 +733,12 @@ void SdkTest::createFile(string filename, bool largeFile)
     }
 }
 
-size_t SdkTest::getFilesize(string filename)
+int64_t SdkTest::getFilesize(string filename)
 {
     struct stat stat_buf;
     int rc = stat(filename.c_str(), &stat_buf);
 
-    return rc == 0 ? stat_buf.st_size : -1;
+    return rc == 0 ? int64_t(stat_buf.st_size) : int64_t(-1);
 }
 
 void SdkTest::deleteFile(string filename)
@@ -902,7 +902,7 @@ void SdkTest::getContactRequest(unsigned int apiIndex, bool outgoing, int expect
     delete crl;
 }
 
-void SdkTest::createFolder(unsigned int apiIndex, char *name, MegaNode *n, int timeout)
+void SdkTest::createFolder(unsigned int apiIndex, const char *name, MegaNode *n, int timeout)
 {
     mApi[apiIndex].requestFlags[MegaRequest::TYPE_CREATE_FOLDER] = false;
     mApi[apiIndex].megaApi->createFolder(name, n);
@@ -1482,8 +1482,8 @@ TEST_F(SdkTest, SdkTestTransfers)
 
     // --- Get the size of a file ---
 
-    long long filesize = long long(getFilesize(filename1));
-    long long nodesize = megaApi[0]->getSize(n2);
+    int64_t filesize = getFilesize(filename1);
+    int64_t nodesize = megaApi[0]->getSize(n2);
     EXPECT_EQ(filesize, nodesize) << "Wrong size of uploaded file";
 
 
@@ -1802,8 +1802,8 @@ TEST_F(SdkTest, SdkTestContacts)
     ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_AVATAR));
     ASSERT_STREQ( "Avatar changed", attributeValue.data()) << "Failed to change avatar";
 
-    size_t filesizeSrc = getFilesize(AVATARSRC);
-    size_t filesizeDst = getFilesize(AVATARDST);
+    int64_t filesizeSrc = getFilesize(AVATARSRC);
+    int64_t filesizeDst = getFilesize(AVATARDST);
     ASSERT_EQ(filesizeDst, filesizeSrc) << "Received avatar differs from uploaded avatar";
 
     delete u;
@@ -3843,7 +3843,7 @@ TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
 
     MegaNode *nonRaidNode = megaApi[0]->getNodeByHandle(mApi[0].h);
 
-    size_t filesize = getFilesize(filename2);
+    int64_t filesize = getFilesize(filename2);
     std::ifstream compareDecryptedFile(filename2.c_str(), ios::binary);
     ::mega::byte* compareDecryptedData = new ::mega::byte[filesize];
     compareDecryptedFile.read((char*)compareDecryptedData, filesize);

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -99,10 +99,7 @@ std::string megaApiCacheFolder(int index)
 #else
     p += "/";
 #endif
-    if (index == 0)
-        p += "sdk_test_mega_cache_0";
-    else
-        p += "sdk_test_mega_cache_1";
+    p += "sdk_test_mega_cache_" + to_string(index);
 
     if (!fileexists(p))
     {
@@ -128,6 +125,19 @@ void WaitMillisec(unsigned n)
     usleep(n * 1000);
 #endif
 }
+
+bool WaitFor(std::function<bool()>&& f, unsigned millisec)
+{
+    unsigned waited = 0;
+    for (;;)
+    {
+        if (f()) return true;
+        if (waited >= millisec) return false;
+        WaitMillisec(100);
+        waited += 100;
+    }
+}
+
 
 enum { USERALERT_ARRIVAL_MILLISEC = 1000 };
 
@@ -181,23 +191,27 @@ namespace
 void SdkTest::SetUp()
 {
     // do some initialization
-    megaApi[0] = megaApi[1] = NULL;
-
+    if (megaApi.size() < 2)
+    {
+        megaApi.resize(2);
+        mApi.resize(2);
+    }
     char *buf = getenv("MEGA_EMAIL");
     if (buf)
-        email[0].assign(buf);
-    ASSERT_LT((size_t)0, email[0].length()) << "Set your username at the environment variable $MEGA_EMAIL";
+        mApi[0].email.assign(buf);
+    ASSERT_LT((size_t)0, mApi[0].email.length()) << "Set your username at the environment variable $MEGA_EMAIL";
 
     buf = getenv("MEGA_PWD");
     if (buf)
-        pwd[0].assign(buf);
-    ASSERT_LT((size_t)0, pwd[0].length()) << "Set your password at the environment variable $MEGA_PWD";
+        mApi[0].pwd.assign(buf);
+    ASSERT_LT((size_t)0, mApi[0].pwd.length()) << "Set your password at the environment variable $MEGA_PWD";
 
     gTestingInvalidArgs = false;
 
-    if (megaApi[0] == NULL)
+    if (megaApi[0].get() == NULL)
     {
-        megaApi[0] = new MegaApi(APP_KEY.c_str(), megaApiCacheFolder(0).c_str(), USER_AGENT.c_str());
+        megaApi[0].reset(new MegaApi(APP_KEY.c_str(), megaApiCacheFolder(0).c_str(), USER_AGENT.c_str()));
+        mApi[0].megaApi = megaApi[0].get();
 
         megaApi[0]->setLoggingName("0");
         megaApi[0]->addListener(this);
@@ -250,25 +264,23 @@ void SdkTest::TearDown()
     }
 }
 
-void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
+int SdkTest::getApiIndex(MegaApi* api)
 {
-    unsigned int apiIndex;
-    if (api == megaApi[0])
-    {
-        apiIndex = 0;
-    }
-    else if (api == megaApi[1])
-    {
-        apiIndex = 1;
-    }
-    else
+    int apiIndex = -1;
+    for (int i = megaApi.size(); i--; )  if (megaApi[i].get() == api) apiIndex = i;
+    if (apiIndex == -1)
     {
         LOG_err << "Instance of MegaApi not recognized";
-        return;
     }
+    return apiIndex;
+}
 
-    requestFlags[apiIndex][request->getType()] = true;
-    lastError[apiIndex] = e->getErrorCode();
+void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
+{
+    int apiIndex = getApiIndex(api);
+    if (apiIndex < 0) return;
+    mApi[apiIndex].requestFlags[request->getType()] = true;
+    mApi[apiIndex].lastError = e->getErrorCode();
 
     switch(request->getType())
     {
@@ -281,7 +293,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         break;
 
     case MegaRequest::TYPE_EXPORT:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             h = request->getNodeHandle();
             if (request->getAccess())
@@ -292,7 +304,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         break;
 
     case MegaRequest::TYPE_GET_PUBLIC_NODE:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             publicNode = request->getPublicMegaNode();
         }
@@ -303,19 +315,19 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         break;
 
     case MegaRequest::TYPE_GET_ATTR_USER:
-        if ( (lastError[apiIndex] == API_OK) && (request->getParamType() != MegaApi::USER_ATTR_AVATAR) )
+        if ( (mApi[apiIndex].lastError == API_OK) && (request->getParamType() != MegaApi::USER_ATTR_AVATAR) )
         {
             attributeValue = request->getText();
         }
 
         if (request->getParamType() == MegaApi::USER_ATTR_AVATAR)
         {
-            if (lastError[apiIndex] == API_OK)
+            if (mApi[apiIndex].lastError == API_OK)
             {
                 attributeValue = "Avatar changed";
             }
 
-            if (lastError[apiIndex] == API_ENOENT)
+            if (mApi[apiIndex].lastError == API_ENOENT)
             {
                 attributeValue = "Avatar not found";
             }
@@ -325,7 +337,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
 #ifdef ENABLE_CHAT
 
     case MegaRequest::TYPE_CHAT_CREATE:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             MegaTextChat *chat = request->getMegaTextChatList()->get(0)->copy();
 
@@ -339,7 +351,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         break;
 
     case MegaRequest::TYPE_CHAT_INVITE:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             chatid = request->getNodeHandle();
             if (chats.find(chatid) != chats.end())
@@ -372,7 +384,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         break;
 
     case MegaRequest::TYPE_CHAT_REMOVE:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             chatid = request->getNodeHandle();
             if (chats.find(chatid) != chats.end())
@@ -403,7 +415,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         break;
 
     case MegaRequest::TYPE_CHAT_URL:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             link.assign(request->getLink());
         }
@@ -411,7 +423,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
 #endif
 
     case MegaRequest::TYPE_CREATE_ACCOUNT:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             sid = request->getSessionKey();
         }
@@ -425,14 +437,14 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
         break;
 
     case MegaRequest::TYPE_GET_REGISTERED_CONTACTS:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             stringTable.reset(request->getMegaStringTable()->copy());
         }
         break;
 
     case MegaRequest::TYPE_GET_COUNTRY_CALLING_CODES:
-        if (lastError[apiIndex] == API_OK)
+        if (mApi[apiIndex].lastError == API_OK)
         {
             stringListMap.reset(request->getMegaStringListMap()->copy());
         }
@@ -443,25 +455,13 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
 
 void SdkTest::onTransferFinish(MegaApi* api, MegaTransfer *transfer, MegaError* e)
 {
-    unsigned int apiIndex;
-    if (api == megaApi[0])
-    {
-        apiIndex = 0;
-    }
-    else if (api == megaApi[1])
-    {
-        apiIndex = 1;
-    }
-    else
-    {
-        LOG_err << "Instance of MegaApi not recognized";
-        return;
-    }
+    int apiIndex = getApiIndex(api);
+    if (apiIndex < 0) return;
 
-    transferFlags[apiIndex][transfer->getType()] = true;
-    lastError[apiIndex] = e->getErrorCode();
+    mApi[apiIndex].transferFlags[transfer->getType()] = true;
+    mApi[apiIndex].lastError = e->getErrorCode();
 
-    if (lastError[apiIndex] == MegaError::API_OK)
+    if (mApi[apiIndex].lastError == MegaError::API_OK)
         h = transfer->getNodeHandle();
 }
 
@@ -473,40 +473,16 @@ void SdkTest::onTransferUpdate(MegaApi *api, MegaTransfer *transfer)
 
 void SdkTest::onAccountUpdate(MegaApi* api)
 {
-    unsigned int apiIndex;
-    if (api == megaApi[0])
-    {
-        apiIndex = 0;
-    }
-    else if (api == megaApi[1])
-    {
-        apiIndex = 1;
-    }
-    else
-    {
-        LOG_err << "Instance of MegaApi not recognized";
-        return;
-    }
+    int apiIndex = getApiIndex(api);
+    if (apiIndex < 0) return;
 
-    accountUpdated[apiIndex] = true;
+    mApi[apiIndex].accountUpdated = true;
 }
 
 void SdkTest::onUsersUpdate(MegaApi* api, MegaUserList *users)
 {
-    unsigned int apiIndex;
-    if (api == megaApi[0])
-    {
-        apiIndex = 0;
-    }
-    else if (api == megaApi[1])
-    {
-        apiIndex = 1;
-    }
-    else
-    {
-        LOG_err << "Instance of MegaApi not recognized";
-        return;
-    }
+    int apiIndex = getApiIndex(api);
+    if (apiIndex < 0) return;
 
     if (!users)
         return;
@@ -519,161 +495,125 @@ void SdkTest::onUsersUpdate(MegaApi* api, MegaUserList *users)
                 || u->hasChanged(MegaUser::CHANGE_TYPE_FIRSTNAME)
                 || u->hasChanged(MegaUser::CHANGE_TYPE_LASTNAME))
         {
-            userUpdated[apiIndex] = true;
+            mApi[apiIndex].userUpdated = true;
         }
         else
         {
             // Contact is removed from main account
-            requestFlags[apiIndex][MegaRequest::TYPE_REMOVE_CONTACT] = true;
-            userUpdated[apiIndex] = true;
+            mApi[apiIndex].requestFlags[MegaRequest::TYPE_REMOVE_CONTACT] = true;
+            mApi[apiIndex].userUpdated = true;
         }
     }
 }
 
 void SdkTest::onNodesUpdate(MegaApi* api, MegaNodeList *nodes)
 {
-    unsigned int apiIndex;
-    if (api == megaApi[0])
-    {
-        apiIndex = 0;
-    }
-    else if (api == megaApi[1])
-    {
-        apiIndex = 1;
-    }
-    else
-    {
-        LOG_err << "Instance of MegaApi not recognized";
-        return;
-    }
+    int apiIndex = getApiIndex(api);
+    if (apiIndex < 0) return;
 
-    nodeUpdated[apiIndex] = true;
+    mApi[apiIndex].nodeUpdated = true;
 }
 
 void SdkTest::onContactRequestsUpdate(MegaApi* api, MegaContactRequestList* requests)
 {
-    unsigned int apiIndex;
-    if (api == megaApi[0])
-    {
-        apiIndex = 0;
-    }
-    else if (api == megaApi[1])
-    {
-        apiIndex = 1;
-    }
-    else
-    {
-        LOG_err << "Instance of MegaApi not recognized";
-        return;
-    }
+    int apiIndex = getApiIndex(api);
+    if (apiIndex < 0) return;
 
-    contactRequestUpdated[apiIndex] = true;
+    mApi[apiIndex].contactRequestUpdated = true;
 }
 
 #ifdef ENABLE_CHAT
 void SdkTest::onChatsUpdate(MegaApi *api, MegaTextChatList *chats)
 {
-    unsigned int apiIndex;
-    if (api == megaApi[0])
-    {
-        apiIndex = 0;
+    int apiIndex = getApiIndex(api);
+    if (apiIndex < 0) return;
 
-        MegaTextChatList *list = NULL;
-        if (chats)
-        {
-            list = chats->copy();
-        }
-        else
-        {
-            list = megaApi[0]->getChatList();
-        }
-        for (int i = 0; i < list->size(); i++)
-        {
-            handle chatid = list->get(i)->getHandle();
-            if (this->chats.find(chatid) != this->chats.end())
-            {
-                delete this->chats[chatid];
-                this->chats[chatid] = list->get(i)->copy();
-            }
-            else
-            {
-                this->chats[chatid] = list->get(i)->copy();
-            }
-        }
-        delete list;
-    }
-    else if (api == megaApi[1])
+    MegaTextChatList *list = NULL;
+    if (chats)
     {
-        apiIndex = 1;
+        list = chats->copy();
     }
     else
     {
-        LOG_err << "Instance of MegaApi not recognized";
-        return;
+        list = megaApi[apiIndex]->getChatList();
     }
+    for (int i = 0; i < list->size(); i++)
+    {
+        handle chatid = list->get(i)->getHandle();
+        if (this->chats.find(chatid) != this->chats.end())
+        {
+            delete this->chats[chatid];
+            this->chats[chatid] = list->get(i)->copy();
+        }
+        else
+        {
+            this->chats[chatid] = list->get(i)->copy();
+        }
+    }
+    delete list;
 
-    chatUpdated[apiIndex] = true;
+    mApi[apiIndex].chatUpdated = true;
 }
 
 void SdkTest::createChat(bool group, MegaTextChatPeerList *peers, int timeout)
 {
-    requestFlags[0][MegaRequest::TYPE_CHAT_CREATE] = false;
+    mApi[apiIndex].mApi[0].requestFlags[MegaRequest::TYPE_CHAT_CREATE] = false;
     megaApi[0]->createChat(group, peers);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_CHAT_CREATE], timeout);
+    waitForResponse(&mApi[apiIndex].mApi[0].requestFlags[MegaRequest::TYPE_CHAT_CREATE], timeout);
     if (timeout)
     {
-        ASSERT_TRUE(requestFlags[0][MegaRequest::TYPE_CHAT_CREATE]) << "Chat creation not finished after " << timeout  << " seconds";
+        ASSERT_TRUE(mApi[apiIndex].mApi[0].requestFlags[MegaRequest::TYPE_CHAT_CREATE]) << "Chat creation not finished after " << timeout  << " seconds";
     }
 
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Chat creation failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Chat creation failed (error: " << mApi[0].lastError << ")";
 }
 
 #endif
 
 void SdkTest::login(unsigned int apiIndex, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_LOGIN] = false;
-    megaApi[apiIndex]->login(email[apiIndex].data(), pwd[apiIndex].data());
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGIN] = false;
+    mApi[apiIndex].megaApi->login(mApi[apiIndex].email.data(), mApi[apiIndex].pwd.data());
 
-    ASSERT_TRUE(waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_LOGIN], timeout))
+    ASSERT_TRUE(waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGIN], timeout))
         << "Logging failed after " << timeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Logging failed (error: " << lastError[apiIndex] << ")";
-    ASSERT_TRUE(megaApi[apiIndex]->isLoggedIn()) << "Not logged it";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Logging failed (error: " << mApi[apiIndex].lastError << ")";
+    ASSERT_TRUE(mApi[apiIndex].megaApi->isLoggedIn()) << "Not logged it";
 }
 
 void SdkTest::loginBySessionId(unsigned int apiIndex, const std::string& sessionId, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_LOGIN] = false;
-    megaApi[apiIndex]->login(email[apiIndex].data(), pwd[apiIndex].data());
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGIN] = false;
+    mApi[apiIndex].megaApi->login(mApi[apiIndex].email.data(), mApi[apiIndex].pwd.data());
 
-    ASSERT_TRUE(waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_LOGIN], timeout))
+    ASSERT_TRUE(waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGIN], timeout))
         << "Logging failed after " << timeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Logging failed (error: " << lastError[apiIndex] << ")";
-    ASSERT_TRUE(megaApi[apiIndex]->isLoggedIn()) << "Not logged it";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Logging failed (error: " << mApi[apiIndex].lastError << ")";
+    ASSERT_TRUE(mApi[apiIndex].megaApi->isLoggedIn()) << "Not logged it";
 }
 
 void SdkTest::fetchnodes(unsigned int apiIndex, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_FETCH_NODES] = false;
-    megaApi[apiIndex]->fetchNodes();
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_FETCH_NODES] = false;
+    mApi[apiIndex].megaApi->fetchNodes();
 
-    ASSERT_TRUE( waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_FETCH_NODES], timeout) )
+    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_FETCH_NODES], timeout) )
             << "Fetchnodes failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Fetchnodes failed (error: " << lastError[apiIndex] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Fetchnodes failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
 void SdkTest::logout(unsigned int apiIndex, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_LOGOUT] = false;
-    megaApi[apiIndex]->logout(this);
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGOUT] = false;
+    mApi[apiIndex].megaApi->logout(this);
 
-    EXPECT_TRUE( waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_LOGOUT], timeout) )
+    EXPECT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGOUT], timeout) )
             << "Logout failed after " << timeout  << " seconds";
 
     // if the connection was closed before the response of the request was received, the result is ESID
-    if (lastError[apiIndex] == MegaError::API_ESID) lastError[apiIndex] = MegaError::API_OK;
+    if (mApi[apiIndex].lastError == MegaError::API_ESID) mApi[apiIndex].lastError = MegaError::API_OK;
 
-    EXPECT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Logout failed (error: " << lastError[apiIndex] << ")";
+    EXPECT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Logout failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
 char* SdkTest::dumpSession()
@@ -683,43 +623,36 @@ char* SdkTest::dumpSession()
 
 void SdkTest::locallogout(int timeout)
 {
-    requestFlags[0][MegaRequest::TYPE_LOGOUT] = false;
-    megaApi[0]->localLogout(this);
+    int apiIndex = 0;
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGOUT] = false;
+    megaApi[apiIndex]->localLogout(this);
 
-    EXPECT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_LOGOUT], timeout) )
+    EXPECT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_LOGOUT], timeout) )
             << "Local logout failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Local logout failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Local logout failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
 void SdkTest::resumeSession(const char *session, int timeout)
 {
-    requestFlags[0][MegaRequest::TYPE_LOGIN] = false;
-    megaApi[0]->fastLogin(session, this);
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_LOGIN], timeout) )
-            << "Resume session failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Resume session failed (error: " << lastError[0] << ")";
+    int apiIndex = 0;
+    ASSERT_EQ(MegaError::API_OK, synchronousFastLogin(apiIndex, session, this)) << "Resume session failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
 void SdkTest::purgeTree(MegaNode *p)
 {
+    int apiIndex = 0;
     MegaNodeList *children;
     children = megaApi[0]->getChildren(p);
 
     for (int i = 0; i < children->size(); i++)
     {
         MegaNode *n = children->get(i);
+
+        // removing the folder removes the children anyway
         if (n->isFolder())
             purgeTree(n);
 
-
-        requestFlags[0][MegaRequest::TYPE_REMOVE] = false;
-
-        megaApi[0]->remove(n);
-
-        ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_REMOVE]) )
-                << "Remove node operation failed after " << maxTimeout  << " seconds";
-        ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Remove node operation failed (error: " << lastError[0] << ")";
+        ASSERT_EQ(MegaError::API_OK, synchronousRemove(apiIndex, n)) << "Remove node operation failed (error: " << mApi[apiIndex].lastError << ")";
     }
 }
 
@@ -755,11 +688,26 @@ bool SdkTest::waitForResponse(bool *responseReceived, unsigned int timeout)
     return true;    // response is received
 }
 
-bool SdkTest::synchronousCall(bool &responseFlag, std::function<void()> f, unsigned int timeout)
+bool SdkTest::synchronousTransfer(int apiIndex, int type, std::function<void()> f, unsigned int timeout)
 {
-    responseFlag = false;
+    auto& flag = mApi[apiIndex].transferFlags[type];
+    flag = false;
     f();
-    return waitForResponse(&responseFlag, timeout);
+    auto result = waitForResponse(&flag, timeout);
+    EXPECT_TRUE(result) << "Transfer (type " << type << ") failed after " << timeout << " seconds";
+    if (!result) mApi[apiIndex].lastError = -999; // local timeout
+    return result;
+}
+
+bool SdkTest::synchronousRequest(int apiIndex, int type, std::function<void()> f, unsigned int timeout)
+{
+    auto& flag = mApi[apiIndex].requestFlags[type];
+    flag = false;
+    f();
+    auto result = waitForResponse(&flag, timeout);
+    EXPECT_TRUE(result) << "Request (type " << type << ") failed after " << timeout << " seconds";
+    if (!result) mApi[apiIndex].lastError = -999;
+    return result;
 }
 
 void SdkTest::createFile(string filename, bool largeFile)
@@ -798,145 +746,137 @@ void SdkTest::deleteFile(string filename)
 }
 
 
-void SdkTest::getMegaApiAux()
+void SdkTest::getMegaApiAux(unsigned index)
 {
-    if (megaApi[1] == NULL)
+    if (index >= megaApi.size())
     {
-        char *buf;
-        buf = getenv("MEGA_EMAIL_AUX");
-        if (buf)
-            email[1].assign(buf);
-        ASSERT_LT((size_t) 0, email[1].length()) << "Set auxiliar username at the environment variable $MEGA_EMAIL_AUX";
+        megaApi.resize(index + 1);
+        mApi.resize(index + 1);
+    }
+    if (megaApi[index].get() == NULL)
+    {
+        string strIndex = index > 1 ? to_string(index) : "";
+        if (const char *buf = getenv(("MEGA_EMAIL_AUX" + strIndex).c_str()))
+        {
+            mApi[index].email.assign(buf);
+        }
+        ASSERT_LT((size_t) 0, mApi[index].email.length()) << "Set auxiliar username at the environment variable $MEGA_EMAIL_AUX" << strIndex;
 
-        buf = getenv("MEGA_PWD_AUX");
-        if (buf)
-            pwd[1].assign(buf);
-        ASSERT_LT((size_t) 0, pwd[1].length()) << "Set the auxiliar password at the environment variable $MEGA_PWD_AUX";
+        if (const char* buf = getenv(("MEGA_PWD_AUX" + strIndex).c_str()))
+        {
+            mApi[index].pwd.assign(buf);
+        }
+        ASSERT_LT((size_t) 0, mApi[index].pwd.length()) << "Set the auxiliar password at the environment variable $MEGA_PWD_AUX" << strIndex;
 
-        megaApi[1] = new MegaApi(APP_KEY.c_str(), megaApiCacheFolder(1).c_str(), USER_AGENT.c_str());
+        megaApi[index].reset(new MegaApi(APP_KEY.c_str(), megaApiCacheFolder(index).c_str(), USER_AGENT.c_str()));
+        mApi[index].megaApi = megaApi[index].get();
 
-        megaApi[1]->setLoggingName("1");
-        megaApi[1]->setLogLevel(MegaApi::LOG_LEVEL_DEBUG);
-        megaApi[1]->addListener(this);
+        megaApi[index]->setLoggingName(to_string(index).c_str());
+        megaApi[index]->setLogLevel(MegaApi::LOG_LEVEL_DEBUG);
+        megaApi[index]->addListener(this);    // TODO: really should be per api
 
-        ASSERT_NO_FATAL_FAILURE( login(1) );
-        ASSERT_NO_FATAL_FAILURE( fetchnodes(1) );
+        ASSERT_NO_FATAL_FAILURE( login(index) );
+        ASSERT_NO_FATAL_FAILURE( fetchnodes(index) );
     }
 }
 
 void SdkTest::releaseMegaApi(unsigned int apiIndex)
 {
-    if (megaApi[apiIndex])
+    assert(megaApi[apiIndex].get() == mApi[apiIndex].megaApi);
+    if (mApi[apiIndex].megaApi)
     {
-        if (megaApi[apiIndex]->isLoggedIn())
+        if (mApi[apiIndex].megaApi->isLoggedIn())
         {
             ASSERT_NO_FATAL_FAILURE( logout(apiIndex) );
         }
 
-        delete megaApi[apiIndex];
-        megaApi[apiIndex] = NULL;
+        megaApi[apiIndex].reset();
+        mApi[apiIndex].megaApi = NULL;
     }
 }
 
-void SdkTest::inviteContact(string email, string message, int action, int timeout)
+void SdkTest::inviteContact(string email, string message, int action)
 {
-    requestFlags[0][MegaRequest::TYPE_INVITE_CONTACT] = false;
-    megaApi[0]->inviteContact(email.data(), message.data(), action);
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_INVITE_CONTACT], timeout) )
-            << "Contact invitation not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Contact invitation failed (error: " << lastError[0] << ")";
+    int apiIndex = 0;
+    ASSERT_EQ(MegaError::API_OK, synchronousInviteContact(apiIndex, email.data(), message.data(), action)) << "Contact invitation failed";
 }
 
-void SdkTest::replyContact(MegaContactRequest *cr, int action, int timeout)
+void SdkTest::replyContact(MegaContactRequest *cr, int action)
 {
-    requestFlags[1][MegaRequest::TYPE_REPLY_CONTACT_REQUEST] = false;
-    megaApi[1]->replyContactRequest(cr, action);
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[1][MegaRequest::TYPE_REPLY_CONTACT_REQUEST], timeout) )
-            << "Contact reply not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[1]) << "Contact reply failed (error: " << lastError[1] << ")";
+    int apiIndex = 1;
+    ASSERT_EQ(MegaError::API_OK, synchronousReplyContactRequest(apiIndex, cr, action)) << "Contact reply failed";
 }
 
 void SdkTest::removeContact(string email, int timeout)
 {
-    MegaUser *u = megaApi[0]->getContact(email.data());
+    int apiIndex = 0;
+    MegaUser *u = megaApi[apiIndex]->getContact(email.data());
     bool null_pointer = (u == NULL);
     ASSERT_FALSE(null_pointer) << "Cannot find the specified contact (" << email << ")";
 
     if (u->getVisibility() != MegaUser::VISIBILITY_VISIBLE)
     {
-        userUpdated[0] = true;  // nothing to do
+        mApi[apiIndex].userUpdated = true;  // nothing to do
         delete u;
         return;
     }
 
-    requestFlags[0][MegaRequest::TYPE_REMOVE_CONTACT] = false;
-    megaApi[0]->removeContact(u);
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_REMOVE_CONTACT], timeout) )
-            << "Contact deletion not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Contact deletion failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousRemoveContact(apiIndex, u)) << "Contact deletion failed";
 
     delete u;
 }
 
 void SdkTest::shareFolder(MegaNode *n, const char *email, int action, int timeout)
 {
-    requestFlags[0][MegaRequest::TYPE_SHARE] = false;
-    megaApi[0]->share(n, email, action);
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_SHARE], timeout) )
-            << "Folder sharing not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Folder sharing failed (error: " << lastError[0] << ")" << endl << "User: " << email << " Action: " << action;
+    int apiIndex = 0;
+    ASSERT_EQ(MegaError::API_OK, synchronousShare(apiIndex, n, email, action)) << "Folder sharing failed" << endl << "User: " << email << " Action: " << action;
 }
 
 void SdkTest::createPublicLink(unsigned apiIndex, MegaNode *n, m_time_t expireDate, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_EXPORT] = false;
-    megaApi[apiIndex]->exportNode(n, expireDate);
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_EXPORT] = false;
+    
+    auto err = synchronousExportNode(apiIndex, n, expireDate);
 
-    ASSERT_TRUE( waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_EXPORT], timeout) )
-            << "Public link creation not finished after " << timeout  << " seconds";
     if (!expireDate)
     {
-        ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Public link creation failed (error: " << lastError[apiIndex] << ")";
+        ASSERT_EQ(MegaError::API_OK, err) << "Public link creation failed (error: " << mApi[apiIndex].lastError << ")";
     }
     else
     {
-        bool res = MegaError::API_OK != lastError[apiIndex];
-        ASSERT_TRUE(res) << "Public link creation with expire time on free account (" << email[apiIndex] << ") succeed, and it mustn't";
+        bool res = MegaError::API_OK != err && err != -999;
+        ASSERT_TRUE(res) << "Public link creation with expire time on free account (" << mApi[apiIndex].email << ") succeed, and it mustn't";
     }
 }
 
 void SdkTest::importPublicLink(unsigned apiIndex, string link, MegaNode *parent, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_IMPORT_LINK] = false;
-    megaApi[apiIndex]->importFileLink(link.data(), parent);
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_IMPORT_LINK] = false;
+    mApi[apiIndex].megaApi->importFileLink(link.data(), parent);
 
-    ASSERT_TRUE(waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_IMPORT_LINK], timeout) )
+    ASSERT_TRUE(waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_IMPORT_LINK], timeout) )
             << "Public link import not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Public link import failed (error: " << lastError[apiIndex] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Public link import failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
 void SdkTest::getPublicNode(unsigned apiIndex, string link, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_GET_PUBLIC_NODE] = false;
-    megaApi[apiIndex]->getPublicNode(link.data());
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_GET_PUBLIC_NODE] = false;
+    mApi[apiIndex].megaApi->getPublicNode(link.data());
 
-    ASSERT_TRUE(waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_GET_PUBLIC_NODE], timeout) )
+    ASSERT_TRUE(waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_GET_PUBLIC_NODE], timeout) )
             << "Public link retrieval not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Public link retrieval failed (error: " << lastError[apiIndex] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Public link retrieval failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
 void SdkTest::removePublicLink(unsigned apiIndex, MegaNode *n, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_EXPORT] = false;
-    megaApi[apiIndex]->disableExport(n);
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_EXPORT] = false;
+    mApi[apiIndex].megaApi->disableExport(n);
 
-    ASSERT_TRUE( waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_EXPORT], timeout) )
+    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_EXPORT], timeout) )
             << "Public link removal not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Public link removal failed (error: " << lastError[apiIndex] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Public link removal failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
 void SdkTest::getContactRequest(unsigned int apiIndex, bool outgoing, int expectedSize)
@@ -945,17 +885,17 @@ void SdkTest::getContactRequest(unsigned int apiIndex, bool outgoing, int expect
 
     if (outgoing)
     {
-        crl = megaApi[apiIndex]->getOutgoingContactRequests();
-        ASSERT_EQ(expectedSize, crl->size()) << "Too many outgoing contact requests in main account";
+        crl = mApi[apiIndex].megaApi->getOutgoingContactRequests();
+        ASSERT_EQ(expectedSize, crl->size()) << "Too many outgoing contact requests in account " << apiIndex;
         if (expectedSize)
-            cr[apiIndex] = crl->get(0)->copy();
+            mApi[apiIndex].cr.reset(crl->get(0)->copy());
     }
     else
     {
-        crl = megaApi[apiIndex]->getIncomingContactRequests();
-        ASSERT_EQ(expectedSize, crl->size()) << "Too many incoming contact requests in auxiliar account";
+        crl = mApi[apiIndex].megaApi->getIncomingContactRequests();
+        ASSERT_EQ(expectedSize, crl->size()) << "Too many incoming contact requests in account " << apiIndex;
         if (expectedSize)
-            cr[apiIndex] = crl->get(0)->copy();
+            mApi[apiIndex].cr.reset(crl->get(0)->copy());
     }
 
     delete crl;
@@ -963,76 +903,67 @@ void SdkTest::getContactRequest(unsigned int apiIndex, bool outgoing, int expect
 
 void SdkTest::createFolder(unsigned int apiIndex, char *name, MegaNode *n, int timeout)
 {
-    requestFlags[apiIndex][MegaRequest::TYPE_CREATE_FOLDER] = false;
-    megaApi[apiIndex]->createFolder(name, n);
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_CREATE_FOLDER] = false;
+    mApi[apiIndex].megaApi->createFolder(name, n);
 
-    ASSERT_TRUE( waitForResponse(&requestFlags[apiIndex][MegaRequest::TYPE_CREATE_FOLDER], timeout) )
+    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_CREATE_FOLDER], timeout) )
             << "Folder creation failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[apiIndex]) << "Cannot create a folder (error: " << lastError[apiIndex] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Cannot create a folder (error: " << mApi[apiIndex].lastError << ")";
 }
 
-void SdkTest::getRegisteredContacts(const std::map<std::string, std::string>& contacts, const int timeout)
+void SdkTest::getRegisteredContacts(const std::map<std::string, std::string>& contacts)
 {
+    int apiIndex = 0;
+
     auto contactsStringMap = std::unique_ptr<MegaStringMap>{MegaStringMap::createInstance()};
     for  (const auto& pair : contacts)
     {
         contactsStringMap->set(pair.first.c_str(), pair.second.c_str());
     }
 
-    requestFlags[0][MegaRequest::TYPE_GET_REGISTERED_CONTACTS] = false;
-    megaApi[0]->getRegisteredContacts(contactsStringMap.get(), this);
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_GET_REGISTERED_CONTACTS], timeout) )
-            << "Get registered contacts not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Get registered contacts failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousGetRegisteredContacts(apiIndex, contactsStringMap.get(), this)) << "Get registered contacts failed";
 }
 
 void SdkTest::getCountryCallingCodes(const int timeout)
 {
-    requestFlags[0][MegaRequest::TYPE_GET_COUNTRY_CALLING_CODES] = false;
-    megaApi[0]->getCountryCallingCodes(this);
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_GET_COUNTRY_CALLING_CODES], timeout) )
-            << "Get country calling codes not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Get country calling codes failed (error: " << lastError[0] << ")";
+    int apiIndex = 0;
+    ASSERT_EQ(MegaError::API_OK, synchronousGetCountryCallingCodes(apiIndex, this)) << "Get country calling codes failed";
 }
 
 void SdkTest::setUserAttribute(int type, string value, int timeout)
 {
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_USER] = false;
+    int apiIndex = 0;
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_SET_ATTR_USER] = false;
 
     if (type == MegaApi::USER_ATTR_AVATAR)
     {
-        megaApi[0]->setAvatar(value.empty() ? NULL : value.c_str());
+        megaApi[apiIndex]->setAvatar(value.empty() ? NULL : value.c_str());
     }
     else
     {
-        megaApi[0]->setUserAttribute(type, value.c_str());
+        megaApi[apiIndex]->setUserAttribute(type, value.c_str());
     }
 
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_USER], timeout) )
+    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_SET_ATTR_USER], timeout) )
             << "User attribute setup not finished after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "User attribute setup failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "User attribute setup failed (error: " << mApi[apiIndex].lastError << ")";
 }
 
-void SdkTest::getUserAttribute(MegaUser *u, int type, int timeout, int accountIndex)
+void SdkTest::getUserAttribute(MegaUser *u, int type, int timeout, int apiIndex)
 {
-    requestFlags[accountIndex][MegaRequest::TYPE_GET_ATTR_USER] = false;
+    mApi[apiIndex].requestFlags[MegaRequest::TYPE_GET_ATTR_USER] = false;
 
+    int err;
     if (type == MegaApi::USER_ATTR_AVATAR)
     {
-        megaApi[accountIndex]->getUserAvatar(u, AVATARDST.data());
+        err = synchronousGetUserAvatar(apiIndex, u, AVATARDST.data());
     }
     else
     {
-        megaApi[accountIndex]->getUserAttribute(u, type);
+        err = synchronousGetUserAttribute(apiIndex, u, type);
     }
-
-    ASSERT_TRUE( waitForResponse(&requestFlags[accountIndex][MegaRequest::TYPE_GET_ATTR_USER], timeout) )
-            << "User attribute retrieval not finished after " << timeout  << " seconds";
-
-    bool result = (lastError[accountIndex] == MegaError::API_OK) || (lastError[accountIndex] == MegaError::API_ENOENT);
-    ASSERT_TRUE(result) << "User attribute retrieval failed (error: " << lastError[accountIndex] << ")";
+    bool result = (err == MegaError::API_OK) || (err == MegaError::API_ENOENT);
+    ASSERT_TRUE(result) << "User attribute retrieval failed (error: " << err << ")";
 }
 
 ///////////////////////////__ Tests using SdkTest __//////////////////////////////////
@@ -1055,31 +986,25 @@ TEST_F(SdkTest, DISABLED_SdkTestCreateAccount)
     LOG_info << "___TEST Create account___";
 
     // Create an ephemeral session internally and send a confirmation link to email
-    requestFlags[0][MegaRequest::TYPE_CREATE_ACCOUNT] = false;
-    megaApi[0]->createAccount(email1.c_str(), pwd.c_str(), "MyFirstname", "MyLastname");
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CREATE_ACCOUNT]) )
+    ASSERT_TRUE(synchronousCreateAccount(0, email1.c_str(), pwd.c_str(), "MyFirstname", "MyLastname"))
             << "Account creation has failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Account creation failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Account creation failed (error: " << mApi[0].lastError << ")";
 
     // Logout from ephemeral session and resume session
     ASSERT_NO_FATAL_FAILURE( locallogout() );
-    requestFlags[0][MegaRequest::TYPE_CREATE_ACCOUNT] = false;
-    megaApi[0]->resumeCreateAccount(sid.c_str());
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CREATE_ACCOUNT]) )
+    ASSERT_TRUE(synchronousResumeCreateAccount(0, sid.c_str()))
             << "Account creation has failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Account creation failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Account creation failed (error: " << mApi[0].lastError << ")";
 
     // Send the confirmation link to a different email address
-    requestFlags[0][MegaRequest::TYPE_SEND_SIGNUP_LINK] = false;
-    megaApi[0]->sendSignupLink(email2.c_str(), "MyFirstname", pwd.c_str());
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_SEND_SIGNUP_LINK]) )
+    ASSERT_TRUE(synchronousSendSignupLink(0, email2.c_str(), "MyFirstname", pwd.c_str()))
             << "Send confirmation link to another email failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Send confirmation link to another email address failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Send confirmation link to another email address failed (error: " << mApi[0].lastError << ")";
 
     // Now, confirm the account by using a different client...
 
     // ...and wait for the AP notifying the confirmation
-    bool *flag = &accountUpdated[0]; *flag = false;
+    bool *flag = &mApi[0].accountUpdated; *flag = false;
     ASSERT_TRUE( waitForResponse(flag) )
             << "Account confirmation not received after " << maxTimeout << " seconds";
 }
@@ -1109,35 +1034,26 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
 
     string filename1 = UPFILE;
     createFile(filename1, false);
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
-    megaApi[0]->startUpload(filename1.data(), rootnode);
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
 
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload a test file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousStartUpload(0, filename1.data(), rootnode)) << "Cannot upload a test file";
 
     MegaNode *n1 = megaApi[0]->getNodeByHandle(h);
     bool null_pointer = (n1 == NULL);
-    ASSERT_FALSE(null_pointer) << "Cannot initialize test scenario (error: " << lastError[0] << ")";
+    ASSERT_FALSE(null_pointer) << "Cannot initialize test scenario (error: " << mApi[0].lastError << ")";
 
 
     // ___ Set invalid duration of a node ___
 
     gTestingInvalidArgs = true;
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeDuration(n1, -14);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_EARGS, lastError[0]) << "Unexpected error setting invalid node duration (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_EARGS, synchronousSetNodeDuration(0, n1, -14)) << "Unexpected error setting invalid node duration";
 
     gTestingInvalidArgs = false;
 
 
     // ___ Set duration of a node ___
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeDuration(n1, 929734);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot set node duration (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousSetNodeDuration(0, n1, 929734)) << "Cannot set node duration";
 
     delete n1;
     n1 = megaApi[0]->getNodeByHandle(h);
@@ -1146,10 +1062,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
 
     // ___ Reset duration of a node ___
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeDuration(n1, -1);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot reset node duration (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousSetNodeDuration(0, n1, -1)) << "Cannot reset node duration";
 
     delete n1;
     n1 = megaApi[0]->getNodeByHandle(h);
@@ -1160,39 +1073,26 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
 
     gTestingInvalidArgs = true;
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, -1523421.8719987255814, +6349.54);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_EARGS, lastError[0]) << "Unexpected error setting invalid node coordinates (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_EARGS, synchronousSetNodeCoordinates(0, n1, -1523421.8719987255814, +6349.54)) << "Unexpected error setting invalid node coordinates";
 
 
     // ___ Set invalid coordinates of a node (out of range) ___
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, -160.8719987255814, +49.54);    // latitude must be [-90, 90]
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_EARGS, lastError[0]) << "Unexpected error setting invalid node coordinates (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_EARGS, synchronousSetNodeCoordinates(0, n1, -160.8719987255814, +49.54)) << "Unexpected error setting invalid node coordinates";
 
 
     // ___ Set invalid coordinates of a node (out of range) ___
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, MegaNode::INVALID_COORDINATE, +69.54);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_EARGS, lastError[0]) << "Unexpected error trying to reset only one coordinate (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_EARGS, synchronousSetNodeCoordinates(0, n1, MegaNode::INVALID_COORDINATE, +69.54)) << "Unexpected error trying to reset only one coordinate";
 
     gTestingInvalidArgs = false;
-
 
     // ___ Set coordinates of a node ___
 
     double lat = -51.8719987255814;
     double lon = +179.54;
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, lat, lon);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot set node coordinates (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousSetNodeCoordinates(0, n1, lat, lon)) << "Cannot set node coordinates";
 
     delete n1;
     n1 = megaApi[0]->getNodeByHandle(h);
@@ -1214,10 +1114,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     lon = 0;
     lat = 0;
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, 0, 0);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot set node coordinates (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousSetNodeCoordinates(0, n1, 0, 0)) << "Cannot set node coordinates";
 
     delete n1;
     n1 = megaApi[0]->getNodeByHandle(h);
@@ -1235,10 +1132,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     lat = 90;
     lon = 180;
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, lat, lon);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot set node coordinates (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousSetNodeCoordinates(0, n1, lat, lon)) << "Cannot set node coordinates";
 
     delete n1;
     n1 = megaApi[0]->getNodeByHandle(h);
@@ -1253,10 +1147,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     lat = -90;
     lon = -180;
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, lat, lon);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot set node coordinates (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousSetNodeCoordinates(0, n1, lat, lon)) << "Cannot set node coordinates";
 
     delete n1;
     n1 = megaApi[0]->getNodeByHandle(h);
@@ -1270,9 +1161,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
 
     lat = lon = MegaNode::INVALID_COORDINATE;
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, lat, lon);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
+    synchronousSetNodeCoordinates(0, n1, lat, lon);
 
     delete n1;
     n1 = megaApi[0]->getNodeByHandle(h);
@@ -1285,10 +1174,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     // ___ set the coords  (shareable)
     lat = -51.8719987255814;
     lon = +179.54;
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
-    megaApi[0]->setNodeCoordinates(n1, lat, lon);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot set node coordinates (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousSetNodeCoordinates(0, n1, lat, lon)) << "Cannot set node coordinates";
 
     // ___ get a link to the file node
     ASSERT_NO_FATAL_FAILURE(createPublicLink(0, n1));
@@ -1306,30 +1192,27 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     ASSERT_TRUE(veryclose(lon, nimported->getLongitude())) << "Longitude " << n1->getLongitude() << " value does not match " << lon;
 
     // ___ remove the imported node, for a clean next test
-    requestFlags[1][MegaRequest::TYPE_REMOVE] = false;
+    mApi[1].requestFlags[MegaRequest::TYPE_REMOVE] = false;
     megaApi[1]->remove(nimported);
-    ASSERT_TRUE(waitForResponse(&requestFlags[1][MegaRequest::TYPE_REMOVE]))
+    ASSERT_TRUE(waitForResponse(&mApi[1].requestFlags[MegaRequest::TYPE_REMOVE]))
         << "Remove operation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[1]) << "Cannot remove a node (error: " << lastError[1] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[1].lastError) << "Cannot remove a node (error: " << mApi[1].lastError << ")";
 
 
     // ___ again but unshareable this time - totally separate new node - set the coords  (unshareable)
 
     string filename2 = "a"+UPFILE;
     createFile(filename2, false);
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
-    megaApi[0]->startUpload(filename2.data(), rootnode);
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload a test file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousStartUpload(0, filename2.data(), rootnode)) << "Cannot upload a test file";
     MegaNode *n2 = megaApi[0]->getNodeByHandle(h);
-    ASSERT_NE(n2, ((void*)NULL)) << "Cannot initialize second node for scenario (error: " << lastError[0] << ")";
+    ASSERT_NE(n2, ((void*)NULL)) << "Cannot initialize second node for scenario (error: " << mApi[0].lastError << ")";
 
     lat = -5 + -51.8719987255814;
     lon = -5 + +179.54;
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_SET_ATTR_NODE] = false;
     megaApi[0]->setUnshareableNodeCoordinates(n2, lat, lon);
-    waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_NODE]);
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot set unshareable node coordinates (error: " << lastError[0] << ")";
+    waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_SET_ATTR_NODE]);
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot set unshareable node coordinates (error: " << mApi[0].lastError << ")";
 
     // ___ confirm this user can read them
     MegaNode* selfread = megaApi[0]->getNodeByHandle(n2->getHandle());
@@ -1405,11 +1288,11 @@ TEST_F(SdkTest, SdkTestNodeOperations)
     MegaNode *n1 = megaApi[0]->getNodeByHandle(h);
     strcpy(name1, "Folder renamed");
 
-    requestFlags[0][MegaRequest::TYPE_RENAME] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_RENAME] = false;
     megaApi[0]->renameNode(n1, name1);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_RENAME]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_RENAME]) )
             << "Rename operation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot rename a node (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot rename a node (error: " << mApi[0].lastError << ")";
 
 
     // --- Copy a node ---
@@ -1417,11 +1300,11 @@ TEST_F(SdkTest, SdkTestNodeOperations)
     MegaNode *n2;
     char name2[64] = "Folder copy";
 
-    requestFlags[0][MegaRequest::TYPE_COPY] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_COPY] = false;
     megaApi[0]->copyNode(n1, rootnode, name2);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_COPY]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_COPY]) )
             << "Copy operation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot create a copy of a node (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot create a copy of a node (error: " << mApi[0].lastError << ")";
     n2 = megaApi[0]->getNodeByHandle(h);
 
 
@@ -1470,11 +1353,11 @@ TEST_F(SdkTest, SdkTestNodeOperations)
 
     // --- Move a node ---
 
-    requestFlags[0][MegaRequest::TYPE_MOVE] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_MOVE] = false;
     megaApi[0]->moveNode(n1, n2);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_MOVE]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_MOVE]) )
             << "Move operation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot move node (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot move node (error: " << mApi[0].lastError << ")";
 
 
     // --- Get parent node ---
@@ -1487,20 +1370,20 @@ TEST_F(SdkTest, SdkTestNodeOperations)
 
     // --- Send to Rubbish bin ---
 
-    requestFlags[0][MegaRequest::TYPE_MOVE] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_MOVE] = false;
     megaApi[0]->moveNode(n2, megaApi[0]->getRubbishNode());
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_MOVE]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_MOVE]) )
             << "Move operation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot move node to Rubbish bin (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot move node to Rubbish bin (error: " << mApi[0].lastError << ")";
 
 
     // --- Remove a node ---
 
-    requestFlags[0][MegaRequest::TYPE_REMOVE] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_REMOVE] = false;
     megaApi[0]->remove(n2);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_REMOVE]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_REMOVE]) )
             << "Remove operation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot remove a node (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot remove a node (error: " << mApi[0].lastError << ")";
 
     delete rootnode;
     delete n1;
@@ -1535,53 +1418,53 @@ TEST_F(SdkTest, SdkTestTransfers)
 
     // --- Cancel a transfer ---
 
-    requestFlags[0][MegaRequest::TYPE_CANCEL_TRANSFERS] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_CANCEL_TRANSFERS] = false;
     megaApi[0]->startUpload(filename1.data(), rootnode);
     megaApi[0]->cancelTransfers(MegaTransfer::TYPE_UPLOAD);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CANCEL_TRANSFERS]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_CANCEL_TRANSFERS]) )
             << "Cancellation of transfers failed after " << maxTimeout << " seconds";
-    EXPECT_EQ(MegaError::API_OK, lastError[0]) << "Transfer cancellation failed (error: " << lastError[0] << ")";
+    EXPECT_EQ(MegaError::API_OK, mApi[0].lastError) << "Transfer cancellation failed (error: " << mApi[0].lastError << ")";
 
 
     // --- Upload a file (part 1) ---
 
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_UPLOAD] = false;
     megaApi[0]->startUpload(filename1.data(), rootnode);
     // do not wait yet for completion
 
 
     // --- Pause a transfer ---
 
-    requestFlags[0][MegaRequest::TYPE_PAUSE_TRANSFERS] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_PAUSE_TRANSFERS] = false;
     megaApi[0]->pauseTransfers(true, MegaTransfer::TYPE_UPLOAD);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_PAUSE_TRANSFERS]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_PAUSE_TRANSFERS]) )
             << "Pause of transfers failed after " << maxTimeout << " seconds";
-    EXPECT_EQ(MegaError::API_OK, lastError[0]) << "Cannot pause transfer (error: " << lastError[0] << ")";
+    EXPECT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot pause transfer (error: " << mApi[0].lastError << ")";
     EXPECT_TRUE(megaApi[0]->areTransfersPaused(MegaTransfer::TYPE_UPLOAD)) << "Upload transfer not paused";
 
 
     // --- Resume a transfer ---
 
-    requestFlags[0][MegaRequest::TYPE_PAUSE_TRANSFERS] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_PAUSE_TRANSFERS] = false;
     megaApi[0]->pauseTransfers(false, MegaTransfer::TYPE_UPLOAD);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_PAUSE_TRANSFERS]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_PAUSE_TRANSFERS]) )
             << "Resumption of transfers after pause has failed after " << maxTimeout << " seconds";
-    EXPECT_EQ(MegaError::API_OK, lastError[0]) << "Cannot resume transfer (error: " << lastError[0] << ")";
+    EXPECT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot resume transfer (error: " << mApi[0].lastError << ")";
     EXPECT_FALSE(megaApi[0]->areTransfersPaused(MegaTransfer::TYPE_UPLOAD)) << "Upload transfer not resumed";
 
 
     // --- Upload a file (part 2) ---
 
 
-    ASSERT_TRUE( waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD], 600) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_UPLOAD], 600) )
             << "Upload transfer failed after " << 600 << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot upload file (error: " << mApi[0].lastError << ")";
 
     MegaNode *n1 = megaApi[0]->getNodeByHandle(h);
     bool null_pointer = (n1 == NULL);
 
-    ASSERT_FALSE(null_pointer) << "Cannot upload file (error: " << lastError[0] << ")";
-    ASSERT_STREQ(filename1.data(), n1->getName()) << "Uploaded file with wrong name (error: " << lastError[0] << ")";
+    ASSERT_FALSE(null_pointer) << "Cannot upload file (error: " << mApi[0].lastError << ")";
+    ASSERT_STREQ(filename1.data(), n1->getName()) << "Uploaded file with wrong name (error: " << mApi[0].lastError << ")";
 
 
     // --- Get node by fingerprint (needs to be a file, not a folder) ---
@@ -1607,17 +1490,17 @@ TEST_F(SdkTest, SdkTestTransfers)
 
     string filename2 = "./" + DOWNFILE;
 
-    transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[0]->startDownload(n2, filename2.c_str());
-    ASSERT_TRUE( waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 600) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 600) )
             << "Download transfer failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the file (error: " << mApi[0].lastError << ")";
 
     MegaNode *n3 = megaApi[0]->getNodeByHandle(h);
     null_pointer = (n3 == NULL);
 
     ASSERT_FALSE(null_pointer) << "Cannot download node";
-    ASSERT_EQ(n2->getHandle(), n3->getHandle()) << "Cannot download node (error: " << lastError[0] << ")";
+    ASSERT_EQ(n2->getHandle(), n3->getHandle()) << "Cannot download node (error: " << mApi[0].lastError << ")";
 
 
     // --- Upload a 0-bytes file ---
@@ -1626,34 +1509,29 @@ TEST_F(SdkTest, SdkTestTransfers)
     FILE *fp = fopen(filename3.c_str(), "w");
     fclose(fp);
 
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
-    megaApi[0]->startUpload(filename3.c_str(), rootnode);
-
-    ASSERT_TRUE( waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD], 600) )
-            << "Upload 0-byte file failed after " << 600 << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, synchronousStartUpload(0, filename3.c_str(), rootnode)) << "Cannot upload a test file";
 
     MegaNode *n4 = megaApi[0]->getNodeByHandle(h);
     null_pointer = (n4 == NULL);
 
-    ASSERT_FALSE(null_pointer) << "Cannot upload file (error: " << lastError[0] << ")";
-    ASSERT_STREQ(filename3.data(), n4->getName()) << "Uploaded file with wrong name (error: " << lastError[0] << ")";
+    ASSERT_FALSE(null_pointer) << "Cannot upload file (error: " << mApi[0].lastError << ")";
+    ASSERT_STREQ(filename3.data(), n4->getName()) << "Uploaded file with wrong name (error: " << mApi[0].lastError << ")";
 
 
     // --- Download a 0-byte file ---
 
     filename3 = "./" + EMPTYFILE;
-    transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[0]->startDownload(n4, filename3.c_str());
-    ASSERT_TRUE( waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 600) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 600) )
             << "Download 0-byte file failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the file (error: " << mApi[0].lastError << ")";
 
     MegaNode *n5 = megaApi[0]->getNodeByHandle(h);
     null_pointer = (n5 == NULL);
 
     ASSERT_FALSE(null_pointer) << "Cannot download node";
-    ASSERT_EQ(n4->getHandle(), n5->getHandle()) << "Cannot download node (error: " << lastError[0] << ")";
+    ASSERT_EQ(n4->getHandle(), n5->getHandle()) << "Cannot download node (error: " << mApi[0].lastError << ")";
 
 
     delete rootnode;
@@ -1703,100 +1581,100 @@ TEST_F(SdkTest, SdkTestContacts)
 
     // --- Check my email and the email of the contact ---
 
-    EXPECT_STREQ(email[0].data(), megaApi[0]->getMyEmail());
-    EXPECT_STREQ(email[1].data(), megaApi[1]->getMyEmail());
+    EXPECT_STREQ(mApi[0].email.data(), megaApi[0]->getMyEmail());
+    EXPECT_STREQ(mApi[1].email.data(), megaApi[1]->getMyEmail());
 
 
     // --- Send a new contact request ---
 
     string message = "Hi contact. This is a testing message";
 
-    contactRequestUpdated[0] = contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( inviteContact(email[1], message, MegaContactRequest::INVITE_ACTION_ADD) );
+    mApi[0].contactRequestUpdated = mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( inviteContact(mApi[1].email, message, MegaContactRequest::INVITE_ACTION_ADD) );
     // if there were too many invitations within a short period of time, the invitation can be rejected by
     // the API with `API_EOVERQUOTA = -17` as counter spamming meassure (+500 invites in the last 50 days)
 
 
     // --- Check the sent contact request ---
 
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[0]) )   // at the source side (main account)
+    ASSERT_TRUE( waitForResponse(&mApi[0].contactRequestUpdated) )   // at the source side (main account)
             << "Contact request update not received after " << maxTimeout << " seconds";
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(0, true) );
 
-    ASSERT_STREQ(message.data(), cr[0]->getSourceMessage()) << "Message sent is corrupted";
-    ASSERT_STREQ(email[0].data(), cr[0]->getSourceEmail()) << "Wrong source email";
-    ASSERT_STREQ(email[1].data(), cr[0]->getTargetEmail()) << "Wrong target email";
-    ASSERT_EQ(MegaContactRequest::STATUS_UNRESOLVED, cr[0]->getStatus()) << "Wrong contact request status";
-    ASSERT_TRUE(cr[0]->isOutgoing()) << "Wrong direction of the contact request";
+    ASSERT_STREQ(message.data(), mApi[0].cr->getSourceMessage()) << "Message sent is corrupted";
+    ASSERT_STREQ(mApi[0].email.data(), mApi[0].cr->getSourceEmail()) << "Wrong source email";
+    ASSERT_STREQ(mApi[1].email.data(), mApi[0].cr->getTargetEmail()) << "Wrong target email";
+    ASSERT_EQ(MegaContactRequest::STATUS_UNRESOLVED, mApi[0].cr->getStatus()) << "Wrong contact request status";
+    ASSERT_TRUE(mApi[0].cr->isOutgoing()) << "Wrong direction of the contact request";
 
-    delete cr[0];      cr[0] = NULL;
+    mApi[0].cr.reset();
 
 
     // --- Check received contact request ---
 
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request update not received after " << maxTimeout << " seconds";
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false) );
 
     // There isn't message when a user invites the same user too many times, to avoid spamming
-    if (cr[1]->getSourceMessage())
+    if (mApi[1].cr->getSourceMessage())
     {
-        ASSERT_STREQ(message.data(), cr[1]->getSourceMessage()) << "Message received is corrupted";
+        ASSERT_STREQ(message.data(), mApi[1].cr->getSourceMessage()) << "Message received is corrupted";
     }
-    ASSERT_STREQ(email[0].data(), cr[1]->getSourceEmail()) << "Wrong source email";
-    ASSERT_STREQ(NULL, cr[1]->getTargetEmail()) << "Wrong target email";    // NULL according to MegaApi documentation
-    ASSERT_EQ(MegaContactRequest::STATUS_UNRESOLVED, cr[1]->getStatus()) << "Wrong contact request status";
-    ASSERT_FALSE(cr[1]->isOutgoing()) << "Wrong direction of the contact request";
+    ASSERT_STREQ(mApi[0].email.data(), mApi[1].cr->getSourceEmail()) << "Wrong source email";
+    ASSERT_STREQ(NULL, mApi[1].cr->getTargetEmail()) << "Wrong target email";    // NULL according to MegaApi documentation
+    ASSERT_EQ(MegaContactRequest::STATUS_UNRESOLVED, mApi[1].cr->getStatus()) << "Wrong contact request status";
+    ASSERT_FALSE(mApi[1].cr->isOutgoing()) << "Wrong direction of the contact request";
 
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
 
     // --- Ignore received contact request ---
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false) );
 
-    contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( replyContact(cr[1], MegaContactRequest::REPLY_ACTION_IGNORE) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( replyContact(mApi[1].cr.get(), MegaContactRequest::REPLY_ACTION_IGNORE) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request update not received after " << maxTimeout << " seconds";
 
     // Ignoring a PCR does not generate actionpackets for the account sending the invitation
 
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false, 0) );
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
 
     // --- Cancel the invitation ---
 
     message = "I don't wanna be your contact anymore";
 
-    contactRequestUpdated[0] = false;
-    ASSERT_NO_FATAL_FAILURE( inviteContact(email[1], message, MegaContactRequest::INVITE_ACTION_DELETE) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[0]) )   // at the target side (auxiliar account), where the deletion is checked
+    mApi[0].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( inviteContact(mApi[1].email, message, MegaContactRequest::INVITE_ACTION_DELETE) );
+    ASSERT_TRUE( waitForResponse(&mApi[0].contactRequestUpdated) )   // at the target side (auxiliar account), where the deletion is checked
             << "Contact request update not received after " << maxTimeout << " seconds";
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(0, true, 0) );
-    delete cr[0];      cr[0] = NULL;
+    mApi[0].cr.reset();
     
 
     // --- Remind a contact invitation (cannot until 2 weeks after invitation/last reminder) ---
 
-//    contactRequestUpdated[1] = false;
-//    megaApi->inviteContact(email[1].data(), message.data(), MegaContactRequest::INVITE_ACTION_REMIND);
-//    waitForResponse(&contactRequestUpdated[1], 0);    // only at auxiliar account, where the deletion is checked
+//    mApi[1].contactRequestUpdated = false;
+//    megaApi->inviteContact(mApi[1].email.data(), message.data(), MegaContactRequest::INVITE_ACTION_REMIND);
+//    waitForResponse(&mApi[1].contactRequestUpdated, 0);    // only at auxiliar account, where the deletion is checked
 
-//    ASSERT_TRUE(contactRequestUpdated[1]) << "Contact invitation reminder not received after " << timeout  << " seconds";
+//    ASSERT_TRUE(mApi[1].contactRequestUpdated) << "Contact invitation reminder not received after " << timeout  << " seconds";
 
 
     // --- Invite a new contact (again) ---
 
-    contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( inviteContact(email[1], message, MegaContactRequest::INVITE_ACTION_ADD) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( inviteContact(mApi[1].email, message, MegaContactRequest::INVITE_ACTION_ADD) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
 
 
@@ -1804,27 +1682,27 @@ TEST_F(SdkTest, SdkTestContacts)
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false) );
 
-    contactRequestUpdated[0] = contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( replyContact(cr[1], MegaContactRequest::REPLY_ACTION_DENY) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[0].contactRequestUpdated = mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( replyContact(mApi[1].cr.get(), MegaContactRequest::REPLY_ACTION_DENY) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[0]) )   // at the source side (main account)
+    ASSERT_TRUE( waitForResponse(&mApi[0].contactRequestUpdated) )   // at the source side (main account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
 
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(0, true, 0) );
-    delete cr[0];   cr[0] = NULL;
+    mApi[0].cr.reset();
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false, 0) );
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
 
     // --- Invite a new contact (again) ---
 
-    contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( inviteContact(email[1], message, MegaContactRequest::INVITE_ACTION_ADD) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( inviteContact(mApi[1].email, message, MegaContactRequest::INVITE_ACTION_ADD) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
 
 
@@ -1832,29 +1710,29 @@ TEST_F(SdkTest, SdkTestContacts)
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false) );
 
-    contactRequestUpdated[0] = contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( replyContact(cr[1], MegaContactRequest::REPLY_ACTION_ACCEPT) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[0]) )   // at the target side (main account)
+    mApi[0].contactRequestUpdated = mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( replyContact(mApi[1].cr.get(), MegaContactRequest::REPLY_ACTION_ACCEPT) );
+    ASSERT_TRUE( waitForResponse(&mApi[0].contactRequestUpdated) )   // at the target side (main account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
 
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(0, true, 0) );
-    delete cr[0];   cr[0] = NULL;
+    mApi[0].cr.reset();
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false, 0) );
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
 
     // --- Modify firstname ---
 
     string firstname = "My firstname";
 
-    userUpdated[1] = false;
+    mApi[1].userUpdated = false;
     ASSERT_NO_FATAL_FAILURE( setUserAttribute(MegaApi::USER_ATTR_FIRSTNAME, firstname));
-    ASSERT_TRUE( waitForResponse(&userUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].userUpdated) )   // at the target side (auxiliar account)
             << "User attribute update not received after " << maxTimeout << " seconds";
 
 
@@ -1863,7 +1741,7 @@ TEST_F(SdkTest, SdkTestContacts)
     MegaUser *u = megaApi[0]->getMyUser();
 
     bool null_pointer = (u == NULL);
-    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << email[0];
+    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << mApi[0].email;
 
     ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_FIRSTNAME));
     ASSERT_EQ( firstname, attributeValue) << "Firstname is wrong";
@@ -1875,9 +1753,9 @@ TEST_F(SdkTest, SdkTestContacts)
 
     u = megaApi[0]->getMyUser();
 
-    requestFlags[0][MegaRequest::TYPE_SET_ATTR_USER] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_SET_ATTR_USER] = false;
     megaApi[0]->masterKeyExported();
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_SET_ATTR_USER]) );
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_SET_ATTR_USER]) );
 
     ASSERT_NO_FATAL_FAILURE( getUserAttribute(u, MegaApi::USER_ATTR_PWD_REMINDER, maxTimeout, 0));
     string pwdReminder = attributeValue;
@@ -1905,9 +1783,9 @@ TEST_F(SdkTest, SdkTestContacts)
 
     ASSERT_TRUE(fileexists(AVATARSRC)) <<  "File " +AVATARSRC+ " is needed in folder " << cwd();
 
-    userUpdated[1] = false;
+    mApi[1].userUpdated = false;
     ASSERT_NO_FATAL_FAILURE( setUserAttribute(MegaApi::USER_ATTR_AVATAR, AVATARSRC));
-    ASSERT_TRUE( waitForResponse(&userUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].userUpdated) )   // at the target side (auxiliar account)
             << "User attribute update not received after " << maxTimeout << " seconds";
 
 
@@ -1916,7 +1794,7 @@ TEST_F(SdkTest, SdkTestContacts)
     u = megaApi[0]->getMyUser();
 
     null_pointer = (u == NULL);
-    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << email[0];
+    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << mApi[0].email;
 
     attributeValue = "";
 
@@ -1932,9 +1810,9 @@ TEST_F(SdkTest, SdkTestContacts)
 
     // --- Delete avatar ---
 
-    userUpdated[1] = false;
+    mApi[1].userUpdated = false;
     ASSERT_NO_FATAL_FAILURE( setUserAttribute(MegaApi::USER_ATTR_AVATAR, ""));
-    ASSERT_TRUE( waitForResponse(&userUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].userUpdated) )   // at the target side (auxiliar account)
             << "User attribute update not received after " << maxTimeout << " seconds";
 
 
@@ -1943,7 +1821,7 @@ TEST_F(SdkTest, SdkTestContacts)
     u = megaApi[0]->getMyUser();
 
     null_pointer = (u == NULL);
-    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << email[0];
+    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << mApi[0].email;
 
     attributeValue = "";
 
@@ -1955,15 +1833,15 @@ TEST_F(SdkTest, SdkTestContacts)
 
     // --- Delete an existing contact ---
 
-    userUpdated[0] = false;
-    ASSERT_NO_FATAL_FAILURE( removeContact(email[1]) );
-    ASSERT_TRUE( waitForResponse(&userUpdated[0]) )   // at the target side (main account)
+    mApi[0].userUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( removeContact(mApi[1].email) );
+    ASSERT_TRUE( waitForResponse(&mApi[0].userUpdated) )   // at the target side (main account)
             << "User attribute update not received after " << maxTimeout << " seconds";
 
-    u = megaApi[0]->getContact(email[1].data());
+    u = megaApi[0]->getContact(mApi[1].email.data());
     null_pointer = (u == NULL);
 
-    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << email[1];
+    ASSERT_FALSE(null_pointer) << "Cannot find the MegaUser for email: " << mApi[1].email;
     ASSERT_EQ(MegaUser::VISIBILITY_HIDDEN, u->getVisibility()) << "New contact is still visible";
 
     delete u;
@@ -1999,7 +1877,7 @@ bool SdkTest::checkAlert(int apiIndex, const string& title, const string& path)
     for (int i = 0; !ok && i < 10; ++i)
     {
 
-        MegaUserAlertList* list = megaApi[apiIndex]->getUserAlerts();
+        MegaUserAlertList* list = mApi[apiIndex].megaApi->getUserAlerts();
         if (list->size() > 0)
         {
             MegaUserAlert* a = list->get(list->size() - 1);
@@ -2093,11 +1971,8 @@ TEST_F(SdkTest, SdkTestShares)
     MegaHandle hfile1;
     createFile(PUBLICFILE.data(), false);   // not a large file since don't need to test transfers here
 
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
-    megaApi[0]->startUpload(PUBLICFILE.data(), megaApi[0]->getNodeByHandle(hfolder1));
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD], 0);   // wait forever
+    ASSERT_EQ(MegaError::API_OK, synchronousStartUpload(0, PUBLICFILE.data(), megaApi[0]->getNodeByHandle(hfolder1))) << "Cannot upload a test file";
 
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload file (error: " << lastError[0] << ")";
     hfile1 = h;
 
 
@@ -2105,21 +1980,21 @@ TEST_F(SdkTest, SdkTestShares)
 
     MegaNode *nNoAuth = megaApi[0]->getNodeByHandle(hfile1);
 
-    transferFlags[1][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[1].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[1]->startDownload(nNoAuth, "unauthorized_node");
-    ASSERT_TRUE( waitForResponse(&transferFlags[1][MegaTransfer::TYPE_DOWNLOAD], 600) )
+    ASSERT_TRUE( waitForResponse(&mApi[1].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 600) )
             << "Download transfer not finished after " << maxTimeout << " seconds";
 
-    bool hasFailed = (lastError[1] != API_OK);
+    bool hasFailed = (mApi[1].lastError != API_OK);
     ASSERT_TRUE(hasFailed) << "Download of node without authorization successful! (it should fail)";
 
     MegaNode *nAuth = megaApi[0]->authorizeNode(nNoAuth);
 
-    transferFlags[1][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[1].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[1]->startDownload(nAuth, "authorized_node");
-    ASSERT_TRUE( waitForResponse(&transferFlags[1][MegaTransfer::TYPE_DOWNLOAD], 600) )
+    ASSERT_TRUE( waitForResponse(&mApi[1].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 600) )
             << "Download transfer not finished after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[1]) << "Cannot download authorized node (error: " << lastError[1] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[1].lastError) << "Cannot download authorized node (error: " << mApi[1].lastError << ")";
 
     delete nNoAuth;
     delete nAuth;
@@ -2128,31 +2003,31 @@ TEST_F(SdkTest, SdkTestShares)
 
     string message = "Hi contact. Let's share some stuff";
 
-    contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( inviteContact(email[1], message, MegaContactRequest::INVITE_ACTION_ADD) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( inviteContact(mApi[1].email, message, MegaContactRequest::INVITE_ACTION_ADD) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
 
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false) );
 
-    contactRequestUpdated[0] = contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( replyContact(cr[1], MegaContactRequest::REPLY_ACTION_ACCEPT) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[0].contactRequestUpdated = mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( replyContact(mApi[1].cr.get(), MegaContactRequest::REPLY_ACTION_ACCEPT) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[0]) )   // at the source side (main account)
+    ASSERT_TRUE( waitForResponse(&mApi[0].contactRequestUpdated) )   // at the source side (main account)
             << "Contact request creation not received after " << maxTimeout << " seconds";
 
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
 
     // --- Create a new outgoing share ---
 
-    nodeUpdated[0] = nodeUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( shareFolder(n1, email[1].data(), MegaShare::ACCESS_READ) );
-    ASSERT_TRUE( waitForResponse(&nodeUpdated[0]) )   // at the target side (main account)
+    mApi[0].nodeUpdated = mApi[1].nodeUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( shareFolder(n1, mApi[1].email.data(), MegaShare::ACCESS_READ) );
+    ASSERT_TRUE( waitForResponse(&mApi[0].nodeUpdated) )   // at the target side (main account)
             << "Node update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&nodeUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].nodeUpdated) )   // at the target side (auxiliar account)
             << "Node update not received after " << maxTimeout << " seconds";
 
 
@@ -2166,7 +2041,7 @@ TEST_F(SdkTest, SdkTestShares)
 
     ASSERT_EQ(MegaShare::ACCESS_READ, s->getAccess()) << "Wrong access level of outgoing share";
     ASSERT_EQ(hfolder1, s->getNodeHandle()) << "Wrong node handle of outgoing share";
-    ASSERT_STREQ(email[1].data(), s->getUser()) << "Wrong email address of outgoing share";
+    ASSERT_STREQ(mApi[1].email.data(), s->getUser()) << "Wrong email address of outgoing share";
     ASSERT_TRUE(n1->isShared()) << "Wrong sharing information at outgoing share";
     ASSERT_TRUE(n1->isOutShare()) << "Wrong sharing information at outgoing share";
 
@@ -2178,7 +2053,7 @@ TEST_F(SdkTest, SdkTestShares)
     sl = megaApi[1]->getInSharesList();
     ASSERT_EQ(1, sl->size()) << "Incoming share not received in auxiliar account";
 
-    nl = megaApi[1]->getInShares(megaApi[1]->getContact(email[0].data()));
+    nl = megaApi[1]->getInShares(megaApi[1]->getContact(mApi[0].email.data()));
     ASSERT_EQ(1, nl->size()) << "Incoming share not received in auxiliar account";
     n = nl->get(0);
 
@@ -2191,7 +2066,7 @@ TEST_F(SdkTest, SdkTestShares)
     delete nl;
 
     // check the corresponding user alert
-    ASSERT_TRUE(checkAlert(1, "New shared folder from " + email[0], email[0] + ":Shared-folder"));
+    ASSERT_TRUE(checkAlert(1, "New shared folder from " + mApi[0].email, mApi[0].email + ":Shared-folder"));
 
     // add a folder under the share
     char foldernameA[64] = "dummyname1";
@@ -2200,18 +2075,18 @@ TEST_F(SdkTest, SdkTestShares)
     ASSERT_NO_FATAL_FAILURE(createFolder(0, foldernameB, megaApi[0]->getNodeByHandle(hfolder2)));
 
     // check the corresponding user alert
-    ASSERT_TRUE(checkAlert(1, email[0] + " added 2 folders", megaApi[0]->getNodeByHandle(hfolder2)->getHandle(), 2));
+    ASSERT_TRUE(checkAlert(1, mApi[0].email + " added 2 folders", megaApi[0]->getNodeByHandle(hfolder2)->getHandle(), 2));
 
     // --- Modify the access level of an outgoing share ---
 
-    nodeUpdated[0] = nodeUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( shareFolder(megaApi[0]->getNodeByHandle(hfolder1), email[1].data(), MegaShare::ACCESS_READWRITE) );
-    ASSERT_TRUE( waitForResponse(&nodeUpdated[0]) )   // at the target side (main account)
+    mApi[0].nodeUpdated = mApi[1].nodeUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( shareFolder(megaApi[0]->getNodeByHandle(hfolder1), mApi[1].email.data(), MegaShare::ACCESS_READWRITE) );
+    ASSERT_TRUE( waitForResponse(&mApi[0].nodeUpdated) )   // at the target side (main account)
             << "Node update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&nodeUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].nodeUpdated) )   // at the target side (auxiliar account)
             << "Node update not received after " << maxTimeout << " seconds";
 
-    nl = megaApi[1]->getInShares(megaApi[1]->getContact(email[0].data()));
+    nl = megaApi[1]->getInShares(megaApi[1]->getContact(mApi[0].email.data()));
     ASSERT_EQ(1, nl->size()) << "Incoming share not received in auxiliar account";
     n = nl->get(0);
 
@@ -2222,18 +2097,18 @@ TEST_F(SdkTest, SdkTestShares)
 
     // --- Revoke access to an outgoing share ---
 
-    nodeUpdated[0] = nodeUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( shareFolder(n1, email[1].data(), MegaShare::ACCESS_UNKNOWN) );
-    ASSERT_TRUE( waitForResponse(&nodeUpdated[0]) )   // at the target side (main account)
+    mApi[0].nodeUpdated = mApi[1].nodeUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( shareFolder(n1, mApi[1].email.data(), MegaShare::ACCESS_UNKNOWN) );
+    ASSERT_TRUE( waitForResponse(&mApi[0].nodeUpdated) )   // at the target side (main account)
             << "Node update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&nodeUpdated[1]) )   // at the target side (auxiliar account)
+    ASSERT_TRUE( waitForResponse(&mApi[1].nodeUpdated) )   // at the target side (auxiliar account)
             << "Node update not received after " << maxTimeout << " seconds";
 
     sl = megaApi[0]->getOutShares();
     ASSERT_EQ(0, sl->size()) << "Outgoing share revocation failed";
     delete sl;
 
-    nl = megaApi[1]->getInShares(megaApi[1]->getContact(email[0].data()));
+    nl = megaApi[1]->getInShares(megaApi[1]->getContact(mApi[0].email.data()));
     ASSERT_EQ(0, nl->size()) << "Incoming share revocation failed";
     delete nl;
 
@@ -2242,8 +2117,8 @@ TEST_F(SdkTest, SdkTestShares)
         MegaUserAlertList* list = megaApi[1]->getUserAlerts();
         ASSERT_TRUE(list->size() > 0);
         MegaUserAlert* a = list->get(list->size() - 1);
-        ASSERT_STREQ(a->getTitle(), ("Access to folders shared by " + email[0] + " was removed").c_str());
-        ASSERT_STREQ(a->getPath(), (email[0] + ":Shared-folder").c_str());
+        ASSERT_STREQ(a->getTitle(), ("Access to folders shared by " + mApi[0].email + " was removed").c_str());
+        ASSERT_STREQ(a->getPath(), (mApi[0].email + ":Shared-folder").c_str());
         ASSERT_NE(a->getNodeHandle(), UNDEF);
         delete list;
     }
@@ -2257,12 +2132,12 @@ TEST_F(SdkTest, SdkTestShares)
 
     n = megaApi[0]->getNodeByHandle(hfolder2);
 
-    contactRequestUpdated[0] = false;
-    nodeUpdated[0] = false;
+    mApi[0].contactRequestUpdated = false;
+    mApi[0].nodeUpdated = false;
     ASSERT_NO_FATAL_FAILURE( shareFolder(n, emailfake, MegaShare::ACCESS_FULL) );
-    ASSERT_TRUE( waitForResponse(&nodeUpdated[0]) )   // at the target side (main account)
+    ASSERT_TRUE( waitForResponse(&mApi[0].nodeUpdated) )   // at the target side (main account)
             << "Node update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[0]) )   // at the target side (main account)
+    ASSERT_TRUE( waitForResponse(&mApi[0].contactRequestUpdated) )   // at the target side (main account)
             << "Contact request update not received after " << maxTimeout << " seconds";
 
     sl = megaApi[0]->getPendingOutShares(n);   delete n;
@@ -2362,6 +2237,87 @@ TEST_F(SdkTest, SdkTestShares)
     delete nfolder1;
 
 }
+
+
+TEST_F(SdkTest, SdkTestShareKeys)
+{
+    LOG_info << "___TEST ShareKeys___";
+
+    // Three user scenario, with nested shares and new nodes created that need keys to be shared to the other users.
+    // User A creates folder and shares it with user B
+    // User A creates folders / subfolder and shares it with user C
+    // When user C adds files to subfolder, does B receive the keys ?
+
+    ASSERT_NO_FATAL_FAILURE(getMegaApiAux());    // login + fetchnodes
+    ASSERT_NO_FATAL_FAILURE(getMegaApiAux(2));    // login + fetchnodes
+
+    unique_ptr<MegaNode> rootnodeA(megaApi[0]->getRootNode());
+    unique_ptr<MegaNode> rootnodeB(megaApi[1]->getRootNode());
+    unique_ptr<MegaNode> rootnodeC(megaApi[2]->getRootNode());
+
+    ASSERT_TRUE(rootnodeA &&rootnodeB &&rootnodeC);
+
+    ASSERT_NO_FATAL_FAILURE(createFolder(0, "share-folder-A", rootnodeA.get()));
+    unique_ptr<MegaNode> shareFolderA(megaApi[0]->getNodeByHandle(h));
+    ASSERT_TRUE(!!shareFolderA);
+
+    ASSERT_NO_FATAL_FAILURE(createFolder(0, "sub-folder-A", shareFolderA.get()));
+    unique_ptr<MegaNode> subFolderA(megaApi[0]->getNodeByHandle(h));
+    ASSERT_TRUE(!!subFolderA);
+
+    // Initialize a test scenario: create a new contact to share to
+
+    ASSERT_EQ(MegaError::API_OK, synchronousInviteContact(0, mApi[1].email.c_str(), "SdkTestShareKeys contact request A to B", MegaContactRequest::INVITE_ACTION_ADD));
+    ASSERT_EQ(MegaError::API_OK, synchronousInviteContact(0, mApi[2].email.c_str(), "SdkTestShareKeys contact request A to C", MegaContactRequest::INVITE_ACTION_ADD));
+
+    ASSERT_TRUE(WaitFor([this]() {return unique_ptr<MegaContactRequestList>(megaApi[1]->getIncomingContactRequests())->size() == 1 
+                                      && unique_ptr<MegaContactRequestList>(megaApi[2]->getIncomingContactRequests())->size() == 1;}, 3000));
+    ASSERT_NO_FATAL_FAILURE(getContactRequest(1, false));
+    ASSERT_NO_FATAL_FAILURE(getContactRequest(2, false));
+    
+
+    ASSERT_EQ(MegaError::API_OK, synchronousReplyContactRequest(1, mApi[1].cr.get(), MegaContactRequest::REPLY_ACTION_ACCEPT));
+    ASSERT_EQ(MegaError::API_OK, synchronousReplyContactRequest(2, mApi[2].cr.get(), MegaContactRequest::REPLY_ACTION_ACCEPT));
+
+    WaitMillisec(3000);
+
+    ASSERT_EQ(MegaError::API_OK, synchronousShare(0, shareFolderA.get(), mApi[1].email.c_str(), MegaShare::ACCESS_READ));
+    ASSERT_EQ(MegaError::API_OK, synchronousShare(0, subFolderA.get(), mApi[2].email.c_str(), MegaShare::ACCESS_FULL));
+
+    WaitFor([this]() { return unique_ptr<MegaShareList>(megaApi[1]->getInSharesList())->size() == 1 
+                           && unique_ptr<MegaShareList>(megaApi[2]->getInSharesList())->size() == 1; }, 3000);
+
+    unique_ptr<MegaNodeList> nl1(megaApi[1]->getInShares(megaApi[1]->getContact(mApi[0].email.c_str())));
+    unique_ptr<MegaNodeList> nl2(megaApi[2]->getInShares(megaApi[2]->getContact(mApi[0].email.c_str())));
+    
+    ASSERT_EQ(1, nl1->size());
+    ASSERT_EQ(1, nl2->size());
+
+    MegaNode* receivedShareNodeB = nl1->get(0);
+    MegaNode* receivedShareNodeC = nl2->get(0);
+
+    ASSERT_NO_FATAL_FAILURE(createFolder(2, "folderByC1", receivedShareNodeC));
+    ASSERT_NO_FATAL_FAILURE(createFolder(2, "folderByC2", receivedShareNodeC));
+
+    WaitMillisec(10000);  // make it shorter once we do actually get the keys (seems to need a bug fix)
+
+    // can A see the added folders?    
+    
+    unique_ptr<MegaNodeList> aView(megaApi[0]->getChildren(subFolderA.get()));
+    ASSERT_EQ(2, aView->size());
+    ASSERT_STREQ(aView->get(0)->getName(), "folderByC1");
+    ASSERT_STREQ(aView->get(1)->getName(), "folderByC2");
+
+    // Can B see the added folders?
+    unique_ptr<MegaNodeList> bView(megaApi[1]->getChildren(receivedShareNodeB));
+    ASSERT_EQ(1, bView->size());
+    ASSERT_STREQ(bView->get(0)->getName(), "sub-folder-A");
+    unique_ptr<MegaNodeList> bView2(megaApi[1]->getChildren(bView->get(0)));
+    ASSERT_EQ(2, bView2->size());
+    ASSERT_STREQ(bView2->get(0)->getName(), "folderByC1");
+    ASSERT_STREQ(bView2->get(1)->getName(), "folderByC2");
+}
+
 
 /**
 * @brief TEST_F SdkTestConsoleAutocomplete
@@ -2463,7 +2419,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
 
     ::mega::handle megaCurDir = UNDEF;
 
-    MegaApiImpl* impl = *((MegaApiImpl**)(((char*)megaApi[0]) + sizeof(*megaApi[0])) - 1); //megaApi[0]->pImpl;
+    MegaApiImpl* impl = *((MegaApiImpl**)(((char*)megaApi[0].get()) + sizeof(*megaApi[0].get())) - 1); //megaApi[0]->pImpl;
     MegaClient* client = impl->getMegaClient();
 
 
@@ -3038,9 +2994,9 @@ TEST_F(SdkTest, SdkTestChat)
 
     string message = "Hi contact. This is a testing message";
 
-    contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( inviteContact(email[1], message, MegaContactRequest::INVITE_ACTION_ADD) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( inviteContact(mApi[1].email, message, MegaContactRequest::INVITE_ACTION_ADD) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request update not received after " << maxTimeout << " seconds";    
     // if there were too many invitations within a short period of time, the invitation can be rejected by
     // the API with `API_EOVERQUOTA = -17` as counter spamming meassure (+500 invites in the last 50 days)
@@ -3049,14 +3005,14 @@ TEST_F(SdkTest, SdkTestChat)
 
     ASSERT_NO_FATAL_FAILURE( getContactRequest(1, false) );
 
-    contactRequestUpdated[0] = contactRequestUpdated[1] = false;
-    ASSERT_NO_FATAL_FAILURE( replyContact(cr[1], MegaContactRequest::REPLY_ACTION_ACCEPT) );
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[1]) )   // at the target side (auxiliar account)
+    mApi[0].contactRequestUpdated = mApi[1].contactRequestUpdated = false;
+    ASSERT_NO_FATAL_FAILURE( replyContact(mApi[1].cr.get(), MegaContactRequest::REPLY_ACTION_ACCEPT) );
+    ASSERT_TRUE( waitForResponse(&mApi[1].contactRequestUpdated) )   // at the target side (auxiliar account)
             << "Contact request update not received after " << maxTimeout << " seconds";
-    ASSERT_TRUE( waitForResponse(&contactRequestUpdated[0]) )   // at the target side (main account)
+    ASSERT_TRUE( waitForResponse(&mApi[0].contactRequestUpdated) )   // at the target side (main account)
             << "Contact request update not received after " << maxTimeout << " seconds";
 
-    delete cr[1];   cr[1] = NULL;
+    mApi[1].cr.reset();
 
 
     // --- Check list of available chats --- (fetch is done at SetUp())
@@ -3076,11 +3032,11 @@ TEST_F(SdkTest, SdkTestChat)
     group = true;
 
     chatUpdated[1] = false;
-    requestFlags[0][MegaRequest::TYPE_CHAT_CREATE] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_CHAT_CREATE] = false;
     ASSERT_NO_FATAL_FAILURE( createChat(group, peers) );    
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CHAT_CREATE]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_CHAT_CREATE]) )
             << "Cannot create a new chat";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Chat creation failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Chat creation failed (error: " << mApi[0].lastError << ")";
     ASSERT_TRUE( waitForResponse(&chatUpdated[1]) )   // at the target side (auxiliar account)
             << "Chat update not received after " << maxTimeout << " seconds";
 
@@ -3096,11 +3052,11 @@ TEST_F(SdkTest, SdkTestChat)
     // --- Remove a peer from the chat ---
 
     chatUpdated[1] = false;
-    requestFlags[0][MegaRequest::TYPE_CHAT_REMOVE] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_CHAT_REMOVE] = false;
     megaApi[0]->removeFromChat(chatid, h);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CHAT_REMOVE]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_CHAT_REMOVE]) )
             << "Chat remove failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Removal of chat peer failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Removal of chat peer failed (error: " << mApi[0].lastError << ")";
     int numpeers = chats[chatid]->getPeerList() ? chats[chatid]->getPeerList()->size() : 0;
     ASSERT_EQ(numpeers, 0) << "Wrong number of peers in the list of peers";
     ASSERT_TRUE( waitForResponse(&chatUpdated[1]) )   // at the target side (auxiliar account)
@@ -3110,11 +3066,11 @@ TEST_F(SdkTest, SdkTestChat)
     // --- Invite a contact to a chat ---
 
     chatUpdated[1] = false;
-    requestFlags[0][MegaRequest::TYPE_CHAT_INVITE] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_CHAT_INVITE] = false;
     megaApi[0]->inviteToChat(chatid, h, PRIV_STANDARD);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CHAT_INVITE]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_CHAT_INVITE]) )
             << "Chat invitation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Invitation of chat peer failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Invitation of chat peer failed (error: " << mApi[0].lastError << ")";
     numpeers = chats[chatid]->getPeerList() ? chats[chatid]->getPeerList()->size() : 0;
     ASSERT_EQ(numpeers, 1) << "Wrong number of peers in the list of peers";
     ASSERT_TRUE( waitForResponse(&chatUpdated[1]) )   // at the target side (auxiliar account)
@@ -3123,21 +3079,21 @@ TEST_F(SdkTest, SdkTestChat)
 
     // --- Get the user-specific URL for the chat ---
 
-    requestFlags[0][MegaRequest::TYPE_CHAT_URL] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_CHAT_URL] = false;
     megaApi[0]->getUrlChat(chatid);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CHAT_URL]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_CHAT_URL]) )
             << "Retrieval of chat URL failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Retrieval of chat URL failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Retrieval of chat URL failed (error: " << mApi[0].lastError << ")";
 
 
     // --- Update Permissions of an existing peer in the chat
 
     chatUpdated[1] = false;
-    requestFlags[0][MegaRequest::TYPE_CHAT_UPDATE_PERMISSIONS] = false;
+    mApi[0].requestFlags[MegaRequest::TYPE_CHAT_UPDATE_PERMISSIONS] = false;
     megaApi[0]->updateChatPermissions(chatid, h, PRIV_RO);
-    ASSERT_TRUE( waitForResponse(&requestFlags[0][MegaRequest::TYPE_CHAT_UPDATE_PERMISSIONS]) )
+    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_CHAT_UPDATE_PERMISSIONS]) )
             << "Update chat permissions failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Update of chat permissions failed (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Update of chat permissions failed (error: " << mApi[0].lastError << ")";
     ASSERT_TRUE( waitForResponse(&chatUpdated[1]) )   // at the target side (auxiliar account)
             << "The peer didn't receive notification of the invitation after " << maxTimeout << " seconds";
 
@@ -3396,11 +3352,11 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
     deleteFile(filename.c_str());
 
     // plain cloudraid download
-    transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[0]->startDownload(nimported, filename.c_str());
-    ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 600))
+    ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 600))
         << "Download cloudraid transfer failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the cloudraid file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the cloudraid file (error: " << mApi[0].lastError << ")";
 
 
     // cloudraid download with periodic pause and resume
@@ -3417,7 +3373,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
     {
         onTransferUpdate_progress = 0;
         onTransferUpdate_filesize = 0;
-        transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+        mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
         megaApi[0]->startDownload(nimported, filename.c_str());
 
         m_off_t lastprogress = 0, pausecount = 0;
@@ -3438,8 +3394,8 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
         ASSERT_GE(onTransferUpdate_filesize, 0u);
         ASSERT_TRUE(onTransferUpdate_progress == onTransferUpdate_filesize);
         ASSERT_GE(pausecount, 3);
-        ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 1))<< "Download cloudraid transfer with pauses failed";
-        ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the cloudraid file (error: " << lastError[0] << ")";
+        ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 1))<< "Download cloudraid transfer with pauses failed";
+        ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the cloudraid file (error: " << mApi[0].lastError << ")";
     }
 
 
@@ -3449,7 +3405,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
     // cloudraid download with periodic full exit and resume from session ID
     // plain cloudraid download
     {
-        transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+        mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
         megaApi[0]->startDownload(nimported, filename.c_str());
 
         std::string sessionId = megaApi[0]->dumpSession();
@@ -3463,12 +3419,12 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
         {
             if (onTransferUpdate_progress > lastprogress + onTransferUpdate_filesize/6)
             {
-                delete megaApi[0];
-                megaApi[0] = NULL;
+                megaApi[0].reset();
                 exitresumecount += 1;
                 WaitMillisec(100);
                 
-                megaApi[0] = new MegaApi(APP_KEY.c_str(), megaApiCacheFolder(0).c_str(), USER_AGENT.c_str());
+                megaApi[0].reset(new MegaApi(APP_KEY.c_str(), megaApiCacheFolder(0).c_str(), USER_AGENT.c_str()));
+                mApi[0].megaApi = megaApi[0].get();
                 megaApi[0]->setLogLevel(MegaApi::LOG_LEVEL_DEBUG);
                 megaApi[0]->addListener(this);
 
@@ -3480,8 +3436,8 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
         }
         ASSERT_TRUE(onTransferUpdate_progress == onTransferUpdate_filesize);
         ASSERT_GE(exitresumecount, 3u);
-        ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 1)) << "Download cloudraid transfer with pauses failed";
-        ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the cloudraid file (error: " << lastError[0] << ")";
+        ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 1)) << "Download cloudraid transfer with pauses failed";
+        ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the cloudraid file (error: " << mApi[0].lastError << ")";
     }
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
@@ -3526,11 +3482,11 @@ TEST_F(SdkTest, SdkTestCloudraidTransferWithConnectionFailures)
     {
         onTransferUpdate_progress = 0;
         onTransferUpdate_filesize = 0;
-        transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+        mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
         megaApi[0]->startDownload(nimported, filename.c_str());
 
-        ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 180)) << "Cloudraid download with 404 and 403 errors time out (180 seconds)";
-        ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the cloudraid file (error: " << lastError[0] << ")";
+        ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 180)) << "Cloudraid download with 404 and 403 errors time out (180 seconds)";
+        ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the cloudraid file (error: " << mApi[0].lastError << ")";
         ASSERT_GE(onTransferUpdate_filesize, 0u);
         ASSERT_TRUE(onTransferUpdate_progress == onTransferUpdate_filesize);
         ASSERT_LT(DebugTestHook::countdownTo404, 0);
@@ -3579,11 +3535,11 @@ TEST_F(SdkTest, SdkTestCloudraidTransferWithSingleChannelTimeouts)
     {
         onTransferUpdate_progress = 0;
         onTransferUpdate_filesize = 0;
-        transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+        mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
         megaApi[0]->startDownload(nimported, filename.c_str());
 
-        ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 180)) << "Cloudraid download with timeout errors timed out (180 seconds)";
-        ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the cloudraid file (error: " << lastError[0] << ")";
+        ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 180)) << "Cloudraid download with timeout errors timed out (180 seconds)";
+        ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the cloudraid file (error: " << mApi[0].lastError << ")";
         ASSERT_GE(onTransferUpdate_filesize, 0u);
         ASSERT_TRUE(onTransferUpdate_progress == onTransferUpdate_filesize);
         ASSERT_LT(DebugTestHook::countdownToTimeout, 0);
@@ -3612,9 +3568,9 @@ TEST_F(SdkTest, SdkTestOverquotaNonCloudraid)
     MegaNode *rootnode = megaApi[0]->getRootNode();
     deleteFile(UPFILE);
     createFile(UPFILE, true);
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_UPLOAD] = false;
     megaApi[0]->startUpload(UPFILE.c_str(), rootnode);
-    ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD], 600))
+    ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_UPLOAD], 600))
         << "Upload transfer failed after " << 600 << " seconds";
     MegaNode *n1 = megaApi[0]->getNodeByHandle(h);
     ASSERT_NE(n1, ((::mega::MegaNode *)NULL));
@@ -3631,7 +3587,7 @@ TEST_F(SdkTest, SdkTestOverquotaNonCloudraid)
     // download - we should see a 30 second pause for 509 processing in the middle
     string filename2 = "./" + DOWNFILE;
     deleteFile(filename2);
-    transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[0]->startDownload(n1, filename2.c_str());
 
     // get to 30 sec pause point
@@ -3654,9 +3610,9 @@ TEST_F(SdkTest, SdkTestOverquotaNonCloudraid)
 
     // Now wait for the file to finish
 
-    ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 600))
+    ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 600))
         << "Download transfer failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the file (error: " << mApi[0].lastError << ")";
 
     ASSERT_LT(DebugTestHook::countdownToOverquota, 0);
     ASSERT_LT(DebugTestHook::countdownToOverquota, originalcount);  // there should have been more http activity after the wait
@@ -3696,7 +3652,7 @@ TEST_F(SdkTest, SdkTestOverquotaCloudraid)
     // download - we should see a 30 second pause for 509 processing in the middle
     string filename2 = "./" + DOWNFILE;
     deleteFile(filename2);
-    transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[0]->startDownload(nimported, filename2.c_str());
 
     // get to 30 sec pause point
@@ -3719,9 +3675,9 @@ TEST_F(SdkTest, SdkTestOverquotaCloudraid)
 
     // Now wait for the file to finish
 
-    ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD], 600))
+    ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD], 600))
         << "Download transfer failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the file (error: " << mApi[0].lastError << ")";
 
     ASSERT_LT(DebugTestHook::countdownToOverquota, 0);
     ASSERT_LT(DebugTestHook::countdownToOverquota, originalcount);  // there should have been more http activity after the wait
@@ -3856,10 +3812,10 @@ TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
     string filename2 = "./" + DOWNFILE;
     deleteFile(filename2);
 
-    transferFlags[0][MegaTransfer::TYPE_DOWNLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD] = false;
     megaApi[0]->startDownload(nimported, filename2.c_str());
-    ASSERT_TRUE(waitForResponse(&transferFlags[0][MegaTransfer::TYPE_DOWNLOAD])) << "Setup transfer failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot download the initial file (error: " << lastError[0] << ")";
+    ASSERT_TRUE(waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_DOWNLOAD])) << "Setup transfer failed after " << maxTimeout << " seconds";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot download the initial file (error: " << mApi[0].lastError << ")";
 
     char raidchar = 0;
     char nonraidchar = 'M';
@@ -3878,11 +3834,11 @@ TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
     }
 
     // actual upload
-    transferFlags[0][MegaTransfer::TYPE_UPLOAD] = false;
+    mApi[0].transferFlags[MegaTransfer::TYPE_UPLOAD] = false;
     megaApi[0]->startUpload(filename3.data(), rootnode);
-    waitForResponse(&transferFlags[0][MegaTransfer::TYPE_UPLOAD]);
+    waitForResponse(&mApi[0].transferFlags[MegaTransfer::TYPE_UPLOAD]);
 
-    ASSERT_EQ(MegaError::API_OK, lastError[0]) << "Cannot upload a test file (error: " << lastError[0] << ")";
+    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot upload a test file (error: " << mApi[0].lastError << ")";
 
     MegaNode *nonRaidNode = megaApi[0]->getNodeByHandle(h);
 
@@ -3947,7 +3903,7 @@ TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
 
         LOG_info << "beginning stream test, " << start << " to " << end << "(len " << end - start << ") " << (nonraid ? " non-raid " : " RAID ") << (!nonraid ? (smallpieces ? " smallpieces " : "normalpieces") : "");
 
-        CheckStreamedFile_MegaTransferListener* p = StreamRaidFilePart(megaApi[0], start, end, !nonraid, smallpieces, nimported, nonRaidNode, compareDecryptedData);
+        CheckStreamedFile_MegaTransferListener* p = StreamRaidFilePart(megaApi[0].get(), start, end, !nonraid, smallpieces, nimported, nonRaidNode, compareDecryptedData);
 
         for (unsigned i = 0; p->comparedEqual; ++i)
         {
@@ -4002,14 +3958,14 @@ TEST_F(SdkTest, SdkRecentsTest)
 
     string filename1 = UPFILE;
     createFile(filename1, false);
-    auto err = synchronousUpload(0, filename1.c_str(), rootnode);
+    auto err = synchronousStartUpload(0, filename1.c_str(), rootnode);
     ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload a test file (error: " << err << ")";
 
     ofstream f(filename1);
     f << "update";
     f.close();
 
-    err = synchronousUpload(0, filename1.c_str(), rootnode);
+    err = synchronousStartUpload(0, filename1.c_str(), rootnode);
     ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload an updated test file (error: " << err << ")";
 
     synchronousCatchup(0);
@@ -4017,14 +3973,14 @@ TEST_F(SdkTest, SdkRecentsTest)
     string filename2 = DOWNFILE;
     createFile(filename2, false);
     
-    err = synchronousUpload(0, filename2.c_str(), rootnode);
+    err = synchronousStartUpload(0, filename2.c_str(), rootnode);
     ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload a test file2 (error: " << err << ")";
 
     ofstream f2(filename2);
     f2 << "update";
     f2.close();
 
-    err = synchronousUpload(0, filename2.c_str(), rootnode);
+    err = synchronousStartUpload(0, filename2.c_str(), rootnode);
     ASSERT_EQ(MegaError::API_OK, err) << "Cannot upload an updated test file2 (error: " << err << ")";
 
     synchronousCatchup(0);

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -251,7 +251,7 @@ public:
 
     void getContactRequest(unsigned int apiIndex, bool outgoing, int expectedSize = 1);
 
-    void createFolder(unsigned int apiIndex, char * name, MegaNode *n, int timeout = maxTimeout);
+    void createFolder(unsigned int apiIndex, const char * name, MegaNode *n, int timeout = maxTimeout);
 
     void getRegisteredContacts(const std::map<std::string, std::string>& contacts);
 

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -230,7 +230,7 @@ public:
     template<typename ... requestArgs> int doRequestLogout(int apiIndex, requestArgs... args) { RequestTracker rt; megaApi[apiIndex]->logout(args..., &rt); return rt.waitForResult(); }
 
     void createFile(string filename, bool largeFile = true);
-    size_t getFilesize(string filename);
+    int64_t getFilesize(string filename);
     void deleteFile(string filename);
 
     void getMegaApiAux(unsigned index = 1);

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -132,6 +132,8 @@ public:
         bool contactRequestUpdated;
         bool accountUpdated;
 
+        MegaHandle h;
+
 #ifdef ENABLE_CHAT
         bool chatUpdated;        // flags to monitor the updates of chats due to actionpackets
         map<handle, MegaTextChat*> chats;   //  runtime cache of fetched/updated chats
@@ -143,7 +145,6 @@ public:
     std::vector<std::unique_ptr<MegaApi>> megaApi;
 
     // relevant values received in response of requests
-    MegaHandle h;
     string link;
     MegaNode *publicNode;
     string attributeValue;

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -112,15 +112,35 @@ struct RequestTracker : public ::mega::MegaRequestListener
 class SdkTest : public ::testing::Test, public MegaListener, MegaRequestListener, MegaTransferListener, MegaLogger {
 
 public:
-    MegaApi* megaApi[2];
-    string email[2];
-    string pwd[2];
 
-    int lastError[2];
+    struct PerApi
+    {
+        MegaApi* megaApi = nullptr;
+        string email;
+        string pwd;
+        int lastError;
+        
+        // flags to monitor the completion of requests/transfers
+        bool requestFlags[MegaRequest::TOTAL_OF_REQUEST_TYPES];
+        bool transferFlags[MegaTransfer::TYPE_LOCAL_HTTP_DOWNLOAD];
+        
+        std::unique_ptr<MegaContactRequest> cr;
 
-    // flags to monitor the completion of requests/transfers
-    bool requestFlags[2][MegaRequest::TOTAL_OF_REQUEST_TYPES];
-    bool transferFlags[2][MegaTransfer::TYPE_LOCAL_HTTP_DOWNLOAD];
+        // flags to monitor the updates of nodes/users/PCRs due to actionpackets
+        bool nodeUpdated;
+        bool userUpdated;
+        bool contactRequestUpdated;
+        bool accountUpdated;
+
+#ifdef ENABLE_CHAT
+        bool chatUpdated;        // flags to monitor the updates of chats due to actionpackets
+        map<handle, MegaTextChat*> chats;   //  runtime cache of fetched/updated chats
+        MegaHandle chatid;          // last chat added
+#endif
+    };
+
+    std::vector<PerApi> mApi;
+    std::vector<std::unique_ptr<MegaApi>> megaApi;
 
     // relevant values received in response of requests
     MegaHandle h;
@@ -131,20 +151,6 @@ public:
     std::unique_ptr<MegaStringListMap> stringListMap;
     std::unique_ptr<MegaStringTable> stringTable;
 
-    MegaContactRequest* cr[2];
-
-    // flags to monitor the updates of nodes/users/PCRs due to actionpackets
-    bool nodeUpdated[2];
-    bool userUpdated[2];
-    bool contactRequestUpdated[2];
-    bool accountUpdated[2];
-
-#ifdef ENABLE_CHAT
-    bool chatUpdated[2];        // flags to monitor the updates of chats due to actionpackets
-    map<handle, MegaTextChat*> chats;   //  runtime cache of fetched/updated chats
-    MegaHandle chatid;          // last chat added
-#endif
-
     MegaLoggerSDK *logger;
 
     m_off_t onTransferUpdate_progress;
@@ -154,6 +160,8 @@ public:
 protected:
     virtual void SetUp();
     virtual void TearDown();
+
+    int getApiIndex(MegaApi* api);
 
     bool checkAlert(int apiIndex, const string& title, const string& path);
     bool checkAlert(int apiIndex, const string& title, handle h, int n);
@@ -193,11 +201,28 @@ public:
     void purgeTree(MegaNode *p);
     bool waitForResponse(bool *responseReceived, unsigned int timeout = maxTimeout);
 
-    bool synchronousCall(bool &responseFlag, std::function<void()> f, unsigned int timeout = maxTimeout);
+    bool synchronousRequest(int apiIndex, int type, std::function<void()> f, unsigned int timeout = maxTimeout);
+    bool synchronousTransfer(int apiIndex, int type, std::function<void()> f, unsigned int timeout = maxTimeout);
 
     // convenience functions - template args just make it easy to code, no need to copy all the exact argument types with listener defaults etc. To add a new one, just copy a line and change the flag and the function called.
-    template<typename ... uploadArgs> int synchronousUpload(int apiIndex, uploadArgs... args) { synchronousCall(transferFlags[apiIndex][MegaTransfer::TYPE_UPLOAD], [this, apiIndex, args...]() { megaApi[apiIndex]->startUpload(args...); }); return lastError[apiIndex]; }
-    template<typename ... uploadArgs> int synchronousCatchup(int apiIndex, uploadArgs... args) { synchronousCall(requestFlags[apiIndex][MegaRequest::TYPE_CATCHUP], [this, apiIndex, args...]() { megaApi[apiIndex]->catchup(args...); }); return lastError[apiIndex]; }
+    template<typename ... Args> int synchronousStartUpload(int apiIndex, Args... args) { synchronousTransfer(apiIndex, MegaTransfer::TYPE_UPLOAD, [this, apiIndex, args...]() { megaApi[apiIndex]->startUpload(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousCatchup(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CATCHUP, [this, apiIndex, args...]() { megaApi[apiIndex]->catchup(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousCreateAccount(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CREATE_ACCOUNT, [this, apiIndex, args...]() { megaApi[apiIndex]->createAccount(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousResumeCreateAccount(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CREATE_ACCOUNT, [this, apiIndex, args...]() { megaApi[apiIndex]->resumeCreateAccount(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousSendSignupLink(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SEND_SIGNUP_LINK, [this, apiIndex, args...]() { megaApi[apiIndex]->sendSignupLink(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousFastLogin(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_LOGIN, [this, apiIndex, args...]() { megaApi[apiIndex]->fastLogin(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousRemove(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REMOVE, [this, apiIndex, args...]() { megaApi[apiIndex]->remove(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousInviteContact(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_INVITE_CONTACT, [this, apiIndex, args...]() { megaApi[apiIndex]->inviteContact(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousReplyContactRequest(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REPLY_CONTACT_REQUEST, [this, apiIndex, args...]() { megaApi[apiIndex]->replyContactRequest(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousRemoveContact(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REMOVE_CONTACT, [this, apiIndex, args...]() { megaApi[apiIndex]->removeContact(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousShare(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SHARE, [this, apiIndex, args...]() { megaApi[apiIndex]->share(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousExportNode(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_EXPORT, [this, apiIndex, args...]() { megaApi[apiIndex]->exportNode(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetRegisteredContacts(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_REGISTERED_CONTACTS, [this, apiIndex, args...]() { megaApi[apiIndex]->getRegisteredContacts(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetCountryCallingCodes(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_COUNTRY_CALLING_CODES, [this, apiIndex, args...]() { megaApi[apiIndex]->getCountryCallingCodes(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetUserAvatar(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_ATTR_USER, [this, apiIndex, args...]() { megaApi[apiIndex]->getUserAvatar(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetUserAttribute(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_ATTR_USER, [this, apiIndex, args...]() { megaApi[apiIndex]->getUserAttribute(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousSetNodeDuration(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SET_ATTR_NODE, [this, apiIndex, args...]() { megaApi[apiIndex]->setNodeDuration(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousSetNodeCoordinates(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SET_ATTR_NODE, [this, apiIndex, args...]() { megaApi[apiIndex]->setNodeCoordinates(args...); }); return mApi[apiIndex].lastError; }
 
 
     // convenience functions - make a request and wait for the result via listener, return the result code.  To add new functions to call, just copy the line
@@ -207,11 +232,11 @@ public:
     size_t getFilesize(string filename);
     void deleteFile(string filename);
 
-    void getMegaApiAux();
+    void getMegaApiAux(unsigned index = 1);
     void releaseMegaApi(unsigned int apiIndex);
 
-    void inviteContact(string email, string message, int action, int timeout = maxTimeout);
-    void replyContact(MegaContactRequest *cr, int action, int timeout = maxTimeout);
+    void inviteContact(string email, string message, int action);
+    void replyContact(MegaContactRequest *cr, int action);
     void removeContact(string email, int timeout = maxTimeout);
     void setUserAttribute(int type, string value, int timeout = maxTimeout);
     void getUserAttribute(MegaUser *u, int type, int timeout = maxTimeout, int accountIndex = 1);
@@ -227,7 +252,7 @@ public:
 
     void createFolder(unsigned int apiIndex, char * name, MegaNode *n, int timeout = maxTimeout);
 
-    void getRegisteredContacts(const std::map<std::string, std::string>& contacts, int timeout = maxTimeout);
+    void getRegisteredContacts(const std::map<std::string, std::string>& contacts);
 
     void getCountryCallingCodes(int timeout = maxTimeout);
 

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -2410,7 +2410,7 @@ Node* makenode(MegaClient& mc, handle parent, ::mega::nodetype_t type, m_off_t s
     std::vector<Node*> dp;
     auto newnode = new Node(&mc, &dp, ++handlegenerator, parent, type, size, owner, nullptr, 1);
     
-    newnode->nodekey.assign((char*)key, type == FILENODE ? FILENODEKEYLENGTH : FOLDERNODEKEYLENGTH);
+    newnode->setkey(key);
     newnode->attrstring = new string;
 
     SymmCipher sc;

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -54,9 +54,7 @@ public:
             }
             else
             {
-#ifdef _WIN32
-                OutputDebugStringA(os.str().c_str());
-#else
+#ifndef _WIN32
                 std::cout << os.str();
 #endif
                 if (!gTestingInvalidArgs)
@@ -64,6 +62,9 @@ public:
                     ASSERT_NE(loglevel, logError) << os.str();
                 }
             }
+#ifdef _WIN32
+            OutputDebugStringA(os.str().c_str());
+#endif
         }
     }
 


### PR DESCRIPTION
If all nodes have their keys, then there is no need to scan through the entire node map, which we were doing quite frequently, which slowed things down a lot when processing actionpackets etc.
Separated `nodekey`out from NodeCore, so that we can track updates to it separately in Node.  NewNode which used to inherit that field, gets its own field with that name instead.
Node's version of `nodeky`is now private, called `nodekeydata`, with a read accessor.  Functions that update it also update the count of applied keys.
If the number of nodes that have keys applied matches the number of nodes (taking into account that the root nodes do not have keys), then the applykey() loop is skipped.
Also added a megacli command to exercise `setmaxconnections` (related to transfer performance testing).