### PR TITLE
 #13795. Don't timeout a whole transfer if some large chunks are making progress

### DIFF
--- a/include/mega/raid.h
+++ b/include/mega/raid.h
@@ -23,6 +23,7 @@
 #define MEGA_RAID_H 1
 
 #include "http.h"
+#include "utils.h"
 
 namespace mega {
 
@@ -197,9 +198,6 @@ namespace mega {
 
         Transfer* transfer;
 
-        // get the next pos to start transferring from/to on this connection, for non-raid
-        m_off_t nextTransferPos();
-
         // decrypt and mac downloaded chunk
         void finalize(FilePiece& r) override;
         m_off_t calcOutputChunkPos(m_off_t acquiredpos) override;
@@ -220,9 +218,6 @@ namespace mega {
     private:
 
         DirectRead* directRead;
-
-        // get the next pos to start transferring from/to on this connection, for non-raid
-        m_off_t nextTransferPos();
 
         // decrypt and mac downloaded chunk
         void finalize(FilePiece& r) override;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -169,15 +169,7 @@ struct ChunkMAC
     bool finished;
 };
 
-// file chunk macs
-class chunkmac_map : public map<m_off_t, ChunkMAC>
-{
-public:
-    int64_t macsmac(SymmCipher *cipher);
-    void serialize(string& d) const;
-    bool unserialize(const char*& ptr, const char* end);
-    void calcprogress(m_off_t size, m_off_t& chunkpos, m_off_t& completedprogress, m_off_t* lastblockprogress = nullptr);
-};
+class chunkmac_map;
 
 /**
  * @brief Declaration of API error codes.

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -418,6 +418,19 @@ void tolower_string(std::string& str);
 int macOSmajorVersion();
 #endif
 
+// file chunk macs
+class chunkmac_map : public map<m_off_t, ChunkMAC>
+{
+public:
+    int64_t macsmac(SymmCipher *cipher);
+    void serialize(string& d) const;
+    bool unserialize(const char*& ptr, const char* end);
+    void calcprogress(m_off_t size, m_off_t& chunkpos, m_off_t& completedprogress, m_off_t* lastblockprogress = nullptr);
+    m_off_t nextUnprocessedPosFrom(m_off_t pos);
+    m_off_t expandUnprocessedPiece(m_off_t pos, m_off_t npos, m_off_t fileSize, m_off_t maxReqSize);
+    void finishedUploadChunks(m_off_t pos, m_off_t size);
+};
+
 struct CacheableWriter
 {
     CacheableWriter(string& d);

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -459,6 +459,13 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                             reqs[i]->status = REQ_READY;
                         }
                     }
+
+                    if (reqs[i]->lastdata > lastdata)
+                    {
+                        // prevent overall timeout if all channels are busy with big chunks for a while
+                        lastdata = reqs[i]->lastdata;
+                    }
+
                     break;
 
                 case REQ_SUCCESS:
@@ -515,14 +522,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                                     errorcount = 0;
                                     transfer->failcount = 0;
 
-                                    m_off_t startpos = reqs[i]->pos;
-                                    m_off_t finalpos = startpos + reqs[i]->size;
-                                    while (startpos < finalpos)
-                                    {
-                                        transfer->chunkmacs[startpos].finished = true;
-                                        LOG_verbose << "Upload chunk completed: " << startpos;
-                                        startpos = ChunkedHash::chunkceil(startpos, finalpos);
-                                    }
+                                    transfer->chunkmacs.finishedUploadChunks(reqs[i]->pos, reqs[i]->size);
 
                                     updatecontiguousprogress();
 
@@ -592,14 +592,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                             return transfer->failed(e, committer);
                         }
 
-                        m_off_t startpos = reqs[i]->pos;
-                        m_off_t finalpos = startpos + reqs[i]->size;
-                        while (startpos < finalpos)
-                        {
-                            transfer->chunkmacs[startpos].finished = true;
-                            LOG_verbose << "Upload chunk completed: " << startpos;
-                            startpos = ChunkedHash::chunkceil(startpos, finalpos);
-                        }
+                        transfer->chunkmacs.finishedUploadChunks(reqs[i]->pos, reqs[i]->size);
                         transfer->progresscompleted += reqs[i]->size;
 
                         updatecontiguousprogress();
@@ -1132,7 +1125,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
 
     if (Waiter::ds - lastdata >= XFERTIMEOUT && !failure)
     {
-        LOG_warn << "Failed chunk due to a timeout";
+        LOG_warn << "Failed chunk(s) due to a timeout: no data moved for " << (XFERTIMEOUT/10) << " seconds" ;
         failure = true;
         bool changeport = false;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -268,6 +268,48 @@ void chunkmac_map::calcprogress(m_off_t size, m_off_t& chunkpos, m_off_t& progre
     }
 }
 
+m_off_t chunkmac_map::nextUnprocessedPosFrom(m_off_t pos)
+{
+    for (const_iterator it = find(ChunkedHash::chunkfloor(pos));
+        it != end();
+        it = find(ChunkedHash::chunkfloor(pos)))
+    {
+        if (it->second.finished)
+        {
+            pos = ChunkedHash::chunkceil(pos);
+        }
+        else
+        {
+            pos += it->second.offset;
+            break;
+        }
+    }
+    return pos;
+}
+
+m_off_t chunkmac_map::expandUnprocessedPiece(m_off_t pos, m_off_t npos, m_off_t fileSize, m_off_t maxReqSize)
+{
+    for (iterator it = find(npos);
+        npos < fileSize && (npos - pos) <= maxReqSize && (it == end() || (!it->second.finished && !it->second.offset));
+        it = find(npos))
+    {
+        npos = ChunkedHash::chunkceil(npos, fileSize);
+    }
+    return npos;
+}
+
+void chunkmac_map::finishedUploadChunks(m_off_t pos, m_off_t size)
+{
+    m_off_t startpos = pos;
+    m_off_t finalpos = startpos + size;
+    while (startpos < finalpos)
+    {
+        (*this)[startpos].finished = true;
+        LOG_verbose << "Upload chunk completed: " << startpos;
+        startpos = ChunkedHash::chunkceil(startpos, finalpos);
+    }
+}
+
 bool CacheableReader::unserializechunkmacs(chunkmac_map& m)
 {
     if (m.unserialize(ptr, end))   // ptr is adjusted by reference

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -37,6 +37,8 @@ using namespace std;
 
 MegaFileSystemAccess fileSystemAccess;
 
+string USER_AGENT = "Integration Tests with GoogleTest framework";
+
 #ifdef _WIN32
 #if (__cplusplus >= 201700L)
 namespace fs = std::filesystem;

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -35,7 +35,6 @@ using namespace mega;
 using ::testing::Test;
 
 static const string APP_KEY     = "8QxzVRxD";
-static const string USER_AGENT  = "Integration Tests with GoogleTest framework";
 
 // IMPORTANT: the main account must be empty (Cloud & Rubbish) before starting the test and it will be purged at exit.
 // Both main and auxiliar accounts shouldn't be contacts yet and shouldn't have any pending contact requests.

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -82,16 +82,24 @@ int main (int argc, char *argv[])
         return 1;
     }
 
-    vector<char*> myargv(argv, argv + argc);
+    vector<char*> myargv1(argv, argv + argc);
+    vector<char*> myargv2;
 
-    for (auto it = myargv.begin(); it != myargv.end(); ++it)
+    for (auto it = myargv1.begin(); it != myargv1.end(); ++it)
     {
         if (string(*it) == "--CI")
         {
             gRunningInCI = true;
-            myargv.erase(it);
             argc -= 1;
-            break;
+        }
+        else if (string(*it).substr(0, 12) == "--USERAGENT:")
+        {
+            USER_AGENT = string(*it).substr(12);
+            argc -= 1;
+        }
+        else
+        {
+            myargv2.push_back(*it);
         }
     }
 
@@ -105,6 +113,6 @@ int main (int argc, char *argv[])
     wc->setShellConsole();
 #endif
 
-    ::testing::InitGoogleTest(&argc, myargv.data());
+    ::testing::InitGoogleTest(&argc, myargv2.data());
     return RUN_ALL_TESTS();
 }

--- a/tests/integration/test.h
+++ b/tests/integration/test.h
@@ -1,3 +1,4 @@
-
+#include <string>
+extern std::string USER_AGENT;
 extern bool gRunningInCI;
 extern bool gTestingInvalidArgs;


### PR DESCRIPTION
There are separate timeouts per chunk (cURL checks for insufficient data rate per connection).
Only time out the whole transfer if no chunks are moving
Also factored some chunkmac_map loops into member functions of chunkmac_map
Also moved chunkmac_map declaration to Utils.h since its members are defined in Utils.cpp
Also allowed useragent to be specified by command line for integration tests