### PR TITLE
#13636. Allow params embedded in public links

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -2761,6 +2761,19 @@ typedef NS_ENUM(NSInteger, BusinessStatus) {
 - (void)publicNodeForMegaFileLink:(NSString *)megaFileLink;
 
 /**
+* @brief Build the URL for a public link
+*
+* @note This function does not create the public link itself. It simply builds the URL
+* from the provided data.
+*
+* @param publicHandle Public handle of the link, in B64url encoding.
+* @param key Encryption key of the link.
+* @param isFolder True for folder links, false for file links.
+* @return The public link for the provided data
+*/
+- (NSString *)buildPublicLinkForHandle:(NSString *)publicHandle key:(NSString *)key isFolder:(BOOL)isFolder;
+
+/**
  * @brief Set the GPS coordinates of image files as a node attribute.
  *
  * To remove the existing coordinates, set both the latitude and longitude to nil.

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -915,6 +915,16 @@ using namespace mega;
     self.megaApi->getPublicNode((megaFileLink != nil) ? [megaFileLink UTF8String] : NULL);
 }
 
+- (NSString *)buildPublicLinkForHandle:(NSString *)publicHandle key:(NSString *)key isFolder:(BOOL)isFolder {
+    const char *link = self.megaApi->buildPublicLink(publicHandle.UTF8String, key.UTF8String, isFolder);
+    
+    if (!link) return nil;
+    NSString *stringLink = [NSString.alloc initWithUTF8String:link];
+    
+    delete [] link;
+    return stringLink;
+}
+
 - (void)setNodeCoordinates:(MEGANode *)node latitude:(NSNumber *)latitude longitude:(NSNumber *)longitude delegate:(id<MEGARequestDelegate>)delegate {
     self.megaApi->setNodeCoordinates(node ? [node getCPtr] : NULL, (latitude ? latitude.doubleValue : MegaNode::INVALID_COORDINATE), (longitude ? longitude.doubleValue : MegaNode::INVALID_COORDINATE), [self createDelegateMEGARequestListener:delegate singleListener:YES]);
 }

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2634,7 +2634,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_codepage, sequence(text("codepage"), opt(sequence(wholenumber(65001), opt(wholenumber(65001))))));
     p->Add(exec_log, sequence(text("log"), either(text("utf8"), text("utf16"), text("codepage")), localFSFile()));
 #endif
-    p->Add(exec_test, sequence(text("test")));
+    p->Add(exec_test, sequence(text("test"), opt(param("data"))));
 #ifdef ENABLE_CHAT
     p->Add(exec_chats, sequence(text("chats")));
     p->Add(exec_chatc, sequence(text("chatc"), param("group"), repeat(opt(sequence(contactEmail(client), either(text("ro"), text("sta"), text("mod")))))));
@@ -3454,9 +3454,12 @@ void exec_get(autocomplete::ACState& s)
     }
     else
     {
-        if (client->openfilelink(s.words[1].s.c_str(), 0) == API_OK)
+        handle ph = UNDEF;
+        byte key[FILENODEKEYLENGTH];
+        if (client->parsepubliclink(s.words[1].s.c_str(), ph, key, false) == API_OK)
         {
             cout << "Checking link..." << endl;
+            client->openfilelink(ph, key, 0);
             return;
         }
 
@@ -5118,9 +5121,13 @@ void exec_export(autocomplete::ACState& s)
 
 void exec_import(autocomplete::ACState& s)
 {
-    if (client->openfilelink(s.words[1].s.c_str(), 1) == API_OK)
+    handle ph = UNDEF;
+    byte key[FILENODEKEYLENGTH];
+    error e = client->parsepubliclink(s.words[1].s.c_str(), ph, key, false);
+    if (e == API_OK)
     {
         cout << "Opening link..." << endl;
+        client->openfilelink(ph, key, 1);
     }
     else
     {
@@ -5134,7 +5141,7 @@ void exec_folderlinkinfo(autocomplete::ACState& s)
 
     handle ph = UNDEF;
     byte folderkey[SymmCipher::KEYLENGTH];
-    if (client->parsefolderlink(publiclink.c_str(), ph, folderkey) == API_OK)
+    if (client->parsepubliclink(publiclink.c_str(), ph, folderkey, true) == API_OK)
     {
         cout << "Loading public folder link info..." << endl;
         client->getpubliclinkinfo(ph);
@@ -6582,7 +6589,7 @@ void DemoApp::folderlinkinfo_result(error e, handle owner, handle /*ph*/, string
 
     handle ph;
     byte folderkey[SymmCipher::KEYLENGTH];
-    error eaux = client->parsefolderlink(publiclink.c_str(), ph, folderkey);
+    error eaux = client->parsepubliclink(publiclink.c_str(), ph, folderkey, true);
     assert(eaux == API_OK);
 
     // Decrypt nodekey with the key of the folder link

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -6588,7 +6588,7 @@ void DemoApp::folderlinkinfo_result(error e, handle owner, handle /*ph*/, string
     }
 
     handle ph;
-    byte folderkey[SymmCipher::KEYLENGTH];
+    byte folderkey[FOLDERNODEKEYLENGTH];
     error eaux = client->parsepubliclink(publiclink.c_str(), ph, folderkey, true);
     assert(eaux == API_OK);
 

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -455,7 +455,7 @@ public:
     void cancel();
     void procresult();
 
-    CommandGetFile(MegaClient *client, TransferSlot*, byte*, handle, bool, const char* = NULL, const char* = NULL, const char *chatauth = NULL);
+    CommandGetFile(MegaClient *client, TransferSlot*, const byte*, handle, bool, const char* = NULL, const char* = NULL, const char *chatauth = NULL);
 };
 
 class MEGA_API CommandPutFile : public Command

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -330,14 +330,14 @@ public:
     void killsession(handle session);
     void killallsessions();
 
