### PR TITLE
#13864 Add sync config to megacli

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -167,13 +167,20 @@ static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::
     toLower(overwrite);
 
     SyncConfig::Type syncType;
-    if (type == "up") {
+    if (type == "up")
+    {
         syncType = SyncConfig::TYPE_UP;
-    } else if (type == "down") {
+    }
+    else if (type == "down")
+    {
         syncType = SyncConfig::TYPE_DOWN;
-    } else if (type == "twoway") {
+    }
+    else if (type == "twoway")
+    {
         syncType = SyncConfig::TYPE_DEFAULT;
-    } else {
+    }
+    else
+    {
         return std::make_pair(false, SyncConfig{});
     }
 
@@ -182,19 +189,29 @@ static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::
 
     if (syncType != SyncConfig::TYPE_DEFAULT)
     {
-        if (syncDel == "on") {
+        if (syncDel == "on")
+        {
             syncDeletions = true;
-        } else if (syncDel == "off") {
+        }
+        else if (syncDel == "off")
+        {
             syncDeletions = false;
-        } else {
+        }
+        else
+        {
             return std::make_pair(false, SyncConfig{});
         }
 
-        if (overwrite == "on") {
+        if (overwrite == "on")
+        {
             forceOverwrite = true;
-        } else if (overwrite == "off") {
+        }
+        else if (overwrite == "off")
+        {
             forceOverwrite = false;
-        } else {
+        }
+        else
+        {
             return std::make_pair(false, SyncConfig{});
         }
     }
@@ -4119,15 +4136,22 @@ void exec_syncconfig(autocomplete::ACState& s)
     else if (s.words.size() == 2 || s.words.size() == 4)
     {
         std::pair<bool, SyncConfig> pair;
-        if (s.words.size() == 2) {
+        if (s.words.size() == 2)
+        {
             pair = syncConfigFromStrings(s.words[1].s);
-        } else {
+        }
+        else
+        {
             pair = syncConfigFromStrings(s.words[1].s, s.words[2].s, s.words[3].s);
         }
-        if (pair.first) {
+
+        if (pair.first)
+        {
             syncConfig = pair.second;
             cout << "Successfully applied new sync config!" << endl;
-        } else {
+        }
+        else
+        {
             cout << "Invalid parameters for syncconfig command." << endl;
         }
     }

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -305,6 +305,7 @@ void exec_mv(autocomplete::ACState& s);
 void exec_cp(autocomplete::ACState& s);
 void exec_du(autocomplete::ACState& s);
 void exec_sync(autocomplete::ACState& s);
+void exec_syncconfig(autocomplete::ACState& s);
 void exec_export(autocomplete::ACState& s);
 void exec_share(autocomplete::ACState& s);
 void exec_invite(autocomplete::ACState& s);

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -45,17 +45,8 @@ class MEGA_API Sync
 {
 public:
 
-    // whether this is an up-sync from local to remote
-    bool isUpSync() const;
-
-    // whether this is a down-sync from remote to local
-    bool isDownSync() const;
-
-    // whether deletions are synced
-    bool syncDeletions() const;
-
-    // whether changes are overwritten irregardless of file properties
-    bool forceOverwrite() const;
+    // returns the sync config
+    const SyncConfig& getConfig() const;
 
     void* appData = nullptr;
 
@@ -180,9 +171,7 @@ protected :
     bool readstatecache();
 
 private:
-    // The sync config is not to be used directly for sync decisions.
-    // Instead, public member functions of `Sync` should be used.
-    SyncConfig mConfig;
+    const SyncConfig mConfig;
 };
 } // namespace
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -672,8 +672,10 @@ namespace CodeCounter
 }
 
 // Holds the config of a sync. Can be extended with future config options
-struct SyncConfig
+class SyncConfig
 {
+public:
+
     enum Type
     {
         TYPE_UP = 0x01, // sync up from local to remote
@@ -681,14 +683,61 @@ struct SyncConfig
         TYPE_DEFAULT = TYPE_UP | TYPE_DOWN, // Two-way sync
     };
 
+    SyncConfig() = default;
+
+    SyncConfig(const Type syncType, const bool syncDeletions, const bool forceOverwrite)
+    : mSyncType{syncType}
+    , mSyncDeletions{syncDeletions}
+    , mForceOverwrite{forceOverwrite}
+    {}
+
+    // whether this is an up-sync from local to remote
+    bool isUpSync() const
+    {
+        return mSyncType & TYPE_UP;
+    }
+
+    // whether this is a down-sync from remote to local
+    bool isDownSync() const
+    {
+        return mSyncType & TYPE_DOWN;
+    }
+
+    // whether deletions are synced
+    bool syncDeletions() const
+    {
+        switch (mSyncType)
+        {
+            case TYPE_UP: return mSyncDeletions;
+            case TYPE_DOWN: return mSyncDeletions;
+            case TYPE_DEFAULT: return true;
+        }
+        assert(false);
+        return true;
+    }
+
+    // whether changes are overwritten irregardless of file properties
+    bool forceOverwrite() const
+    {
+        switch (mSyncType)
+        {
+            case TYPE_UP: return mForceOverwrite;
+            case TYPE_DOWN: return mForceOverwrite;
+            case TYPE_DEFAULT: return false;
+        }
+        assert(false);
+        return false;
+    }
+
+private:
     // type of the sync, defaults to bidirectional
-    Type syncType = TYPE_DEFAULT;
+    Type mSyncType = TYPE_DEFAULT;
 
     // whether deletions are synced (only relevant for one-way-sync)
-    bool syncDeletions = false;
+    bool mSyncDeletions = false;
 
     // whether changes are overwritten irregardless of file properties (only relevant for one-way-sync)
-    bool forceOverwrite = false;
+    bool mForceOverwrite = false;
 };
 
 } // namespace

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -686,9 +686,9 @@ public:
     SyncConfig() = default;
 
     SyncConfig(const Type syncType, const bool syncDeletions, const bool forceOverwrite)
-    : mSyncType{syncType}
-    , mSyncDeletions{syncDeletions}
-    , mForceOverwrite{forceOverwrite}
+        : mSyncType{syncType}
+        , mSyncDeletions{syncDeletions}
+        , mForceOverwrite{forceOverwrite}
     {}
 
     // whether this is an up-sync from local to remote

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1804,7 +1804,7 @@ bool LocalNode::serialize(string* d)
     const char syncable = mSyncable ? 1 : 0;
     d->append(&syncable, sizeof(syncable));
 
-    d->append("\0\0\0\0\0\0", 8); // Use these bytes for extensions
+    d->append("\0\0\0\0\0\0\0", 8); // Use these bytes for extensions
 
     return true;
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -662,40 +662,6 @@ Sync::~Sync()
     }
 }
 
