### PR TITLE
Ensure that access to MegaLoggers is thread-safe in log performance mode

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -8543,7 +8543,7 @@ class MegaApi
          * @brief Enable log to console
          *
          * By default, log to console is false. Logging to console is serialized via a mutex to
-         * avoid interleaving by multiple threads, even in performance mode.
+         * avoid interleaving by multiple threads.
          *
          * @param enable True to show messages in console, false to skip them.
          */
@@ -8558,9 +8558,6 @@ class MegaApi
          *
          * You can remove the existing logger by using MegaApi::removeLoggerObject.
          *
-         * In performance mode, it is assumed that this is only called on startup and
-         * not while actively logging.
-         *
          * @param megaLogger MegaLogger implementation
          */
         static void addLoggerObject(MegaLogger *megaLogger);
@@ -8570,9 +8567,6 @@ class MegaApi
          *
          * If the logger was registered in the past, it will stop receiving log
          * messages after the call to this function.
-         *
-         * In performance mode, it is assumed that this is only called on shutdown and
-         * not while actively logging.
          *
          * @param megaLogger Previously registered MegaLogger implementation
          */
@@ -8586,9 +8580,6 @@ class MegaApi
          *
          * The third and the fouth parameter are optional. You may want to use __FILE__ and __LINE__
          * to complete them.
-         *
-         * In performance mode, only logging to console is serialized through a mutex.
-         * Logging to `MegaLogger`s is not serialized and has to be done by the subclasses if needed.
          *
          * @param logLevel Log level for this message
          * @param message Message for the logging system

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22153,41 +22153,29 @@ ExternalLogger::ExternalLogger()
 
 ExternalLogger::~ExternalLogger()
 {
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.lock();
-#endif
     SimpleLogger::setOutputClass(NULL);
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.unlock();
-#endif
 }
 
 void ExternalLogger::addMegaLogger(MegaLogger *logger)
 {
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.lock();
-#endif
     if (logger && megaLoggers.find(logger) == megaLoggers.end())
     {
         megaLoggers.insert(logger);
     }
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.unlock();
-#endif
 }
 
 void ExternalLogger::removeMegaLogger(MegaLogger *logger)
 {
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.lock();
-#endif
     if (logger)
     {
         megaLoggers.erase(logger);
     }
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.unlock();
-#endif
 }
 
 void ExternalLogger::setLogLevel(int logLevel)
@@ -22217,13 +22205,9 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
         filename = "";
     }
 
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.lock();
-#endif
     SimpleLogger{static_cast<LogLevel>(logLevel), filename, line} << message;
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.unlock();
-#endif
 }
 
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message)
@@ -22243,9 +22227,7 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
         message = "";
     }
 
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.lock();
-#endif
     for (auto logger : megaLoggers)
     {
         logger->log(time, loglevel, source, message);
@@ -22253,17 +22235,9 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
 
     if (logToConsole)
     {
-#ifdef ENABLE_LOG_PERFORMANCE
-        mutex.lock();
-#endif
         std::cout << "[" << time << "][" << SimpleLogger::toStr((LogLevel)loglevel) << "] " << message << std::endl;
-#ifdef ENABLE_LOG_PERFORMANCE
-        mutex.unlock();
-#endif
     }
-#ifndef ENABLE_LOG_PERFORMANCE
     mutex.unlock();
-#endif
 }
 
 


### PR DESCRIPTION
This comes at the cost of logging a mutex every time we issue a log but is necessary if we want to add/remove MegaLoggers while actively logging. 