### PR TITLE
Switch to snprintf for performance logging

### DIFF
--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @file mega/logging.h
  * @brief Logging class
  *
@@ -152,15 +152,16 @@ class SimpleLogger
 #else
     std::array<char, 256> mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
     std::array<char, 256>::iterator mBufferIt;
+    using DiffType = std::array<char, 256>::difference_type;
     using NumBuf = std::array<char, 24>;
 
     template<typename DataIterator>
-    void copyToBuffer(const DataIterator dataIt, size_t currentSize)
+    void copyToBuffer(const DataIterator dataIt, DiffType currentSize)
     {
-        size_t start = 0;
+        DiffType start = 0;
         while (currentSize > 0)
         {
-            const auto size = std::min(currentSize, static_cast<size_t>(std::distance(mBufferIt, mBuffer.end() - 1)));
+            const auto size = std::min(currentSize, std::distance(mBufferIt, mBuffer.end() - 1));
             mBufferIt = std::copy(dataIt + start, dataIt + start + size, mBufferIt);
             if (mBufferIt == mBuffer.end() - 1)
             {
@@ -270,12 +271,12 @@ class SimpleLogger
 
     void logValue(const char* value)
     {
-        copyToBuffer(value, std::strlen(value));
+        copyToBuffer(value, static_cast<DiffType>(std::strlen(value)));
     }
 
     void logValue(const std::string& value)
     {
-        copyToBuffer(value.begin(), value.size());
+        copyToBuffer(value.begin(), static_cast<DiffType>(value.size()));
     }
 #endif
 

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -104,6 +104,8 @@
     #include <QString>
 #endif
 
+#include <mega/utils.h>
+
 namespace mega {
 
 // available log levels
@@ -184,7 +186,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%d", static_cast<int>(value));
+        const auto size = snprintf(buf.data(), buf.size(), "%d", static_cast<int>(value));
         copyToBuffer(buf.data(), size);
     }
 
@@ -193,7 +195,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%p", reinterpret_cast<const void*>(value));
+        const auto size = snprintf(buf.data(), buf.size(), "%p", reinterpret_cast<const void*>(value));
         copyToBuffer(buf.data(), size);
     }
 
@@ -203,7 +205,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%d", value);
+        const auto size = snprintf(buf.data(), buf.size(), "%d", value);
         copyToBuffer(buf.data(), size);
     }
 
@@ -213,7 +215,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%ld", value);
+        const auto size = snprintf(buf.data(), buf.size(), "%ld", value);
         copyToBuffer(buf.data(), size);
     }
 
@@ -223,7 +225,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%lld", value);
+        const auto size = snprintf(buf.data(), buf.size(), "%lld", value);
         copyToBuffer(buf.data(), size);
     }
 
@@ -233,7 +235,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%u", value);
+        const auto size = snprintf(buf.data(), buf.size(), "%u", value);
         copyToBuffer(buf.data(), size);
     }
 
@@ -243,7 +245,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%lu", value);
+        const auto size = snprintf(buf.data(), buf.size(), "%lu", value);
         copyToBuffer(buf.data(), size);
     }
 
@@ -253,7 +255,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%llu", value);
+        const auto size = snprintf(buf.data(), buf.size(), "%llu", value);
         copyToBuffer(buf.data(), size);
     }
 
@@ -262,7 +264,7 @@ class SimpleLogger
     logValue(const T value)
     {
         NumBuf buf;
-        const auto size = std::snprintf(buf.data(), buf.size(), "%g", value);
+        const auto size = snprintf(buf.data(), buf.size(), "%g", value);
         copyToBuffer(buf.data(), size);
     }
 

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -150,6 +150,7 @@ class SimpleLogger
 #else
     std::array<char, 256> mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
     std::array<char, 256>::iterator mBufferIt;
+    using NumBuf = std::array<char, 24>;
 
     template<typename DataIterator>
     void copyToBuffer(const DataIterator dataIt, size_t currentSize)
