### PR TITLE
#13781. Putnodes tctable transaction, megacli logging improvements, factoring.

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -167,14 +167,20 @@ if (WIN32)
     add_definitions( -DNOMINMAX )
 
     IF (NOT USE_PREBUILT_3RDPARTY)
-        #Link against the static C/C++ libraries on windows
+        #Link against the static C/C++ libraries on windows. Though, if linking with prebuilt QT we need dynamic CRT
         foreach(flag_var
                 CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE 
                 CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
                 CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-           if(${flag_var} MATCHES "/MD")
-              string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-           endif(${flag_var} MATCHES "/MD")
+            if (MEGA_LINK_DYNAMIC_CRT)
+                if(${flag_var} MATCHES "/MT")
+                    string(REGEX REPLACE "/MT" "/MD" ${flag_var} "${${flag_var}}")
+                endif()
+            else ()
+                if(${flag_var} MATCHES "/MD")
+                    string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+                endif()
+            endif ()
         endforeach(flag_var)
     ENDIF()
 

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2372,7 +2372,7 @@ void exec_sendDeferred(autocomplete::ACState& s)
 void exec_codeTimings(autocomplete::ACState& s)
 {
     bool reset = s.extractflag("-reset");
-    cout << client->performanceStats.report(reset, client->httpio, client->waiter) << flush;
+    cout << client->performanceStats.report(reset, client->httpio, client->waiter, client->reqs) << flush;
 }
 
 #endif
@@ -2553,6 +2553,45 @@ void exec_setmaxconnections(autocomplete::ACState& s)
     cout << "connections: " << (int)client->connections[direction] << endl;
 }
 
+
+class MegaCLILogger : public ::mega::Logger {
+public:
+    ofstream mLogFile;
+
+    void log(const char*, int loglevel, const char*, const char *message) override
+    {
+        if (mLogFile.is_open())
+        {
+            mLogFile << Waiter::ds << " " << SimpleLogger::toStr(static_cast<LogLevel>(loglevel)) << ": " << message << std::endl;
+        }
+        else
+        {
+#ifdef _WIN32
+            string s;
+            s.reserve(1024);
+            s += message;
+            s += "\r\n";
+            OutputDebugStringA(s.c_str());
+#else
+            if (loglevel >= SimpleLogger::logCurrentLevel)
+            {
+                auto t = std::time(NULL);
+                char ts[50];
+                if (!std::strftime(ts, sizeof(ts), "%H:%M:%S", std::localtime(&t)))
+                {
+                    ts[0] = '\0';
+                }
+                std::cout << "[" << ts << "] " << SimpleLogger::toStr(static_cast<LogLevel>(loglevel)) << ": " << message << std::endl;
+        }
+#endif
+        }
+    }
+};
+
+MegaCLILogger gLogger;
+
+
+
 autocomplete::ACN autocompleteSyntax()
 {
     using namespace autocomplete;
@@ -2637,7 +2676,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_locallogout, sequence(text("locallogout")));
     p->Add(exec_symlink, sequence(text("symlink")));
     p->Add(exec_version, sequence(text("version")));
-    p->Add(exec_debug, sequence(text("debug"), opt(either(flag("-on"), flag("-off")))));
+    p->Add(exec_debug, sequence(text("debug"), opt(either(flag("-on"), flag("-off"))), opt(localFSFile())));
     p->Add(exec_verbose, sequence(text("verbose"), opt(either(flag("-on"), flag("-off")))));
 #if defined(WIN32) && defined(NO_READLINE)
     p->Add(exec_clear, sequence(text("clear")));
@@ -4442,6 +4481,19 @@ void exec_debug(autocomplete::ACState& s)
 {
     bool turnon = s.extractflag("-on");
     bool turnoff = s.extractflag("-off");
+
+    if (s.words.size() > 1)
+    {
+        gLogger.mLogFile.close();
+        if (!s.words[1].s.empty())
+        {
+            gLogger.mLogFile.open(s.words[1].s.c_str());
+            if (!gLogger.mLogFile.is_open())
+            {
+                cout << "Log file open failed: '" << s.words[1].s << "'" << endl;
+            }
+        }
+    }
 
     bool state = client->debugstate();
     if ((turnon && !state) || (turnoff && state) || (!turnon && !turnoff))
@@ -7344,41 +7396,13 @@ void megacli()
     }
 }
 