-bool Sync::isUpSync() const
-{
-    return mConfig.syncType & SyncConfig::TYPE_UP;
-}
-
-bool Sync::isDownSync() const
-{
-    return mConfig.syncType & SyncConfig::TYPE_DOWN;
-}
-
-bool Sync::syncDeletions() const
-{
-    switch (mConfig.syncType)
-    {
-        case SyncConfig::TYPE_UP: return mConfig.syncDeletions;
-        case SyncConfig::TYPE_DOWN: return mConfig.syncDeletions;
-        case SyncConfig::TYPE_DEFAULT: return true;
-    }
-    assert(false);
-    return true;
-}
-
-bool Sync::forceOverwrite() const
-{
-    switch (mConfig.syncType)
-    {
-        case SyncConfig::TYPE_UP: return mConfig.forceOverwrite;
-        case SyncConfig::TYPE_DOWN: return mConfig.forceOverwrite;
-        case SyncConfig::TYPE_DEFAULT: return false;
-    }
-    assert(false);
-    return false;
-}
-
 void Sync::addstatecachechildren(uint32_t parent_dbid, idlocalnode_map* tmap, string* path, LocalNode *p, int maxdepth)
 {
     pair<idlocalnode_map::iterator,idlocalnode_map::iterator> range;
@@ -769,6 +735,11 @@ bool Sync::readstatecache()
     }
 
     return false;
+}
+
+const SyncConfig& Sync::getConfig() const
+{
+    return mConfig;
 }
 
 // remove LocalNode from DB cache

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -2466,7 +2466,7 @@ GTEST_TEST(Sync, PutnodesForMultipleFolders)
 
     handle targethandle = standardclient.client.rootnodes[0];
 
-    std::atomic<bool> putnodesDone = false;
+    std::atomic<bool> putnodesDone{false};
     standardclient.resultproc.prepresult(StandardClient::PUTNODES, [&putnodesDone](error e) {
         putnodesDone = true;
     });

--- a/tests/unit/Sync_test.cpp
+++ b/tests/unit/Sync_test.cpp
@@ -1045,4 +1045,40 @@ TEST(Sync, assignFilesystemIds_whenFileTypeIsUnexpected_hittingAssert)
 }
 #endif
 
+TEST(Sync, SyncConfig_noparam_constructor)
+{
+    const mega::SyncConfig config;
+    ASSERT_TRUE(config.isUpSync());
+    ASSERT_TRUE(config.isDownSync());
+    ASSERT_TRUE(config.syncDeletions());
+    ASSERT_FALSE(config.forceOverwrite());
+}
+
+TEST(Sync, SyncConfig_default_sync)
+{
+    const mega::SyncConfig config{mega::SyncConfig::TYPE_DEFAULT, false, true};
+    ASSERT_TRUE(config.isUpSync());
+    ASSERT_TRUE(config.isDownSync());
+    ASSERT_TRUE(config.syncDeletions());
+    ASSERT_FALSE(config.forceOverwrite());
+}
+
+TEST(Sync, SyncConfig_up_sync)
+{
+    const mega::SyncConfig config{mega::SyncConfig::TYPE_UP, true, true};
+    ASSERT_TRUE(config.isUpSync());
+    ASSERT_FALSE(config.isDownSync());
+    ASSERT_TRUE(config.syncDeletions());
+    ASSERT_TRUE(config.forceOverwrite());
+}
+
+TEST(Sync, SyncConfig_down_sync)
+{
+    const mega::SyncConfig config{mega::SyncConfig::TYPE_DOWN, true, true};
+    ASSERT_FALSE(config.isUpSync());
+    ASSERT_TRUE(config.isDownSync());
+    ASSERT_TRUE(config.syncDeletions());
+    ASSERT_TRUE(config.forceOverwrite());
+}
+
 #endif


### PR DESCRIPTION
This adds the syncconfig to megacli so that we can use two-way and one-way syncing from megacli.