### PR TITLE
Remove delegate parameter for resetCredentialsOfUser

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -1256,9 +1256,8 @@ typedef NS_ENUM(NSInteger, BusinessStatus) {
  * - [MEGARequest flag] - Returns YES
  *
  * @param user MEGAUser of the contact whose credentials want to be reset
- * @param delegate MEGARequestDelegate to track this request
  */
-- (void)resetCredentialsOfUser:(MEGAUser *)user delegate:(id<MEGARequestDelegate>)delegate;
+- (void)resetCredentialsOfUser:(MEGAUser *)user;
 
 #pragma mark - Create account and confirm account Requests
 


### PR DESCRIPTION
Multiple declarations of method 'resetCredentialsOfUser:delegate:' found and ignored