### PR TITLE
Adapt tests to work on debug mode in Jenkins

### DIFF
--- a/include/mega/testhooks.h
+++ b/include/mega/testhooks.h
@@ -33,7 +33,7 @@ namespace mega {
     // The preprocessor is used to ensure that code is not present for release builds, so it can't cause problems.
     // Additionally the hooks use std::function so a suitable compiler and library are needed to leverage those tests.
 
-#if defined(_DEBUG) 
+#ifdef DEBUG
 
     #define MEGASDK_DEBUG_TEST_HOOKS_ENABLED
 

--- a/src/include.am
+++ b/src/include.am
@@ -42,6 +42,7 @@ src_libmega_la_SOURCES += src/mediafileattribute.cpp
 src_libmega_la_SOURCES += src/node.cpp
 src_libmega_la_SOURCES += src/pubkeyaction.cpp
 src_libmega_la_SOURCES += src/raid.cpp
+src_libmega_la_SOURCES += src/testhooks.cpp
 src_libmega_la_SOURCES += src/request.cpp
 src_libmega_la_SOURCES += src/serialize64.cpp
 src_libmega_la_SOURCES += src/share.cpp

--- a/src/testhooks.cpp
+++ b/src/testhooks.cpp
@@ -33,4 +33,4 @@ namespace mega
     {
     }
 #endif
-}; 
+}


### PR DESCRIPTION
Changes to make tests work in Jenkins: _DEBUG to DEBUG so it works under
Linux environment and testhooks added to include.am