### PR TITLE
Work around compile error for broken compilers like the one we use fo…

### DIFF
--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -107,7 +107,7 @@ FileFingerprint *FileFingerprint::unserialize(string *d)
 FileFingerprint::FileFingerprint(const FileFingerprint& other)
 : size{other.size}
 , mtime{other.mtime}
-, crc{other.crc}
+, crc(other.crc)
 , isvalid{other.isvalid}
 {}
 


### PR DESCRIPTION
…r android

In this case the compiler erroneously uses aggregate initialization instead of calling the implicit copy constructor of std::array.
