### PR TITLE
#13826. Fix serialization + skip new member

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2582,7 +2582,7 @@ public:
                     ts[0] = '\0';
                 }
                 std::cout << "[" << ts << "] " << SimpleLogger::toStr(static_cast<LogLevel>(loglevel)) << ": " << message << std::endl;
-        }
+            }
 #endif
         }
     }

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -262,8 +262,10 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     ~Node();
 
 private:
+#ifdef ENABLE_SYNC
     // whether this node can be synced to the local tree
     bool mSyncable = true;
+#endif
 
     // full folder/file key, symmetrically or asymmetrically encrypted
     // node crypto keys (raw or cooked -

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -263,8 +263,8 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
 
 private:
 #ifdef ENABLE_SYNC
-    // whether this node can be synced to the local tree
-    bool mSyncable = true;
+    // whether this node should be skipped from synchronization of the local tree
+    bool mNotSyncable = false;
 #endif
 
     // full folder/file key, symmetrically or asymmetrically encrypted

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -263,8 +263,8 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
 
 private:
 #ifdef ENABLE_SYNC
-    // whether this node should be skipped from synchronization of the local tree
-    bool mNotSyncable = false;
+    // whether this node can be synced to the local tree
+    bool mSyncable = true;
 #endif
 
     // full folder/file key, symmetrically or asymmetrically encrypted

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -372,7 +372,7 @@ Node* Node::unserialize(MegaClient* client, const string* d, node_vector* dp)
 
     n = new Node(client, dp, h, ph, t, s, u, fa, ts);
 #ifdef ENABLE_SYNC
-    n->setSyncable(isNotSyncable != 1);
+    n->setSyncable(!isNotSyncable);
 #endif
 
     if (k)
@@ -534,7 +534,7 @@ bool Node::serialize(string* d)
     d->append((char*)&hasLinkCreationTs, 1);
 
 #ifdef ENABLE_SYNC
-    char isNotSyncable = mNotSyncable ? 1 : 0;
+    char isNotSyncable = mSyncable ? 0 : 1;
 #else
     char isNotSyncable = 0;
 #endif
@@ -1092,12 +1092,12 @@ Node* Node::firstancestor()
 #ifdef ENABLE_SYNC
 void Node::setSyncable(const bool syncable)
 {
-    mNotSyncable = !syncable;
+    mSyncable = syncable;
 }
 
 bool Node::isSyncable() const
 {
-    return !mNotSyncable;
+    return mSyncable;
 }
 #endif
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -252,7 +252,7 @@ Node* Node::unserialize(MegaClient* client, const string* d, node_vector* dp)
     int i;
     char isExported = '\0';
     char hasLinkCreationTs = '\0';
-    char isNodeSyncable = 1;
+    char isNotSyncable = '\0';
 
     if (ptr + sizeof s + 2 * MegaClient::NODEHANDLE + MegaClient::USERHANDLE + 2 * sizeof ts + sizeof ll > end)
     {
@@ -325,7 +325,7 @@ Node* Node::unserialize(MegaClient* client, const string* d, node_vector* dp)
         fa = NULL;
     }
 
-    if (ptr + sizeof isExported + sizeof hasLinkCreationTs + sizeof isNodeSyncable > end)
+    if (ptr + sizeof isExported + sizeof hasLinkCreationTs + sizeof isNotSyncable > end)
     {
         return NULL;
     }
@@ -336,8 +336,8 @@ Node* Node::unserialize(MegaClient* client, const string* d, node_vector* dp)
     hasLinkCreationTs = MemAccess::get<char>(ptr);
     ptr += sizeof(hasLinkCreationTs);
 
-    isNodeSyncable = MemAccess::get<char>(ptr);
-    ptr += sizeof(isNodeSyncable);
+    isNotSyncable = MemAccess::get<char>(ptr);
+    ptr += sizeof(isNotSyncable);
 
     for (i = 5; i--;)
     {
@@ -372,7 +372,7 @@ Node* Node::unserialize(MegaClient* client, const string* d, node_vector* dp)
 
     n = new Node(client, dp, h, ph, t, s, u, fa, ts);
 #ifdef ENABLE_SYNC
-    n->setSyncable(isNodeSyncable);
+    n->setSyncable(isNotSyncable != 1);
 #endif
 
     if (k)
@@ -534,11 +534,11 @@ bool Node::serialize(string* d)
     d->append((char*)&hasLinkCreationTs, 1);
 
 #ifdef ENABLE_SYNC
-    char isNodeSyncable = mSyncable ? 1 : 0;
+    char isNotSyncable = mNotSyncable ? 1 : 0;
 #else
-    char isNodeSyncable = 0;
+    char isNotSyncable = 0;
 #endif
-    d->append((char*)&isNodeSyncable, 1);
+    d->append((char*)&isNotSyncable, 1);
 
     d->append("\0\0\0\0", 5); // Use these bytes for extensions
 
@@ -1092,12 +1092,12 @@ Node* Node::firstancestor()
 #ifdef ENABLE_SYNC
 void Node::setSyncable(const bool syncable)
 {
-    mSyncable = syncable;
+    mNotSyncable = !syncable;
 }
 
 bool Node::isSyncable() const
 {
-    return mSyncable;
+    return !mNotSyncable;
 }
 #endif
 


### PR DESCRIPTION
- Do not use more than one extension byte for the new flag
- Add the new member to Node only for sync-enabled clients