### PR TITLE
#13783. Avoid unnecessary fopen/fingerprinting, fix MegaApi_impl shutdown thr…

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -5881,7 +5881,7 @@ void exec_locallogout(autocomplete::ACState& s)
     cout << "Logging off locally..." << endl;
 
     cwd = UNDEF;
-    client->locallogout();
+    client->locallogout(false);
 }
 
 void exec_recentnodes(autocomplete::ACState& s)
@@ -5973,7 +5973,7 @@ void DemoApp::request_error(error e)
     if ((e == API_ESID) || (e == API_ENOENT))   // Invalid session or Invalid folder handle
     {
         cout << "Invalid or expired session, logging out..." << endl;
-        client->locallogout();
+        client->locallogout(false);
         return;
     }
     else if (e == API_EBLOCKED)
@@ -6397,7 +6397,7 @@ void DemoApp::whyamiblocked_result(int code)
         if (code != 500)
         {
             cout << "Logging out..." << endl;
-            client->locallogout();
+            client->locallogout(false);
         }
     }
 }

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -526,10 +526,7 @@ public:
     void logout();
 
     // free all state information
-    void locallogout();
-
-    // remove caches
-    void removecaches();
+    void locallogout(bool removecaches);
 
     // SDK version
     const char* version();
@@ -882,6 +879,9 @@ private:
     void sc_ub();
 
     void init();
+
+    // remove caches
+    void removeCaches();
 
     // add node to vector and return index
     unsigned addnode(node_vector*, Node*) const;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -5146,6 +5146,7 @@ MegaApiImpl::~MegaApiImpl()
         delete it->second;
     }
 
+    delete client;    //  only delete client now that transfers that might refer to it are finally removed.
     delete gfxAccess;
     delete fsAccess;
     delete waiter;
@@ -6215,18 +6216,19 @@ void MegaApiImpl::loop()
             }
             sendPendingRequests();
             sendPendingScRequest();
-            if(threadExit)
-                break;
+            if (threadExit)
+            {
+                // The ~MegaApiImpl() destructor is responsible for deleting the client after join()ing the thread
+                // But first call locallogout() which may call back to the app (on this thread as usual) to close some requestMap items etc
+                client->locallogout(false);
+                return;
+            }
 
             sdkMutex.lock();
             client->exec();
             sdkMutex.unlock();
         }
     }
-
-    sdkMutex.lock();
-    delete client;
-    sdkMutex.unlock();
 }
 
 
@@ -13791,8 +13793,7 @@ void MegaApiImpl::request_error(error e)
 
     if (e == API_ESID)
     {
-        client->removecaches();
-        client->locallogout();
+        client->locallogout(true);
     }
     requestQueue.push(request);
     waiter->notify();