@@ -182,18 +183,18 @@ class SimpleLogger
     typename std::enable_if<std::is_enum<T>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%d", static_cast<int>(value));
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%d", static_cast<int>(value));
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
     typename std::enable_if<std::is_pointer<T>::value && !std::is_same<T, char*>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%p", reinterpret_cast<const void*>(value));
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%p", reinterpret_cast<const void*>(value));
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
@@ -201,9 +202,9 @@ class SimpleLogger
                             && !std::is_same<T, long>::value && !std::is_same<T, long long>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%d", value);
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%d", value);
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
@@ -211,9 +212,9 @@ class SimpleLogger
                             && std::is_same<T, long>::value && !std::is_same<T, long long>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%ld", value);
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%ld", value);
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
@@ -221,9 +222,9 @@ class SimpleLogger
                             && !std::is_same<T, long>::value && std::is_same<T, long long>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%lld", value);
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%lld", value);
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
@@ -231,9 +232,9 @@ class SimpleLogger
                             && !std::is_same<T, unsigned long>::value && !std::is_same<T, unsigned long long>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%u", value);
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%u", value);
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
@@ -241,9 +242,9 @@ class SimpleLogger
                             && std::is_same<T, unsigned long>::value && !std::is_same<T, unsigned long long>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%lu", value);
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%lu", value);
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
@@ -251,18 +252,18 @@ class SimpleLogger
                             && !std::is_same<T, unsigned long>::value && std::is_same<T, unsigned long long>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%llu", value);
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%llu", value);
+        copyToBuffer(buf.data(), size);
     }
 
     template<typename T>
     typename std::enable_if<std::is_floating_point<T>::value>::type
     logValue(const T value)
     {
-        char str[20];
-        const auto size = std::sprintf(str, "%f", value);
-        copyToBuffer(str, size);
+        NumBuf buf;
+        const auto size = std::snprintf(buf.data(), buf.size(), "%g", value);
+        copyToBuffer(buf.data(), size);
     }
 
     void logValue(const char* value)

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -188,7 +188,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%d", static_cast<int>(value));
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -197,7 +197,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%p", reinterpret_cast<const void*>(value));
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -207,7 +207,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%d", value);
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -217,7 +217,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%ld", value);
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -227,7 +227,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%lld", value);
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -237,7 +237,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%u", value);
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -247,7 +247,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%lu", value);
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -257,7 +257,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%llu", value);
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     template<typename T>
@@ -266,7 +266,7 @@ class SimpleLogger
     {
         NumBuf buf;
         const auto size = snprintf(buf.data(), buf.size(), "%g", value);
-        copyToBuffer(buf.data(), size);
+        copyToBuffer(buf.data(), std::min(size, static_cast<int>(buf.size()) - 1));
     }
 
     void logValue(const char* value)