-
-class MegaCLILogger : public ::mega::Logger {
-public:
-    void log(const char*, int loglevel, const char*, const char *message) override
-    {
-#ifdef _WIN32
-        string s;
-        s.reserve(1024);
-        s += message;
-        s += "\r\n";
-        OutputDebugStringA(s.c_str());
-#else
-        if (loglevel >= SimpleLogger::logCurrentLevel)
-        {
-            auto t = std::time(NULL);
-            char ts[50];
-            if (!std::strftime(ts, sizeof(ts), "%H:%M:%S", std::localtime(&t)))
-            {
-                ts[0] = '\0';
-            }
-            std::cout << "[" << ts << "] " << SimpleLogger::toStr(static_cast<LogLevel>(loglevel)) << ": " << message << std::endl;
-        }
-#endif
-    }
-};
-
-MegaCLILogger logger;
-
 int main()
 {
 #ifdef _WIN32
     SimpleLogger::setLogLevel(logMax);  // warning and stronger to console; info and weaker to VS output window
-    SimpleLogger::setOutputClass(&logger);
+    SimpleLogger::setOutputClass(&gLogger);
 #else
-    SimpleLogger::setOutputClass(&logger);
+    SimpleLogger::setOutputClass(&gLogger);
 #endif
 
     console = new CONSOLE_CLASS;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1579,7 +1579,7 @@ public:
         uint64_t prepwaitImmediate = 0, prepwaitZero = 0, prepwaitHttpio = 0, prepwaitFsaccess = 0, nonzeroWait = 0;
         CodeCounter::DurationSum csRequestWaitTime;
         CodeCounter::DurationSum transfersActiveTime;
-        std::string report(bool reset, HttpIO* httpio, Waiter* waiter);
+        std::string report(bool reset, HttpIO* httpio, Waiter* waiter, const RequestDispatcher& reqs);
     } performanceStats;
 
     MegaClient(MegaApp*, Waiter*, HttpIO*, FileSystemAccess*, DbAccess*, GfxProc*, const char*, const char*);

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -102,9 +102,6 @@ struct MEGA_API Transfer : public FileFingerprint
     // remove file from transfer including in cache
     void removeTransferFile(error, File* f, DBTableTransactionCommitter* committer);
 
-    // next position to download/upload
-    m_off_t nextpos();
-
     // previous wrong fingerprint
     FileFingerprint badfp;
 

--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -139,7 +139,7 @@ struct MEGA_API TransferSlot
     TransferSlot(Transfer*);
     ~TransferSlot();
 
-protected:
+private:
     void toggleport(HttpReqXfer* req);
     bool tryRaidRecoveryFromHttpGetError(unsigned i);
     bool checkTransferFinished(DBTableTransactionCommitter& committer, MegaClient* client);

--- a/include/mega/transferslot.h
+++ b/include/mega/transferslot.h
@@ -142,7 +142,7 @@ struct MEGA_API TransferSlot
 protected:
     void toggleport(HttpReqXfer* req);
     bool tryRaidRecoveryFromHttpGetError(unsigned i);
-
+    bool checkTransferFinished(DBTableTransactionCommitter& committer, MegaClient* client);
 };
 } // namespace
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -188,8 +188,9 @@ typedef enum ErrorCodes
     API_EINTERNAL = -1,             ///< Internal error.
     API_EARGS = -2,                 ///< Bad arguments.
     API_EAGAIN = -3,                ///< Request failed, retry with exponential backoff.