@@ -14915,8 +14916,7 @@ void MegaApiImpl::whyamiblocked_result(int code)
             && code != 500  // don't log out if we can be unblocked via sms verification
             && code != 700) // don't log out if we can be unblocked via verification email (weak account protection)
     {
-        client->removecaches();
-        client->locallogout();
+        client->locallogout(true);
 
         MegaRequestPrivate *logoutRequest = new MegaRequestPrivate(MegaRequest::TYPE_LOGOUT);
         logoutRequest->setFlag(false);
@@ -17683,6 +17683,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                     currentTransfer = transfer;                    
                     string wFileName = fileName;
                     MegaFilePut *f = new MegaFilePut(client, &wLocalPath, &wFileName, transfer->getParentHandle(), "", mtime, isSourceTemporary);
+                    *static_cast<FileFingerprint*>(f) = fp;  // deliberate slicing - startxfer would re-fingerprint if we don't supply this info
                     f->setTransfer(transfer);
                     bool started = client->startxfer(PUT, f, committer, true, startFirst, transfer->isBackupTransfer());
                     if (!started)
@@ -18246,7 +18247,7 @@ void MegaApiImpl::sendPendingRequests()
 
             requestMap[request->getTag()]=request;
 
-            client->locallogout();
+            client->locallogout(false);
             if (sessionKey)
             {
                 byte session[MAX_SESSION_LENGTH];
@@ -18954,7 +18955,7 @@ void MegaApiImpl::sendPendingRequests()
             }
             else
             {
-                client->locallogout();
+                client->locallogout(false);
                 client->restag = nextTag;
                 logout_result(API_OK);
             }
@@ -19673,7 +19674,7 @@ void MegaApiImpl::sendPendingRequests()
 
                 requestMap[reqtag] = request;
 
-                client->locallogout();
+                client->locallogout(false);
 
                 if (resumeProcess)
                 {
@@ -23332,7 +23333,8 @@ void MegaFolderUploadController::onFolderAvailable(MegaHandle handle)
     {
         size_t t = localPath.size();
 
-        while (da->dnext(&localPath, &localname, client->followsymlinks))
+        nodetype_t dirEntryType;
+        while (da->dnext(&localPath, &localname, client->followsymlinks, &dirEntryType))
         {
             if (t)
             {
@@ -23341,35 +23343,30 @@ void MegaFolderUploadController::onFolderAvailable(MegaHandle handle)
 
             localPath.append(localname);
 
-            auto fa = client->fsaccess->newfileaccess();
-            if (fa->fopen(&localPath, true, false))
+            string name = localname;
+            client->fsaccess->local2name(&name);
+            if (dirEntryType == FILENODE)
             {
-                string name = localname;
-                client->fsaccess->local2name(&name);
-                if (fa->type == FILENODE)
-                {
-                    pendingTransfers++;
-                    string utf8path;
-                    client->fsaccess->local2path(&localPath, &utf8path);
+                pendingTransfers++;
+                string utf8path;
+                client->fsaccess->local2path(&localPath, &utf8path);
                     megaApi->startUpload(false, utf8path.c_str(), parent, (const char *)NULL, -1, tag, false, NULL, false, false, this);
+            }
+            else if (dirEntryType == FOLDERNODE)
+            {
+                MegaNode *child = megaApi->getChildNode(parent, name.c_str());
+                if(!child || !child->isFolder())
+                {
+                    pendingFolders.push_back(localPath);
+                    megaApi->createFolder(name.c_str(), parent, this);
                 }
                 else
                 {
-                    MegaNode *child = megaApi->getChildNode(parent, name.c_str());
-                    if(!child || !child->isFolder())
-                    {
-                        pendingFolders.push_back(localPath);
-                        megaApi->createFolder(name.c_str(), parent, this);
-                    }
-                    else
-                    {
-                        pendingFolders.push_front(localPath);
-                        onFolderAvailable(child->getHandle());
-                    }
-                    delete child;
+                    pendingFolders.push_front(localPath);
+                    onFolderAvailable(child->getHandle());
                 }
+                delete child;
             }
-
             localPath.resize(t);
         }
     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1227,7 +1227,7 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
 
 MegaClient::~MegaClient()
 {
-    locallogout();
+    locallogout(false);
 
     delete pendingcs;
     delete pendingsc;
@@ -1743,8 +1743,7 @@ void MegaClient::exec()
 
                                 if (loggedout)
                                 {
-                                    removecaches();
-                                    locallogout();
+                                    locallogout(true);
                                     app->logout_result(API_OK);
                                 }
                             }
@@ -3670,8 +3669,7 @@ void MegaClient::logout()
 {
     if (loggedin() != FULLACCOUNT)
     {
-        removecaches();
-        locallogout();
+        locallogout(true);
 
         restag = reqtag;
         app->logout_result(API_OK);
@@ -3682,8 +3680,13 @@ void MegaClient::logout()
     reqs.add(new CommandLogout(this));
 }
 
-void MegaClient::locallogout()
+void MegaClient::locallogout(bool removecaches)
 {
+    if (removecaches)
+    {
+        removeCaches();
+    }
+
     delete sctable;
     sctable = NULL;
     pendingsccommit = false;
@@ -3813,7 +3816,7 @@ void MegaClient::locallogout()
     fetchingkeys = false;
 }
 
-void MegaClient::removecaches()
+void MegaClient::removeCaches()
 {
     if (sctable)
     {


### PR DESCRIPTION
…eading issue

fixed threading issue: Previously the MegaClient was destroyed on the Impl thread, but then the Impl destructor might need it when deleting any remaining request objects.
Fixed unnecessary fingerprint: MegaFilePut needs one and megasync will do it if it's not done already.  And the code there already has fingerprinted the file once, we can just use it.
Fixed unnecessary fopen(): onFolderAvailable iterates the folder for uploads, but opened each entry to find out if it was a file or folder.  The entry can supply that info though.
refactor: Made removeCaches private, and called from locallogout as that one was only used before locallogout, and an upcoming change will add code that must be done before that, and for all locallogout()s.