--- a/tests/unit/Logging_test.cpp
+++ b/tests/unit/Logging_test.cpp
@@ -142,34 +142,36 @@ TEST(Logging, performanceMode_forNullPointer)
 namespace {
 
 template<typename Type>
-void test_forIntegerNumber()
+void test_forIntegerNumber(const Type number)
 {
     for (int level = 0; level <= mega::LogLevel::logMax; ++level)
     {
         MockLogger logger;
         const std::string file = "file.cpp";
         const int line = 13;
-        const Type obj = 42;
-        mega::SimpleLogger{static_cast<mega::LogLevel>(level), file.c_str(), line} << obj;
+        mega::SimpleLogger{static_cast<mega::LogLevel>(level), file.c_str(), line} << number;
         logger.checkLogLevel(level);
         EXPECT_EQ(1, logger.mMessage.size());
-        EXPECT_EQ(expMsg(file, line, "42"), logger.mMessage[0]);
+        std::ostringstream expected;
+        expected << number;
+        EXPECT_EQ(expMsg(file, line, expected.str()), logger.mMessage[0]);
     }
 }
 
 template<typename Type>
-void test_forFloatingNumber()
+void test_forFloatingNumber(const Type number)
 {
     for (int level = 0; level <= mega::LogLevel::logMax; ++level)
     {
         MockLogger logger;
         const std::string file = "file.cpp";
         const int line = 13;
-        const auto obj = static_cast<Type>(42.123);
-        mega::SimpleLogger{static_cast<mega::LogLevel>(level), file.c_str(), line} << obj;
+        mega::SimpleLogger{static_cast<mega::LogLevel>(level), file.c_str(), line} << number;
         logger.checkLogLevel(level);
         EXPECT_EQ(1, logger.mMessage.size());
-        const auto msg = expMsg(file, line, "42.123");
+        std::ostringstream expected;
+        expected << number;
+        const auto msg = expMsg(file, line, expected.str());
         EXPECT_NE(logger.mMessage[0].find(msg), std::string::npos);
     }
 }
@@ -178,42 +180,73 @@ void test_forFloatingNumber()
 
 TEST(Logging, performanceMode_forInt)
 {
-    test_forIntegerNumber<int>();
+    test_forIntegerNumber<int>(0);
+    test_forIntegerNumber<int>(42);
+    test_forIntegerNumber<int>(-42);
+    test_forIntegerNumber<int>(std::numeric_limits<int>::lowest());
+    test_forIntegerNumber<int>(std::numeric_limits<int>::max());
 }
 
 TEST(Logging, performanceMode_forLong)
 {
-    test_forIntegerNumber<long>();
+    test_forIntegerNumber<long>(0);
+    test_forIntegerNumber<long>(42);
+    test_forIntegerNumber<long>(-42);
+    test_forIntegerNumber<long>(std::numeric_limits<long>::lowest());
+    test_forIntegerNumber<long>(std::numeric_limits<long>::max());
 }
 
 TEST(Logging, performanceMode_forLongLong)
 {
-    test_forIntegerNumber<long long>();
+    test_forIntegerNumber<long long>(0);
+    test_forIntegerNumber<long long>(42);
+    test_forIntegerNumber<long long>(-42);
+    test_forIntegerNumber<long long>(std::numeric_limits<long long>::lowest());
+    test_forIntegerNumber<long long>(std::numeric_limits<long long>::max());
 }
 
 TEST(Logging, performanceMode_forUnsignedInt)
 {
-    test_forIntegerNumber<unsigned int>();
+    test_forIntegerNumber<unsigned int>(0);
+    test_forIntegerNumber<unsigned int>(42);
+    test_forIntegerNumber<unsigned int>(std::numeric_limits<unsigned int>::lowest());
+    test_forIntegerNumber<unsigned int>(std::numeric_limits<unsigned int>::max());
 }
 
 TEST(Logging, performanceMode_forUnsignedLong)
 {
-    test_forIntegerNumber<unsigned long>();
+    test_forIntegerNumber<unsigned long>(0);
+    test_forIntegerNumber<unsigned long>(42);
+    test_forIntegerNumber<unsigned long>(std::numeric_limits<unsigned long>::lowest());
+    test_forIntegerNumber<unsigned long>(std::numeric_limits<unsigned long>::max());
 }
 
 TEST(Logging, performanceMode_forUnsignedLongLong)
 {
-    test_forIntegerNumber<unsigned long long>();
+    test_forIntegerNumber<unsigned long long>(0);
+    test_forIntegerNumber<unsigned long long>(42);
+    test_forIntegerNumber<unsigned long long>(std::numeric_limits<unsigned long long>::lowest());
+    test_forIntegerNumber<unsigned long long>(std::numeric_limits<unsigned long long>::max());
 }
 
 TEST(Logging, performanceMode_forFloat)
 {
-    test_forFloatingNumber<float>();
+    test_forFloatingNumber<float>(0.f);
+    test_forFloatingNumber<float>(42.123f);
+    test_forFloatingNumber<float>(-42.123f);
+    test_forFloatingNumber<float>(std::numeric_limits<float>::lowest());
+    test_forFloatingNumber<float>(std::numeric_limits<float>::min());
+    test_forFloatingNumber<float>(std::numeric_limits<float>::max());
 }
 
 TEST(Logging, performanceMode_forDouble)
 {
-    test_forFloatingNumber<double>();
+    test_forFloatingNumber<double>(0.);
+    test_forFloatingNumber<double>(42.123);
+    test_forFloatingNumber<double>(-42.123);
+    test_forFloatingNumber<double>(std::numeric_limits<double>::lowest());
+    test_forFloatingNumber<double>(std::numeric_limits<double>::min());
+    test_forFloatingNumber<double>(std::numeric_limits<double>::max());
 }
 
 TEST(Logging, performanceMode_withMessageLargeThanLogBuffer)


### PR DESCRIPTION
This prevents stack overruns in certain cases such as when dealing with large numbers. Also, changed from `%f` to `%g` for floating point numbers to either get normal or exponential notation, whichever is more appropriate for its magnitude. Also addressed some conversion warnings.