-    API_ERATELIMIT = -4,            ///< Too many requests, slow down.
-    API_EFAILED = -5,               ///< Request failed permanently.
+    DAEMON_EFAILED = -4,            ///< If returned from the daemon: EFAILED
+    API_ERATELIMIT = -4,            ///< If returned from the API: Too many requests, slow down.
+    API_EFAILED = -5,               ///< Request failed permanently.  This one is only produced by the API, only per command (not batch level)
     API_ETOOMANY = -6,              ///< Too many requests for this resource.
     API_ERANGE = -7,                ///< Resource access out of range.
     API_EEXPIRED = -8,              ///< Resource expired.

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1147,6 +1147,7 @@ void CommandPutNodes::procresult()
     {
         if (client->tctable)
         {
+            client->mTctableRequestCommitter->beginOnce();
             vector<uint32_t> &ids = it->second;
             for (unsigned int i = 0; i < ids.size(); i++)
             {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2791,7 +2791,7 @@ void MegaClient::exec()
     if (Waiter::ds > lasttime + 1200)
     {
         lasttime = Waiter::ds;
-        LOG_info << performanceStats.report(false, httpio, waiter);
+        LOG_info << performanceStats.report(false, httpio, waiter, reqs);
     }
 #endif
 }
@@ -14264,7 +14264,7 @@ void MegaClient::getwelcomepdf()
 }
 
 #ifdef MEGA_MEASURE_CODE
-std::string MegaClient::PerformanceStats::report(bool reset, HttpIO* httpio, Waiter* waiter)
+std::string MegaClient::PerformanceStats::report(bool reset, HttpIO* httpio, Waiter* waiter, const RequestDispatcher& reqs)
 {
     std::ostringstream s;
     s << prepareWait.report(reset) << "\n"
@@ -14279,6 +14279,7 @@ std::string MegaClient::PerformanceStats::report(bool reset, HttpIO* httpio, Wai
         << scProcessingTime.report(reset) << "\n"
         << csResponseProcessingTime.report(reset) << "\n"
         << " cs Request waiting time: " << csRequestWaitTime.report(reset) << "\n"
+        << " cs requests sent/received: " << reqs.csRequestsSent << "/" << reqs.csRequestsCompleted << " batches: " << reqs.csBatchesSent << "/" << reqs.csBatchesReceived << "\n"
         << " transfers active time: " << transfersActiveTime.report(reset) << "\n"
         << " transfer starts/finishes: " << transferStarts << " " << transferFinishes << "\n"
         << " transfer temperror/fails: " << transferTempErrors << " " << transferFails << "\n"

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -1073,24 +1073,6 @@ void Transfer::completefiles()
     ids.push_back(dbid);
 }
 
-m_off_t Transfer::nextpos()
-{
-    while (chunkmacs.find(ChunkedHash::chunkfloor(pos)) != chunkmacs.end() && pos < size)
-    {    
-        if (chunkmacs[ChunkedHash::chunkfloor(pos)].finished)
-        {
-            pos = ChunkedHash::chunkceil(pos, size);
-        }
-        else
-        {
-            pos += chunkmacs[ChunkedHash::chunkfloor(pos)].offset;
-            break;
-        }
-    }
-
-    return pos;
-}
-
 DirectReadNode::DirectReadNode(MegaClient* cclient, handle ch, bool cp, SymmCipher* csymmcipher, int64_t cctriv, const char *privauth, const char *pubauth, const char *cauth)
 {
     client = cclient;

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -344,6 +344,42 @@ int64_t TransferSlot::macsmac(chunkmac_map* m)
     return m->macsmac(transfer->transfercipher());
 }
 
+bool TransferSlot::checkTransferFinished(DBTableTransactionCommitter& committer, MegaClient* client)
+{
+    if (transfer->progresscompleted == transfer->size)
+    {
+        if (transfer->progresscompleted)
+        {
+            transfer->currentmetamac = macsmac(&transfer->chunkmacs);
+            transfer->hascurrentmetamac = true;
+        }
+
+        // verify meta MAC
+        if (!transfer->progresscompleted
+            || (transfer->currentmetamac == transfer->metamac))
+        {
+            client->transfercacheadd(transfer, &committer);
+            if (transfer->progresscompleted != progressreported)
+            {
+                progressreported = transfer->progresscompleted;
+                lastdata = Waiter::ds;
+
+                progress();
+            }
+
+            transfer->complete(committer);
+        }
+        else
+        {
+            client->sendevent(99431, "MAC verification failed", 0);
+            transfer->chunkmacs.clear();
+            transfer->failed(API_EKEY, committer);
+        }
+        return true;
+    }
+    return false;
+}
+
 // file transfer state machine
 void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committer)
 {
@@ -367,10 +403,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                 }
                 else
                 {
-                    int creqtag = client->reqtag;
-                    client->reqtag = 0;
-                    client->sendevent(99432, "MAC verification failed for cached download");
-                    client->reqtag = creqtag;
+                    client->sendevent(99432, "MAC verification failed for cached download", 0);
 
                     transfer->chunkmacs.clear();
                     return transfer->failed(API_EKEY, committer);
@@ -385,10 +418,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
         }
         else
         {
-            int creqtag = client->reqtag;
-            client->reqtag = 0;
-            client->sendevent(99410, "No upload token available");
-            client->reqtag = creqtag;
+            client->sendevent(99410, "No upload token available", 0);
 
             return transfer->failed(API_EINTERNAL, committer);
         }
@@ -555,10 +585,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                             error e = (error)atoi(reqs[i]->in.c_str());
                             if (e == API_EKEY)
                             {
-                                int creqtag = client->reqtag;
-                                client->reqtag = 0;
-                                client->sendevent(99429, "Integrity check failed in upload");
-                                client->reqtag = creqtag;
+                                client->sendevent(99429, "Integrity check failed in upload", 0);
 
                                 lasterror = e;
                                 errorcount++;
@@ -566,24 +593,22 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                                 break;
                             }
 
-                            if (e == API_ERATELIMIT || (reqs[i]->contenttype.find("text/html") != string::npos
+                            if (e == DAEMON_EFAILED || (reqs[i]->contenttype.find("text/html") != string::npos
                                     && !memcmp(reqs[i]->posturl.c_str(), "http:", 5)))
                             {
                                 client->usehttps = true;
                                 client->app->notify_change_to_https();
 
-                                int creqtag = client->reqtag;
-                                client->reqtag = 0;
-                                if (e == API_ERATELIMIT)
+                                if (e == DAEMON_EFAILED)
                                 {
-                                    client->sendevent(99440, "Retry requested by storage server");
+                                    // megad returning -4 should result in restarting the transfer
+                                    client->sendevent(99440, "Retry requested by storage server", 0);
                                 }
                                 else
                                 {
                                     LOG_warn << "Invalid Content-Type detected during upload: " << reqs[i]->contenttype;
                                 }
-                                client->sendevent(99436, "Automatic change to HTTPS");
-                                client->reqtag = creqtag;
+                                client->sendevent(99436, "Automatic change to HTTPS", 0);
 
                                 return transfer->failed(API_EAGAIN, committer);
                             }
@@ -606,10 +631,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
 
                         if (transfer->progresscompleted == transfer->size)
                         {
-                            int creqtag = client->reqtag;
-                            client->reqtag = 0;
-                            client->sendevent(99409, "No upload token received");
-                            client->reqtag = creqtag;
+                            client->sendevent(99409, "No upload token received", 0);
 
                             return transfer->failed(API_EINTERNAL, committer);
                         }
@@ -673,40 +695,11 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                                         break;
                                     }
 
-                                    if (transfer->progresscompleted == transfer->size)
+                                    if (checkTransferFinished(committer, client))
                                     {
-                                        if (transfer->progresscompleted)
-                                        {
-                                            transfer->currentmetamac = macsmac(&transfer->chunkmacs);
-                                            transfer->hascurrentmetamac = true;
-                                        }
-
-                                        // verify meta MAC
-                                        if (!transfer->progresscompleted
-                                            || (transfer->currentmetamac == transfer->metamac))
-                                        {
-                                            client->transfercacheadd(transfer, &committer);
-                                            if (transfer->progresscompleted != progressreported)
-                                            {
-                                                progressreported = transfer->progresscompleted;
-                                                lastdata = Waiter::ds;
-
-                                                progress();
-                                            }
-
-                                            return transfer->complete(committer);
-                                        }
-                                        else
-                                        {
-                                            int creqtag = client->reqtag;
-                                            client->reqtag = 0;
-                                            client->sendevent(99431, "MAC verification failed");
-                                            client->reqtag = creqtag;
-
-                                            transfer->chunkmacs.clear();
-                                            return transfer->failed(API_EKEY, committer);
-                                        }
+                                        return;
                                     }
+
                                     client->transfercacheadd(transfer, &committer);
                                     reqs[i]->status = REQ_READY;
                                 }
@@ -729,18 +722,12 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                                 client->usehttps = true;
                                 client->app->notify_change_to_https();
 
-                                int creqtag = client->reqtag;
-                                client->reqtag = 0;
-                                client->sendevent(99436, "Automatic change to HTTPS");
-                                client->reqtag = creqtag;
+                                client->sendevent(99436, "Automatic change to HTTPS", 0);
 
                                 return transfer->failed(API_EAGAIN, committer);
                             }
 
