### PR TITLE
#13679. Add startUploadForSupport that uploads to support inbox

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -3649,6 +3649,7 @@ class MegaTransfer
          * @brief Returns the parent path related to this request
          *
          * For uploads, this function returns the path to the folder containing the source file.
+         *  except when uploading files for support: it will return the support account then.
          * For downloads, it returns that path to the folder containing the destination file.
          *
          * The SDK retains the ownership of the returned value. It will be valid until
@@ -10728,7 +10729,9 @@ class MegaApi
          * code MegaError::API_EBUSINESSPASTDUE. In this case, apps should show a warning message similar to
          * "Your business account is overdue, please contact your administrator."
          *
-         * @param localPath Local path of the file or folder
+         * For folders, onTransferFinish will be called with error MegaError:API_EARGS;
+         *
+         * @param localPath Local path of the file
          * @param listener MegaTransferListener to track this transfer
          */
         void startUploadForSupport(const char* localPath, MegaTransferListener *listener=NULL);

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10722,6 +10722,19 @@ class MegaApi
         ///////////////////   TRANSFERS ///////////////////
 
         /**
+         * @brief Upload a file to support
+         *
+         * If the status of the business account is expired, onTransferFinish will be called with the error
+         * code MegaError::API_EBUSINESSPASTDUE. In this case, apps should show a warning message similar to
+         * "Your business account is overdue, please contact your administrator."
+         *
+         * @param localPath Local path of the file or folder
+         * @param listener MegaTransferListener to track this transfer
+         */
+        void startUploadForSupport(const char* localPath, MegaTransferListener *listener=NULL);
+
+
+        /**
          * @brief Upload a file or a folder
          *
          * If the status of the business account is expired, onTransferFinish will be called with the error

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -732,7 +732,7 @@ class MegaTransferPrivate : public MegaTransfer, public Cachable
         MegaHandle nodeHandle;
         MegaHandle parentHandle;
         const char* path;
-        const char* parentPath;
+        const char* parentPath; //used as targetUser for uploads
         const char* fileName;
         char *lastBytes;
         MegaNode *publicNode;
@@ -2173,6 +2173,8 @@ class MegaApiImpl : public MegaApp
         void startUpload(const char* localPath, MegaNode *parent, int64_t mtime, MegaTransferListener *listener=NULL);
         void startUpload(const char* localPath, MegaNode* parent, const char* fileName, MegaTransferListener *listener = NULL);
         void startUpload(bool startFirst, const char* localPath, MegaNode* parent, const char* fileName, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, MegaTransferListener *listener);
+        void startUpload(bool startFirst, const char* localPath, MegaNode* parent, const char* fileName, const char* targetUser, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, MegaTransferListener *listener);
+        void startUploadForSupport(const char *localPath, MegaTransferListener *listener=NULL);
         void startDownload(MegaNode* node, const char* localPath, MegaTransferListener *listener = NULL);
         void startDownload(bool startFirst, MegaNode *node, const char* target, int folderTransferTag, const char *appData, MegaTransferListener *listener);
         void startStreaming(MegaNode* node, m_off_t startPos, m_off_t size, MegaTransferListener *listener);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -3560,12 +3560,9 @@ void CommandPubKeyRequest::procresult()
                     if (!ISUNDEF(uh))
                     {
                         client->mapuser(uh, u->email.c_str());
-                        if (u->isTemporary && u->uid == u->email)
+                        if (u->isTemporary && u->uid == u->email) //update uid with the received USERHANDLE (will be used as target for putnodes)
                         {
-                            char uid[12];
-                            Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
-                            uid[11] = '\0';
-                            u->uid = uid;
+                            u->uid = Base64Str<MegaClient::USERHANDLE>(uh);
                         }
                     }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -3560,6 +3560,13 @@ void CommandPubKeyRequest::procresult()
                     if (!ISUNDEF(uh))
                     {
                         client->mapuser(uh, u->email.c_str());
+                        if (u->isTemporary && u->uid == u->email)
+                        {
+                            char uid[12];
+                            Base64::btoa((byte*)&uh, MegaClient::USERHANDLE, uid);
+                            uid[11] = '\0';
+                            u->uid = uid;
+                        }
                     }
 
                     if (client->fetchingkeys && u->userhandle == client->me && len_pubk)

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2873,6 +2873,10 @@ void MegaApi::startUpload(const char* localPath, MegaNode* parent, MegaTransferL
     pImpl->startUpload(localPath, parent, listener);
 }
 
+void MegaApi::startUploadForSupport(const char* localPath, MegaTransferListener *listener)
+{
+    pImpl->startUploadForSupport(localPath, listener);
+}
 
 MegaStringList *MegaApi::getBackupFolders(int backuptag) const
 {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17559,7 +17559,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                 const char *inboxTarget = uploadToInbox ? transfer->getParentPath() : nullptr;
 
                 if (!localPath || !fileName || !(*fileName)
-                        || (!inboxTarget && (!parent || parent->type == FILENODE) ) )
+                        || (!uploadToInbox && (!parent || parent->type == FILENODE) ) )
                 {
                     e = API_EARGS;
                     break;
@@ -17662,7 +17662,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                                 tc.nn->ovhandle = client->getovhandle(parent, &sname);
                             }
 
-                            if (inboxTarget)
+                            if (uploadToInbox)
                             {
                                 client->putnodes(inboxTarget, tc.nn, nc);
                             }
@@ -17683,7 +17683,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
 
                     currentTransfer = transfer;                    
                     string wFileName = fileName;
-                    MegaFilePut *f = new MegaFilePut(client, &wLocalPath, &wFileName, transfer->getParentHandle(), inboxTarget ? inboxTarget : "", mtime, isSourceTemporary);
+                    MegaFilePut *f = new MegaFilePut(client, &wLocalPath, &wFileName, transfer->getParentHandle(), uploadToInbox ? inboxTarget : "", mtime, isSourceTemporary);
                     f->setTransfer(transfer);
                     bool started = client->startxfer(PUT, f, committer, true, startFirst, transfer->isBackupTransfer());
                     if (!started)


### PR DESCRIPTION
Have user handle gatthered from pubk response used when putting nodes

**Notes**
- Folder upload is not possible when sending to Inbox:
   API won't return handle for folder creation, and even if that was the case
   doing a put nodes with t = userhandle & the corresponding handle as parent p, API returns EACCESS

**Risk areas**
- Uploads & transfers in general