### PR TITLE
Fix compilation on Xcode

### DIFF
--- a/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
+++ b/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
@@ -978,6 +978,7 @@
 					3rdparty/include,
 					../../third_party/utf8proc,
 					3rdparty/webrtc/third_party/boringssl/src/include,
+					../../include,
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1005,6 +1006,7 @@
 					3rdparty/include,
 					../../third_party/utf8proc,
 					3rdparty/webrtc/third_party/boringssl/src/include,
+					../../include,
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Compilation error:
/include/mega/logging.h:107:10: 'mega/utils.h' file not found with <angled> include; use "quotes" instead

Fix:
Add ../../include in the Header search paths of the MEGASDK Xcode project