-                            int creqtag = client->reqtag;
-                            client->reqtag = 0;
-                            client->sendevent(99430, "Invalid chunk size");
-                            client->reqtag = creqtag;
+                            client->sendevent(99430, "Invalid chunk size", 0);
 
                             LOG_warn << "Invalid chunk size: " << reqs[i]->size << " - " << reqs[i]->bufpos;
                             lasterror = API_EREAD;
@@ -787,39 +774,9 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
 
                                 updatecontiguousprogress();
 
-                                if (transfer->progresscompleted == transfer->size)
+                                if (checkTransferFinished(committer, client))
                                 {
-                                    if (transfer->progresscompleted)
-                                    {
-                                        transfer->currentmetamac = macsmac(&transfer->chunkmacs);
-                                        transfer->hascurrentmetamac = true;
-                                    }
-
-                                    // verify meta MAC
-                                    if (!transfer->progresscompleted
-                                            || (transfer->currentmetamac == transfer->metamac))
-                                    {
-                                        client->transfercacheadd(transfer, &committer);
-                                        if (transfer->progresscompleted != progressreported)
-                                        {
-                                            progressreported = transfer->progresscompleted;
-                                            lastdata = Waiter::ds;
-
-                                            progress();
-                                        }
-
-                                        return transfer->complete(committer);
-                                    }
-                                    else
-                                    {
-                                        int creqtag = client->reqtag;
-                                        client->reqtag = 0;
-                                        client->sendevent(99431, "MAC verification failed");
-                                        client->reqtag = creqtag;
-
-                                        transfer->chunkmacs.clear();
-                                        return transfer->failed(API_EKEY, committer);
-                                    }
+                                    return;
                                 }
 
                                 client->transfercacheadd(transfer, &committer);
