### PR TITLE
#13826 Use ENABLE_SYNC for mSyncable; use char instead of int8_t for consistency

### DIFF
--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -262,9 +262,10 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     ~Node();
 
 private:
+#ifdef ENABLE_SYNC
     // whether this node can be synced to the local tree
     bool mSyncable = true;
-
+#endif
     // full folder/file key, symmetrically or asymmetrically encrypted
     // node crypto keys (raw or cooked -
     // cooked if size() == FOLDERNODEKEYLENGTH or FILEFOLDERNODEKEYLENGTH)

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -301,7 +301,7 @@ struct MEGA_API LocalNode : public File
     int32_t parent_dbid = 0;
 
     // whether this node can be synced to the remote tree
-    bool syncable = true;
+    bool mSyncable = true;
 
     // children by name
     localnode_map children;

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -236,12 +236,6 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     // location in the tounlink node_set
     // FIXME: merge todebris / tounlink
     node_set::iterator tounlink_it;
-
-    // sets whether this node can be synced to the local tree
-    void setSyncable(bool syncable);
-
-    // can this node be synced to the local tree?
-    bool isSyncable() const;
 #endif
 
     // source tag
@@ -262,10 +256,6 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     ~Node();
 
 private:
-#ifdef ENABLE_SYNC
-    // whether this node can be synced to the local tree
-    bool mSyncable = true;
-#endif
     // full folder/file key, symmetrically or asymmetrically encrypted
     // node crypto keys (raw or cooked -
     // cooked if size() == FOLDERNODEKEYLENGTH or FILEFOLDERNODEKEYLENGTH)

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1823,7 +1823,7 @@ bool LocalNode::serialize(string* d)
     d->append(&syncableByteCount, 1);
     d->append(&syncable, syncableByteCount);
 
-    d->append("\0\0\0\0\0\0", 7); // Use these bytes for extensions
+    d->append("\0\0\0\0\0\0", 8); // Use these bytes for extensions
 
     return true;
 }
@@ -1919,7 +1919,7 @@ LocalNode* LocalNode::unserialize(Sync* sync, const string* d)
         }
 
         // skip extension bytes
-        for (int i = 7; i--;)
+        for (int i = 8; i--;)
         {
             if (ptr + (unsigned char)*ptr < end)
             {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1906,13 +1906,13 @@ LocalNode* LocalNode::unserialize(Sync* sync, const string* d)
         }
     }
 
-    if (ptr < end)
     char syncable = 1;
