### PR TITLE
#13796. Adjust name for singup links

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -7834,7 +7834,7 @@ class MegaApi
          * The associated request type with this request is MegaRequest::TYPE_SEND_SIGNUP_LINK.
          *
          * @param email Email for the account
-         * @param name Fullname of the user (firstname + fullname)
+         * @param name Fullname of the user (firstname + lastname)
          * @param password Password for the account
          * @param listener MegaRequestListener to track this request
          */
@@ -7847,7 +7847,7 @@ class MegaApi
          * email address, in case the user mistyped the email at the registration form.
          *
          * @param email Email for the account
-         * @param name Fullname of the user (firstname + fullname)
+         * @param name Fullname of the user (firstname + lastname)
          * @param base64pwkey Private key returned by MegaRequest::getPrivateKey in the onRequestFinish callback of createAccount
          * @param listener MegaRequestListener to track this request
          *

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -7834,7 +7834,7 @@ class MegaApi
          * The associated request type with this request is MegaRequest::TYPE_SEND_SIGNUP_LINK.
          *
          * @param email Email for the account
-         * @param name Firstname of the user
+         * @param name Fullname of the user (firstname + fullname)
          * @param password Password for the account
          * @param listener MegaRequestListener to track this request
          */
@@ -7847,7 +7847,7 @@ class MegaApi
          * email address, in case the user mistyped the email at the registration form.
          *
          * @param email Email for the account
-         * @param name Firstname of the user
+         * @param name Fullname of the user (firstname + fullname)
          * @param base64pwkey Private key returned by MegaRequest::getPrivateKey in the onRequestFinish callback of createAccount
          * @param listener MegaRequestListener to track this request
          *

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -13054,11 +13054,13 @@ void MegaApiImpl::fetchnodes_result(error e)
             // set names silently...
             int creqtag = client->reqtag;
             client->reqtag = 0;
-            if (request->getName())
+            string firstname = request->getName() ? request->getName() : "";
+            if (!firstname.empty())
             {
                 client->putua(ATTR_FIRSTNAME, (const byte*) request->getName(), int(strlen(request->getName())));
             }
-            if (request->getText())
+            string lastname = request->getText() ? request->getText() : "";
+            if (!lastname.empty())
             {
                 client->putua(ATTR_LASTNAME, (const byte*) request->getText(), int(strlen(request->getText())));
             }
@@ -13070,7 +13072,8 @@ void MegaApiImpl::fetchnodes_result(error e)
             {
                 if (client->nsr_enabled)
                 {
-                    string derivedKey = client->sendsignuplink2(request->getEmail(), request->getPassword(), request->getName());
+                    string fullname = firstname + lastname;
+                    string derivedKey = client->sendsignuplink2(request->getEmail(), request->getPassword(), fullname.c_str());
                     string b64derivedKey;
                     Base64::btoa(derivedKey, b64derivedKey);
                     request->setPrivateKey(b64derivedKey.c_str());


### PR DESCRIPTION
Webclient uses the fullname here, so native apps should behave the same way.