@@ -877,10 +834,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                         client->usehttps = true;
                         client->app->notify_change_to_https();
 
-                        int creqtag = client->reqtag;
-                        client->reqtag = 0;
-                        client->sendevent(99436, "Automatic change to HTTPS");
-                        client->reqtag = creqtag;
+                        client->sendevent(99436, "Automatic change to HTTPS", 0);
 
                         return transfer->failed(API_EAGAIN, committer);
                     }
@@ -889,10 +843,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                     {
                         if (reqs[i]->timeleft < 0)
                         {
-                            int creqtag = client->reqtag;
-                            client->reqtag = 0;
-                            client->sendevent(99408, "Overquota without timeleft");
-                            client->reqtag = creqtag;
+                            client->sendevent(99408, "Overquota without timeleft", 0);
                         }
 
                         LOG_warn << "Bandwidth overquota from storage server";
@@ -1055,10 +1006,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                         unsigned size = (unsigned)(posrange.second - posrange.first);
                         if (size > 16777216)
                         {
-                            int creqtag = client->reqtag;
-                            client->reqtag = 0;
-                            client->sendevent(99434, "Invalid request size");
-                            client->reqtag = creqtag;
+                            client->sendevent(99434, "Invalid request size", 0);
 
                             transfer->chunkmacs.clear();
                             return transfer->failed(API_EINTERNAL, committer);


### PR DESCRIPTION
CMake updates for linking with dynamic CRT on windows
megacli support for specifying a file to log to with the `debug` commands.cpp
Additional report logging for cs requests when MEGA_MEASURE_CODE is on
Remove unused function nextpos()
Added error code DAEMON_EFAILED = -4, use of which makes the code much clearer
Make sure we begin a tctable transaction for PutNodes procresult
Factor some code into checkTransferFinished(), (preparing for changes in that area)
Use the more compact form of sendevent() in transferslot.cpp (preparing for changes in that area)