### PR TITLE
#13649: fix bug when opening an empty folder in an FTP served location

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -29093,6 +29093,13 @@ void MegaFTPServer::processReceivedData(MegaTCPContext *tcpctx, ssize_t nread, c
                 {
                     MegaNodeList *children = ftpctx->megaApi->getChildren(node);
                     assert(!ftpctx->ftpDataServer->resultmsj.size());
+
+                    if (ftpctx->command == FTP_CMD_LIST)
+                    {
+                        ftpctx->ftpDataServer->resultmsj.append(getListingLineFromNode(node,"."));
+                        ftpctx->ftpDataServer->resultmsj.append(crlfout);
+                    }
+
                     for (int i = 0; i < children->size(); i++)
                     {
                         MegaNode *child = children->get(i);


### PR DESCRIPTION
**Risk Areas**

- Ftp serving (only MEGAcmd)

This should fix https://github.com/meganz/MEGAcmd/issues/210