### PR TITLE
Pass the listener parameter from the megaapi interface to megaapi_impl

### DIFF
--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2634,7 +2634,7 @@ void MegaApi::getUserAlias(MegaHandle uh, MegaRequestListener *listener)
 
 void MegaApi::setUserAlias(MegaHandle uh, const char *alias, MegaRequestListener *listener)
 {
-    pImpl->setUserAlias(uh, alias);
+    pImpl->setUserAlias(uh, alias, listener);
 }
 
 void MegaApi::getRubbishBinAutopurgePeriod(MegaRequestListener *listener)

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -54,9 +54,7 @@ public:
             }
             else
             {
-#ifdef _WIN32
-                OutputDebugStringA(os.str().c_str());
-#else
+#ifndef _WIN32
                 std::cout << os.str();
 #endif
                 if (!gTestingInvalidArgs)
@@ -64,6 +62,10 @@ public:
                     ASSERT_NE(loglevel, logError) << os.str();
                 }
             }
+#ifdef _WIN32
+            OutputDebugStringA(os.str().c_str());
+#endif
+
         }
     }
 


### PR DESCRIPTION
Otherwise the client app is not called back on completion, if it relies on that listener

Also a change for integration tests on windows, allow log monitoring from VS output window