-    // extract public handle and key from folder link
-    error parsefolderlink(const char* folderlink, handle &h, byte *key);
+    // extract public handle and key from a public file/folder link
+    error parsepubliclink(const char *link, handle &ph, byte *key, bool isFolderLink);
 
     // set folder link: node, key
     error folderaccess(const char*folderlink);
 
-    // open exported file link
-    error openfilelink(const char*, int);
+    // open exported file link (op=0 -> download, op=1 fetch data)
+    void openfilelink(handle ph, const byte *key, int op);
 
     // decrypt password-protected public link
     // the caller takes the ownership of the returned value in decryptedLink parameter

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -8951,6 +8951,21 @@ class MegaApi
         void getPublicNode(const char* megaFileLink, MegaRequestListener *listener = NULL);
 
         /**
+         * @brief Build the URL for a public link
+         *
+         * @note This function does not create the public link itself. It simply builds the URL
+         * from the provided data.
+         *
+         * You take the ownership of the returned value.
+         *
+         * @param publicHandle Public handle of the link, in B64url encoding.
+         * @param key Encryption key of the link.
+         * @param isFolder True for folder links, false for file links.
+         * @return The public link for the provided data
+         */
+        const char *buildPublicLink(const char *publicHandle, const char *key, bool isFolder);
+
+        /**
          * @brief Get the thumbnail of a node
          *
          * If the node doesn't have a thumbnail the request fails with the MegaError::API_ENOENT

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2088,6 +2088,7 @@ class MegaApiImpl : public MegaApp
         void decryptPasswordProtectedLink(const char* link, const char* password, MegaRequestListener *listener = NULL);
         void encryptLinkWithPassword(const char* link, const char* password, MegaRequestListener *listener = NULL);
         void getPublicNode(const char* megaFileLink, MegaRequestListener *listener = NULL);
+        const char *buildPublicLink(const char *publicHandle, const char *key, bool isFolder);
         void getThumbnail(MegaNode* node, const char *dstFilePath, MegaRequestListener *listener = NULL);
 		void cancelGetThumbnail(MegaNode* node, MegaRequestListener *listener = NULL);
         void setThumbnail(MegaNode* node, const char *srcFilePath, MegaRequestListener *listener = NULL);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -614,7 +614,7 @@ void CommandDirectRead::procresult()
 }
 
 // request temporary source URL for full-file access (p == private node)
-CommandGetFile::CommandGetFile(MegaClient *client, TransferSlot* ctslot, byte* key, handle h, bool p, const char *privateauth, const char *publicauth, const char *chatauth)
+CommandGetFile::CommandGetFile(MegaClient *client, TransferSlot* ctslot, const byte* key, handle h, bool p, const char *privateauth, const char *publicauth, const char *chatauth)
 {
     cmd("g");
     arg(p ? "n" : "p", (byte*)&h, MegaClient::NODEHANDLE);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2255,6 +2255,11 @@ void MegaApi::getPublicNode(const char* megaFileLink, MegaRequestListener *liste
     pImpl->getPublicNode(megaFileLink, listener);
 }
 
+const char *MegaApi::buildPublicLink(const char *publicHandle, const char *key, bool isFolder)
+{
+    return pImpl->buildPublicLink(publicHandle, key, isFolder);
+}
+
 void MegaApi::getThumbnail(MegaNode* node, const char *dstFilePath, MegaRequestListener *listener)
 {
     pImpl->getThumbnail(node, dstFilePath, listener);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -18747,7 +18747,17 @@ void MegaApiImpl::sendPendingRequests()
                 break;
             }
 
-            e = client->openfilelink(megaFileLink, 1);
+            handle ph = UNDEF;
+            byte key[FILENODEKEYLENGTH];
+            e = client->parsepubliclink(megaFileLink, ph, key, false);
+            if (e == API_OK)
+            {
+                client->openfilelink(ph, key, 1);
+            }
+            else if (e == API_EINCOMPLETE)  // no key provided, check only the existence of the node
+            {
+                client->openfilelink(ph, nullptr, 1);
+            }
             break;
         }
         case MegaRequest::TYPE_PASSWORD_LINK:
@@ -21276,7 +21286,7 @@ void MegaApiImpl::sendPendingRequests()
 
             handle h = UNDEF;
             byte folderkey[SymmCipher::KEYLENGTH];
-            e = client->parsefolderlink(link, h, folderkey);
+            e = client->parsepubliclink(link, h, folderkey, true);
             if (e == API_OK)
             {
                 request->setNodeHandle(h);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -6393,6 +6393,13 @@ void MegaApiImpl::getPublicNode(const char* megaFileLink, MegaRequestListener *l
     waiter->notify();
 }
 
+const char *MegaApiImpl::buildPublicLink(const char *publicHandle, const char *key, bool isFolder)
+{
+    handle ph = MegaApi::base64ToHandle(publicHandle);
+    string link = client->getPublicLink(client->mNewLinkFormat, isFolder ? FOLDERNODE : FILENODE, ph, key);
+    return MegaApi::strdup(link.c_str());
+}
+
 void MegaApiImpl::getThumbnail(MegaNode* node, const char *dstFilePath, MegaRequestListener *listener)
 {
     getNodeAttribute(node, GfxProc::THUMBNAIL, dstFilePath, listener);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -21285,12 +21285,12 @@ void MegaApiImpl::sendPendingRequests()
             }
 
             handle h = UNDEF;
-            byte folderkey[SymmCipher::KEYLENGTH];
+            byte folderkey[FOLDERNODEKEYLENGTH];
             e = client->parsepubliclink(link, h, folderkey, true);
             if (e == API_OK)
             {
                 request->setNodeHandle(h);
-                Base64Str<SymmCipher::KEYLENGTH> folderkeyB64(folderkey);
+                Base64Str<FOLDERNODEKEYLENGTH> folderkeyB64(folderkey);
                 request->setPrivateKey(folderkeyB64.chars);
                 client->getpubliclinkinfo(h);
             }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -8058,7 +8058,7 @@ error MegaClient::parsepubliclink(const char* link, handle& ph, byte* key, bool 
             ptr++;
         }
 
-        if (!*ptr || (*ptr == '#' && *(ptr + 1) == '\0'))   // no key provided
+        if (!*ptr || ((*ptr == '#' || *ptr == '!') && *(ptr + 1) == '\0'))   // no key provided
         {
             return API_EINCOMPLETE;
         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -8001,57 +8001,80 @@ bool MegaClient::readusers(JSON* j, bool actionpackets)
     return j->leavearray();
 }
 
-error MegaClient::parsefolderlink(const char *folderlink, handle &h, byte *key)
+// Supported formats:
+//   - file links:      #!<ph>[!<key>]
+//                      <ph>[!<key>]
+//                      /file/<ph>[<params>][#<key>]
+//
+//   - folder links:    #F!<ph>[!<key>]
+//                      /folder/<ph>[<params>][#<key>]
+error MegaClient::parsepubliclink(const char* link, handle& ph, byte* key, bool isFolderLink)
 {
-    // structure of public folder links: ...#F!<handle>!<key> or /folder/<handle>[<params>][#<key>]
+    bool isFolder;
+    const char* ptr = nullptr;
+    if ((ptr = strstr(link, "#F!")))
+    {
+        ptr += 3;
+        isFolder = true;
+    }
+    else if ((ptr = strstr(link, "folder/")))
+    {
+        ptr += 7;
+        isFolder = true;
+    }
+    else if ((ptr = strstr(link, "#!")))
+    {
+        ptr += 2;
+        isFolder = false;
+    }
+    else if ((ptr = strstr(link, "file/")))
+    {
+        ptr += 5;
+        isFolder = false;
+    }
+    else    // legacy file link format without '#'
+    {
+        ptr = link;
+        isFolder = false;
+    }
 
-    const char* ptr;
-    if (!((ptr = strstr(folderlink, "#F!")) && (strlen(ptr) >= 11)) &&
-            !((ptr = strstr(folderlink, "folder/")) && (strlen(ptr) >= 15)))
+    if (isFolder != isFolderLink)
+    {
+        return API_EARGS;   // type of link mismatch
+    }
+
+    if (strlen(ptr) < 8)  // no public handle in the link
     {
         return API_EARGS;
     }
 
-    const char *nodeHandleBegining = nullptr;
-    if (*ptr == 'f')
+    if (Base64::atob(ptr, (byte*)&ph, NODEHANDLE) == NODEHANDLE)
     {
-        nodeHandleBegining = ptr + 7;
-        ptr += 15;
-    }
-    else
-    {
-        nodeHandleBegining = ptr + 3;
-        ptr += 11;
+        ptr += 8;
+
+        // skip any tracking parameter introduced by third-party websites
+        while(*ptr && *ptr != '!' && *ptr != '#')
+        {
+            ptr++;
+        }
+
+        if (!*ptr || (*ptr == '#' && *(ptr + 1) == '\0'))   // no key provided
+        {
+            return API_EINCOMPLETE;
+        }
+
+        if (*ptr == '!' || *ptr == '#')
+        {
+            const char *k = ptr + 1;    // skip '!' or '#' separator
+            size_t keylen = isFolderLink ? SymmCipher::KEYLENGTH : FILENODEKEYLENGTH;
+            if (Base64::atob(k, key, keylen) == keylen)
+            {
+                return API_OK;
+            }
+        }
     }
 
-    // skip any tracking parameter introduced by third-party websites
-    while(*ptr && *ptr != '!' && *ptr != '#')
-    {
-        ptr++;
-    }
-
-    if (*ptr == '\0')    // no key provided, link is incomplete
-    {
-        return API_EINCOMPLETE;
-    }
-
-    // Node handle size is 6 Bytes, so we init with zeros to avoid comparison problems
-    handle auxh = 0;
-    if (Base64::atob(nodeHandleBegining, (byte*)&auxh, NODEHANDLE) != NODEHANDLE)
-    {
-        return API_EARGS;
-    }
-
-    byte auxkey[SymmCipher::KEYLENGTH];
-    const char *k = ptr + 1;    // skip '!' or '#' separator
-    if (Base64::atob(k, auxkey, sizeof auxkey) != sizeof auxkey)
-    {
-        return API_EARGS;
-    }
-
-    h = auxh;
-    memcpy(key, auxkey, sizeof auxkey);
-    return API_OK;
+    return API_EARGS;
 }
 
 error MegaClient::folderaccess(const char *folderlink)
@@ -8060,7 +8083,7 @@ error MegaClient::folderaccess(const char *folderlink)
     byte folderkey[SymmCipher::KEYLENGTH];
 
     error e;
-    if ((e = parsefolderlink(folderlink, h, folderkey)) == API_OK)
+    if ((e = parsepubliclink(folderlink, h, folderkey, true)) == API_OK)
     {
         setrootnode(h);
         key.setkey(folderkey);
@@ -9988,64 +10011,17 @@ void MegaClient::getpubliclink(Node* n, int del, m_time_t ets)
 
 // open exported file link
 // formats supported: ...#!publichandle!key, publichandle!key or file/<ph>[<params>][#<key>]
-error MegaClient::openfilelink(const char* link, int op)
+void MegaClient::openfilelink(handle ph, const byte *key, int op)
 {
-    const char* ptr = NULL;
-    handle ph = 0;
-    byte key[FILENODEKEYLENGTH];
-
-    if ((ptr = strstr(link, "#!")))
+    if (op)
     {
-        ptr += 2;
+        reqs.add(new CommandGetPH(this, ph, key, op));
     }
-    else if ((ptr = strstr(link, "file/")))
+    else
     {
-        ptr += 5;
+        assert(key);
+        reqs.add(new CommandGetFile(this, NULL, key, ph, false));
     }
-    else    // legacy format without '#'
-    {
-        ptr = link;
-    }
-
-    if (Base64::atob(ptr, (byte*)&ph, NODEHANDLE) == NODEHANDLE)
-    {
-        ptr += 8;
-
-        // skip any tracking parameter introduced by third-party websites
-        while(*ptr && *ptr != '!' && *ptr != '#')
-        {
-            ptr++;
-        }
-
-        if (*ptr == '!' || (*ptr == '#' && *(ptr + 1) != '\0'))
-        {
-            ptr++;
-
-            if (Base64::atob(ptr, key, sizeof key) == sizeof key)
-            {
-                if (op)
-                {
-                    reqs.add(new CommandGetPH(this, ph, key, op));
-                }
-                else
-                {
-                    reqs.add(new CommandGetFile(this, NULL, key, ph, false));
-                }
-
-                return API_OK;
-            }
-        }
-        else if (*ptr == '\0' || *ptr == '#')    // no key provided, check only the existence of the node
-        {
-            if (op)
-            {
-                reqs.add(new CommandGetPH(this, ph, NULL, op));
-                return API_OK;
-            }
-        }
-    }
-
-    return API_EARGS;
 }
 
 /* Format of password-protected links

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -8066,7 +8066,7 @@ error MegaClient::parsepubliclink(const char* link, handle& ph, byte* key, bool 
         if (*ptr == '!' || *ptr == '#')
         {
             const char *k = ptr + 1;    // skip '!' or '#' separator
-            size_t keylen = isFolderLink ? SymmCipher::KEYLENGTH : FILENODEKEYLENGTH;
+            int keylen = isFolderLink ? FOLDERNODEKEYLENGTH : FILENODEKEYLENGTH;
             if (Base64::atob(k, key, keylen) == keylen)
             {
                 return API_OK;
@@ -8080,7 +8080,7 @@ error MegaClient::parsepubliclink(const char* link, handle& ph, byte* key, bool 
 error MegaClient::folderaccess(const char *folderlink)
 {
     handle h = UNDEF;
-    byte folderkey[SymmCipher::KEYLENGTH];
+    byte folderkey[FOLDERNODEKEYLENGTH];
 
     error e;
     if ((e = parsepubliclink(folderlink, h, folderkey, true)) == API_OK)


### PR DESCRIPTION
Some websites modify MEGA public links to include tracking params. We need to skip them in order to parse the public-handle and the key.

This PR also solves the ticket #13637, which fixes the public links protected by password.

**Risk area/s**:
- Create/open/import/download a file/folder link with or without key, and password-protected links.