### PR TITLE
Fix compilation error in xcode

### DIFF
--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -104,7 +104,7 @@
     #include <QString>
 #endif
 
-#include <mega/utils.h>
+#include "mega/utils.h"
 
 namespace mega {
 


### PR DESCRIPTION
Compilation error:
/include/mega/logging.h:107:10: 'mega/utils.h' file not found with
include; use "quotes" instead