+    if (ptr + 1 < end)
     {
         const bool hasSyncable = (unsigned char)*ptr == sizeof(syncable);
         ptr += 1;
 
-        if (hasSyncableInt)
+        if (hasSyncable && ptr + 1 < end)
         {
             syncable = MemAccess::get<char>(ptr);
             ptr += sizeof(syncable);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1895,7 +1895,7 @@ LocalNode* LocalNode::unserialize(Sync* sync, const string* d)
     char syncable = 1;
     if (ptr < end)
     {
-        if (ptr + sizeof(syncable) > end)
+        if (ptr + sizeof(syncable) + 8 > end)
         {
             LOG_err << "LocalNode unserialization failed - syncable flag";
             return NULL;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1909,8 +1909,8 @@ LocalNode* LocalNode::unserialize(Sync* sync, const string* d)
     char syncable = 1;
     if (ptr + 1 < end)
     {
-        const bool hasSyncable = (unsigned char)*ptr == sizeof(syncable);
-        ptr += 1;
+        const char hasSyncable = MemAccess::get<char>(ptr) == sizeof(syncable);
+        ptr += sizeof(hasSyncable);
 
         if (hasSyncable && ptr + 1 < end)
         {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1075,18 +1075,6 @@ Node* Node::firstancestor()
     return n;
 }
 
-#ifdef ENABLE_SYNC
-void Node::setSyncable(const bool syncable)
-{
-    mSyncable = syncable;
-}
-
-bool Node::isSyncable() const
-{
-    return mSyncable;
-}
-#endif
-
 // returns 1 if n is under p, 0 otherwise
 bool Node::isbelow(Node* p) const
 {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1818,10 +1818,10 @@ bool LocalNode::serialize(string* d)
         d->append((const char*)buf, Serialize64::serialize(buf, mtime));
     }
 
-    const char syncableInt = syncable ? 1 : 0;
-    const char syncableIntByteCount = sizeof(syncableInt);
-    d->append(&syncableIntByteCount, 1);
-    d->append(&syncableInt, syncableIntByteCount);
+    const char syncable = mSyncable ? 1 : 0;
+    const char syncableByteCount = sizeof(syncable);
+    d->append(&syncableByteCount, 1);
+    d->append(&syncable, syncableByteCount);
 
     d->append("\0\0\0\0\0\0", 7); // Use these bytes for extensions
 
@@ -1906,16 +1906,16 @@ LocalNode* LocalNode::unserialize(Sync* sync, const string* d)
         }
     }
 
-    char syncableInt = 1;
     if (ptr < end)
+    char syncable = 1;
     {
-        const bool hasSyncableInt = (unsigned char)*ptr == sizeof(syncableInt);
+        const bool hasSyncable = (unsigned char)*ptr == sizeof(syncable);
         ptr += 1;
 
         if (hasSyncableInt)
         {
-            syncableInt = MemAccess::get<char>(ptr);
-            ptr += sizeof(syncableInt);
+            syncable = MemAccess::get<char>(ptr);
+            ptr += sizeof(syncable);
         }
 
         // skip extension bytes
@@ -1951,7 +1951,7 @@ LocalNode* LocalNode::unserialize(Sync* sync, const string* d)
     l->node = sync->client->nodebyhandle(h);
     l->parent = nullptr;
     l->sync = sync;
-    l->syncable = syncableInt == 1;
+    l->mSyncable = syncable == 1;
 
     // FIXME: serialize/unserialize
     l->created = false;

--- a/tests/unit/Serialization_test.cpp
+++ b/tests/unit/Serialization_test.cpp
@@ -418,9 +418,6 @@ void checkDeserializedNode(const mega::Node& dl, const mega::Node& ref, bool ign
     ASSERT_EQ(ref.nodekey(), dl.nodekey());
     ASSERT_EQ(ignore_fileattrstring ? "" : ref.fileattrstring, dl.fileattrstring);
     ASSERT_EQ(ref.attrs.map, dl.attrs.map);
-#ifdef ENABLE_SYNC
-    ASSERT_EQ(ref.isSyncable(), dl.isSyncable());
-#endif
     if (ref.plink)
     {
         ASSERT_NE(nullptr, dl.plink);
@@ -458,12 +455,9 @@ TEST(Serialization, Node_forFile_withoutParent_withoutShares_withoutAttrs_withou
     n.size = 12;
     n.owner = 43;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(91, data.size());
+    ASSERT_EQ(90, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -476,12 +470,9 @@ TEST(Serialization, Node_forFolder_withoutParent_withoutShares_withoutAttrs_with
     n.size = -1;
     n.owner = 43;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(72, data.size());
+    ASSERT_EQ(71, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -495,12 +486,9 @@ TEST(Serialization, Node_forFile_withoutShares_withoutAttrs_withoutFileAttrStrin
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(91, data.size());
+    ASSERT_EQ(90, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -514,16 +502,13 @@ TEST(Serialization, Node_forFile_withoutShares_withoutFileAttrString_withoutPlin
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
     };
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(105, data.size());
+    ASSERT_EQ(104, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -537,9 +522,6 @@ TEST(Serialization, Node_forFile_withoutShares_withoutPlink)
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -547,7 +529,7 @@ TEST(Serialization, Node_forFile_withoutShares_withoutPlink)
     n.fileattrstring = "blah";
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(109, data.size());
+    ASSERT_EQ(108, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -561,9 +543,6 @@ TEST(Serialization, Node_forFile_withoutShares)
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -572,7 +551,7 @@ TEST(Serialization, Node_forFile_withoutShares)
     n.plink = new mega::PublicLink{n.nodehandle, 1, 2, false};
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(132, data.size());
+    ASSERT_EQ(131, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -586,12 +565,9 @@ TEST(Serialization, Node_forFolder_withoutShares_withoutAttrs_withoutFileAttrStr
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(72, data.size());
+    ASSERT_EQ(71, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -605,16 +581,13 @@ TEST(Serialization, Node_forFolder_withoutShares_withoutFileAttrString_withoutPl
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
     };
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(86, data.size());
+    ASSERT_EQ(85, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n);
@@ -628,9 +601,6 @@ TEST(Serialization, Node_forFolder_withoutShares_withoutPlink)
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -638,7 +608,7 @@ TEST(Serialization, Node_forFolder_withoutShares_withoutPlink)
     n.fileattrstring = "blah";
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(86, data.size());
+    ASSERT_EQ(85, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n, true);
@@ -652,9 +622,6 @@ TEST(Serialization, Node_forFolder_withoutShares)
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
-#ifdef ENABLE_SYNC
-    n.setSyncable(false);
-#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -663,44 +630,8 @@ TEST(Serialization, Node_forFolder_withoutShares)
     n.plink = new mega::PublicLink{n.nodehandle, 1, 2, false};
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
-    ASSERT_EQ(109, data.size());
+    ASSERT_EQ(108, data.size());
     mega::node_vector dp;
     auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
     checkDeserializedNode(*dn, n, true);
-}
-
-TEST(Serialization, Node_forFile_withoutShares_oldNodeWithoutSyncable)
-{
-    MockClient client;
-    auto& parent = mt::makeNode(*client.cli, mega::FOLDERNODE, 43);
-    auto& n = mt::makeNode(*client.cli, mega::FILENODE, 42, &parent);
-    n.size = 12;
-    n.owner = 88;
-    n.ctime = 44;
-    n.attrs.map = {
-        {101, "foo"},
-        {102, "bar"},
-    };
-    n.fileattrstring = "blah";
-    n.plink = new mega::PublicLink{n.nodehandle, 1, 2, false};
-
-    // This array represents an old Node without syncable flag
-    const std::array<char, 131> rawData = {
-        0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x2b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x2c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x58, 0x58, 0x58, 0x58,
-        0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58,
-        0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58,
-        0x58, 0x58, 0x58, 0x58, 0x05, 0x00, 0x62, 0x6c, 0x61, 0x68, 0x00, 0x01,
-        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x65, 0x03,
-        0x00, 0x66, 0x6f, 0x6f, 0x01, 0x66, 0x03, 0x00, 0x62, 0x61, 0x72, 0x00,
-        0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-    };
-    const std::string data(rawData.data(), rawData.size());
-
-    mega::node_vector dp;
-    auto dn = mega::Node::unserialize(client.cli.get(), &data, &dp);
-    checkDeserializedNode(*dn, n);
 }

--- a/tests/unit/Serialization_test.cpp
+++ b/tests/unit/Serialization_test.cpp
@@ -227,7 +227,7 @@ void checkDeserializedLocalNode(const mega::LocalNode& dl, const mega::LocalNode
     ASSERT_EQ(true, dl.isvalid);
     ASSERT_EQ(nullptr, dl.parent);
     ASSERT_EQ(ref.sync, dl.sync);
-    ASSERT_EQ(ref.syncable, dl.syncable);
+    ASSERT_EQ(ref.mSyncable, dl.mSyncable);
     ASSERT_EQ(false, dl.created);
     ASSERT_EQ(false, dl.reported);
     ASSERT_EQ(true, dl.checked);
@@ -251,7 +251,7 @@ TEST(Serialization, LocalNode_forFolder_withoutParent_withoutNode)
     MockClient client;
     auto sync = mt::makeSync(*client.cli, "wicked");
     auto& l = *sync->localroot;
-    l.syncable = false;
+    l.mSyncable = false;
     l.setfsid(10, client.cli->fsidnode);
     std::string data;
     ASSERT_TRUE(l.serialize(&data));
@@ -265,7 +265,7 @@ TEST(Serialization, LocalNode_forFile_withoutNode)
     MockClient client;
     auto sync = mt::makeSync(*client.cli, "wicked");
     auto l = mt::makeLocalNode(*sync, *sync->localroot, mega::FILENODE, "sweet");
-    l->syncable = false;
+    l->mSyncable = false;
     l->size = 124;
     l->setfsid(10, client.cli->fsidnode);
     l->parent->dbid = 13;
@@ -317,7 +317,7 @@ TEST(Serialization, LocalNode_forFolder)
     MockClient client;
     auto sync = mt::makeSync(*client.cli, "wicked");
     auto l = mt::makeLocalNode(*sync, *sync->localroot, mega::FOLDERNODE, "sweet");
-    l->syncable = false;
+    l->mSyncable = false;
     l->parent->dbid = 13;
     l->parent_dbid = l->parent->dbid;
     auto& n = mt::makeNode(*client.cli, mega::FOLDERNODE, 42);
@@ -360,7 +360,7 @@ TEST(Serialization, LocalNode_forFile)
     MockClient client;
     auto sync = mt::makeSync(*client.cli, "wicked");
     auto l = mt::makeLocalNode(*sync, *sync->localroot, mega::FILENODE, "sweet");
-    l->syncable = false;
+    l->mSyncable = false;
     auto& n = mt::makeNode(*client.cli, mega::FILENODE, 42);
     l->node = &n;
     l->size = 1;

--- a/tests/unit/Serialization_test.cpp
+++ b/tests/unit/Serialization_test.cpp
@@ -418,7 +418,9 @@ void checkDeserializedNode(const mega::Node& dl, const mega::Node& ref, bool ign
     ASSERT_EQ(ref.nodekey(), dl.nodekey());
     ASSERT_EQ(ignore_fileattrstring ? "" : ref.fileattrstring, dl.fileattrstring);
     ASSERT_EQ(ref.attrs.map, dl.attrs.map);
+#ifdef ENABLE_SYNC
     ASSERT_EQ(ref.isSyncable(), dl.isSyncable());
+#endif
     if (ref.plink)
     {
         ASSERT_NE(nullptr, dl.plink);
@@ -456,7 +458,9 @@ TEST(Serialization, Node_forFile_withoutParent_withoutShares_withoutAttrs_withou
     n.size = 12;
     n.owner = 43;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
     ASSERT_EQ(91, data.size());
@@ -472,7 +476,9 @@ TEST(Serialization, Node_forFolder_withoutParent_withoutShares_withoutAttrs_with
     n.size = -1;
     n.owner = 43;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
     ASSERT_EQ(72, data.size());
@@ -489,7 +495,9 @@ TEST(Serialization, Node_forFile_withoutShares_withoutAttrs_withoutFileAttrStrin
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
     ASSERT_EQ(91, data.size());
@@ -506,7 +514,9 @@ TEST(Serialization, Node_forFile_withoutShares_withoutFileAttrString_withoutPlin
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -527,7 +537,9 @@ TEST(Serialization, Node_forFile_withoutShares_withoutPlink)
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -549,7 +561,9 @@ TEST(Serialization, Node_forFile_withoutShares)
     n.size = 12;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -572,7 +586,9 @@ TEST(Serialization, Node_forFolder_withoutShares_withoutAttrs_withoutFileAttrStr
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     std::string data;
     ASSERT_TRUE(n.serialize(&data));
     ASSERT_EQ(72, data.size());
@@ -589,7 +605,9 @@ TEST(Serialization, Node_forFolder_withoutShares_withoutFileAttrString_withoutPl
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -610,7 +628,9 @@ TEST(Serialization, Node_forFolder_withoutShares_withoutPlink)
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},
@@ -632,7 +652,9 @@ TEST(Serialization, Node_forFolder_withoutShares)
     n.size = -1;
     n.owner = 88;
     n.ctime = 44;
+#ifdef ENABLE_SYNC
     n.setSyncable(false);
+#endif
     n.attrs.map = {
         {101, "foo"},
         {102, "bar"},


### PR DESCRIPTION
This is PR does the following:
- Remove `mSyncable` de-/serialization from `Node` (this will be managed in a different data structure)
- Use `ENABLE_SYNC` for `Node`s `mSyncable`
- Use char instead of int8_t for consistency