### PR TITLE
#13651. Efficient removal of sync transfers from database when a sync is remo…

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -3825,10 +3825,10 @@ void exec_sync(autocomplete::ACState& s)
                     static const char* syncstatenames[] =
                     { "Initial scan, please wait", "Active", "Failed" };
 
-                    if ((*it)->localroot.node)
+                    if ((*it)->localroot->node)
                     {
-                        nodepath((*it)->localroot.node->nodehandle, &remotepath);
-                        client->fsaccess->local2path(&(*it)->localroot.localname, &localpath);
+                        nodepath((*it)->localroot->node->nodehandle, &remotepath);
+                        client->fsaccess->local2path(&(*it)->localroot->localname, &localpath);
 
                         cout << i++ << ": " << localpath << " to " << remotepath << " - "
                                 << syncstatenames[(*it)->state] << ", " << (*it)->localbytes

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -53,8 +53,8 @@ public:
     // sync-wide directory notification provider
     std::unique_ptr<DirNotify> dirnotify;
 
-    // root of local filesystem tree, holding the sync's root folder
-    LocalNode localroot;
+    // root of local filesystem tree, holding the sync's root folder.  Never null except briefly in the destructor (to ensure efficient db usage)
+    unique_ptr<LocalNode> localroot;
 
     // Path used to normalize sync locaroot name when using prefix /System/Volumes/Data needed by fsevents, due to notification paths
     // are served with such prefix from macOS catalina +

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -516,7 +516,7 @@ void SyncFileGet::prepare()
         }
         else
         {
-            transfer->localfilename = sync->localroot.localname;
+            transfer->localfilename = sync->localroot->localname;
         }
 
         sync->client->fsaccess->tmpnamelocal(&tmpname);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8108,7 +8108,7 @@ bool MegaApiImpl::moveToLocalDebris(const char *path)
     Sync *sync = NULL;
     for (sync_list::iterator it = client->syncs.begin(); it != client->syncs.end(); it++)
     {
-        string *localroot = &((*it)->localroot.localname);
+        string *localroot = &((*it)->localroot->localname);
         if(((localroot->size()+fsAccess->localseparator.size())<localpath.size()) &&
             !memcmp(localroot->data(), localpath.data(), localroot->size()) &&
             !memcmp(fsAccess->localseparator.data(), localpath.data()+localroot->size(), fsAccess->localseparator.size()))
@@ -8166,8 +8166,8 @@ int MegaApiImpl::syncPathState(string* path)
     for (sync_list::iterator it = client->syncs.begin(); it != client->syncs.end(); it++)
     {
         Sync *sync = (*it);
-        size_t ssize = sync->localroot.localname.size();
-        if (path->size() < ssize || memcmp(path->data(), sync->localroot.localname.data(), ssize))
+        size_t ssize = sync->localroot->localname.size();
+        if (path->size() < ssize || memcmp(path->data(), sync->localroot->localname.data(), ssize))
         {
             continue;
         }
@@ -8185,7 +8185,7 @@ int MegaApiImpl::syncPathState(string* path)
 
         if (path->size() == ssize)
         {
-            state = sync->localroot.ts;
+            state = sync->localroot->ts;
             break;
         }
         else if (!memcmp(path->data()+ssize, client->fsaccess->localseparator.data(), client->fsaccess->localseparator.size()))
@@ -8231,10 +8231,10 @@ MegaNode *MegaApiImpl::getSyncedNode(string *path)
     for (sync_list::iterator it = client->syncs.begin(); (it != client->syncs.end()) && (node == NULL); it++)
     {
         Sync *sync = (*it);
-        if (path->size() == sync->localroot.localname.size() &&
-                !memcmp(path->data(), sync->localroot.localname.data(), path->size()))
+        if (path->size() == sync->localroot->localname.size() &&
+                !memcmp(path->data(), sync->localroot->localname.data(), path->size()))
         {
-            node = MegaNodePrivate::fromNode(sync->localroot.node);
+            node = MegaNodePrivate::fromNode(sync->localroot->node);
             break;
         }
 
@@ -12482,16 +12482,16 @@ void MegaApiImpl::syncupdate_state(Sync *sync, syncstate_t newstate)
     if(syncMap.find(sync->tag) == syncMap.end()) return;
     MegaSyncPrivate* megaSync = syncMap.at(sync->tag);
     megaSync->setState(newstate);
-    LOG_debug << "Sync state change: " << newstate << " Path: " << sync->localroot.name;
+    LOG_debug << "Sync state change: " << newstate << " Path: " << sync->localroot->name;
     client->abortbackoff(false);
 
     if (newstate == SYNC_FAILED)
     {
         MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_ADD_SYNC);
 
-        if(sync->localroot.node)
+        if(sync->localroot->node)
         {
-            request->setNodeHandle(sync->localroot.node->nodehandle);
+            request->setNodeHandle(sync->localroot->node->nodehandle);
         }
 
         int nextTag = client->nextreqtag();
@@ -20419,11 +20419,11 @@ void MegaApiImpl::sendPendingRequests()
                 it++;
 
                 int tag = sync->tag;
-                if (!sync->localroot.node || sync->localroot.node->nodehandle == nodehandle)
+                if (!sync->localroot->node || sync->localroot->node->nodehandle == nodehandle)
                 {
                     string path;
-                    fsAccess->local2path(&sync->localroot.localname, &path);
-                    if (!request->getFile() || sync->localroot.node)
+                    fsAccess->local2path(&sync->localroot->localname, &path);
+                    if (!request->getFile() || sync->localroot->node)
                     {
                         request->setFile(path.c_str());
                     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -459,7 +459,7 @@ void MegaClient::mergenewshare(NewShare *s, bool notify)
             // b) have we just lost full access to the subtree a sync is in?
             for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
             {
-                if ((*it)->inshare && ((*it)->state == SYNC_ACTIVE || (*it)->state == SYNC_INITIALSCAN) && !checkaccess((*it)->localroot.node, FULL))
+                if ((*it)->inshare && ((*it)->state == SYNC_ACTIVE || (*it)->state == SYNC_INITIALSCAN) && !checkaccess((*it)->localroot->node, FULL))
                 {
                     LOG_warn << "Existing inbound share sync lost full access";
                     (*it)->errorcode = API_EACCESS;
@@ -2367,7 +2367,7 @@ void MegaClient::exec()
                                         if (!syncadding)
                                         {
                                             LOG_debug << "Running syncup to create missing folders";
-                                            syncup(&sync->localroot, &nds);
+                                            syncup(sync->localroot.get(), &nds);
                                             sync->cachenodes();
                                         }
 
@@ -2384,7 +2384,7 @@ void MegaClient::exec()
                                     // scan for items that were deleted while the sync was stopped
                                     // FIXME: defer this until RETRY queue is processed
                                     sync->scanseqno++;
-                                    sync->deletemissing(&sync->localroot);
+                                    sync->deletemissing(sync->localroot.get());
                                 }
                             }
                         }
@@ -2473,7 +2473,7 @@ void MegaClient::exec()
                     for (it = syncs.begin(); it != syncs.end(); it++)
                     {
                         // make sure that the remote synced folder still exists
-                        if (!(*it)->localroot.node)
+                        if (!(*it)->localroot->node)
                         {
                             LOG_err << "The remote root node doesn't exist";
                             (*it)->errorcode = API_ENOENT;
@@ -2533,7 +2533,7 @@ void MegaClient::exec()
                                  && !syncadding && syncuprequired && !syncnagleretry)
                                 {
                                     LOG_debug << "Running syncup on demand";
-                                    repeatsyncup |= !syncup(&(*it)->localroot, &nds);
+                                    repeatsyncup |= !syncup((*it)->localroot.get(), &nds);
                                     syncupdone = true;
                                     (*it)->cachenodes();
                                 }
@@ -2583,7 +2583,7 @@ void MegaClient::exec()
                                         if (sync->fullscan)
                                         {
                                             // recursively delete all LocalNodes that were deleted (not moved or renamed!)
-                                            sync->deletemissing(&sync->localroot);
+                                            sync->deletemissing(sync->localroot.get());
                                             sync->cachenodes();
                                         }
 
@@ -2607,7 +2607,7 @@ void MegaClient::exec()
                                                 }
                                                 scanfailed = true;
 
-                                                sync->scan(&sync->localroot.localname, NULL);
+                                                sync->scan(&sync->localroot->localname, NULL);
                                                 sync->dirnotify->error = 0;
                                                 sync->fullscan = true;
                                                 sync->scanseqno++;
@@ -2660,7 +2660,7 @@ void MegaClient::exec()
                     for (it = syncs.begin(); it != syncs.end(); it++)
                     {
                         // make sure that the remote synced folder still exists
-                        if (!(*it)->localroot.node)
+                        if (!(*it)->localroot->node)
                         {
                             LOG_err << "The remote root node doesn't exist";
                             (*it)->errorcode = API_ENOENT;
@@ -2668,11 +2668,11 @@ void MegaClient::exec()
                         }
                         else
                         {
-                            string localpath = (*it)->localroot.localname;
+                            string localpath = (*it)->localroot->localname;
                             if ((*it)->state == SYNC_ACTIVE || (*it)->state == SYNC_INITIALSCAN)
                             {
                                 LOG_debug << "Running syncdown on demand";
-                                if (!syncdown(&(*it)->localroot, &localpath, true))
+                                if (!syncdown((*it)->localroot.get(), &localpath, true))
                                 {
                                     // a local filesystem item was locked - schedule periodic retry
                                     // and force a full rescan afterwards as the local item may
@@ -6456,7 +6456,7 @@ void MegaClient::notifypurge(void)
         for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
         {
             if (((*it)->state == SYNC_ACTIVE || (*it)->state == SYNC_INITIALSCAN)
-             && (*it)->localroot.node->changed.removed)
+             && (*it)->localroot->node->changed.removed)
             {
                 delsync(*it);
             }
@@ -11933,7 +11933,7 @@ error MegaClient::isnodesyncable(Node *remotenode, bool *isinshare)
     {
         if ((*it)->state == SYNC_ACTIVE || (*it)->state == SYNC_INITIALSCAN)
         {
-            n = (*it)->localroot.node;
+            n = (*it)->localroot->node;
 
             do {
                 if (n == remotenode)
@@ -11952,7 +11952,7 @@ error MegaClient::isnodesyncable(Node *remotenode, bool *isinshare)
         for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
         {
             if (((*it)->state == SYNC_ACTIVE || (*it)->state == SYNC_INITIALSCAN)
-             && n == (*it)->localroot.node)
+             && n == (*it)->localroot->node)
             {
                 return API_EEXIST;
             }

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1139,7 +1139,7 @@ struct StandardClient : public MegaApp
         descendants = 0; 
         if (Sync* sync = syncByTag(syncid))
         {
-            if (!recursiveConfirm(mnode, &sync->localroot, descendants, "Sync " + to_string(syncid), 0))
+            if (!recursiveConfirm(mnode, sync->localroot.get(), descendants, "Sync " + to_string(syncid), 0))
             {
                 cout << "syncid " << syncid << " comparison against LocalNodes failed" << endl;
                 return false;

--- a/tests/unit/Commands_test.cpp
+++ b/tests/unit/Commands_test.cpp
@@ -104,7 +104,7 @@ TEST(Commands, CommandGetRegisteredContacts_processResult_onlyOneContact)
     ASSERT_EQ(API_OK, app.mLastError);
     ASSERT_NE(nullptr, app.mRegisteredContacts);
     ASSERT_EQ(expected, *app.mRegisteredContacts);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 TEST(Commands, CommandGetRegisteredContacts_processResult_extraFieldShouldBeIgnored)
@@ -126,7 +126,7 @@ TEST(Commands, CommandGetRegisteredContacts_processResult_extraFieldShouldBeIgno
     ASSERT_EQ(API_OK, app.mLastError);
     ASSERT_NE(nullptr, app.mRegisteredContacts);
     ASSERT_EQ(expected, *app.mRegisteredContacts);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 TEST(Commands, CommandGetRegisteredContacts_processResult_invalidResponse)
@@ -143,7 +143,7 @@ TEST(Commands, CommandGetRegisteredContacts_processResult_invalidResponse)
     ASSERT_EQ(1, app.mCallCount);
     ASSERT_EQ(API_EINTERNAL, app.mLastError);
     ASSERT_EQ(nullptr, app.mRegisteredContacts);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 TEST(Commands, CommandGetRegisteredContacts_processResult_errorCodeReceived)
@@ -160,7 +160,7 @@ TEST(Commands, CommandGetRegisteredContacts_processResult_errorCodeReceived)
     ASSERT_EQ(1, app.mCallCount);
     ASSERT_EQ(API_EEXPIRED, app.mLastError);
     ASSERT_EQ(nullptr, app.mRegisteredContacts);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 namespace {
@@ -212,7 +212,7 @@ TEST(Commands, CommandGetCountryCallingCodes_processResult_happyPath)
     ASSERT_EQ(API_OK, app.mLastError);
     ASSERT_NE(nullptr, app.mCountryCallingCodes);
     ASSERT_EQ(expected, *app.mCountryCallingCodes);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 TEST(Commands, CommandGetCountryCallingCodes_processResult_onlyOneCountry)
@@ -234,7 +234,7 @@ TEST(Commands, CommandGetCountryCallingCodes_processResult_onlyOneCountry)
     ASSERT_EQ(API_OK, app.mLastError);
     ASSERT_NE(nullptr, app.mCountryCallingCodes);
     ASSERT_EQ(expected, *app.mCountryCallingCodes);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 TEST(Commands, CommandGetCountryCallingCodes_processResult_extraFieldShouldBeIgnored)
@@ -256,7 +256,7 @@ TEST(Commands, CommandGetCountryCallingCodes_processResult_extraFieldShouldBeIgn
     ASSERT_EQ(API_OK, app.mLastError);
     ASSERT_NE(nullptr, app.mCountryCallingCodes);
     ASSERT_EQ(expected, *app.mCountryCallingCodes);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 TEST(Commands, CommandGetCountryCallingCodes_processResult_invalidResponse)
@@ -273,7 +273,7 @@ TEST(Commands, CommandGetCountryCallingCodes_processResult_invalidResponse)
     ASSERT_EQ(1, app.mCallCount);
     ASSERT_EQ(API_EINTERNAL, app.mLastError);
     ASSERT_EQ(nullptr, app.mCountryCallingCodes);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }
 
 TEST(Commands, CommandGetCountryCallingCodes_processResult_errorCodeReceived)
@@ -290,5 +290,5 @@ TEST(Commands, CommandGetCountryCallingCodes_processResult_errorCodeReceived)
     ASSERT_EQ(1, app.mCallCount);
     ASSERT_EQ(API_EEXPIRED, app.mLastError);
     ASSERT_EQ(nullptr, app.mCountryCallingCodes);
-    ASSERT_EQ(jsonLength, std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
+    ASSERT_EQ(ptrdiff_t(jsonLength), std::distance(jsonBegin, json.pos)); // assert json has been parsed all the way
 }


### PR DESCRIPTION
…ved.

Closing a sync means we need to remove any active transfers from that sync from the transfer table in the database.
This change means we will just use one begin/commit to update all those transfers, which means it's much faster.