### PR TITLE
Let the type of created ticket to be among allowed values

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -20740,7 +20740,7 @@ void MegaApiImpl::sendPendingRequests()
             int type = request->getParamType();
             const char *message = request->getText();
 
-            if (type != 1 || !message)
+            if ((type < 0 || type > 7) || !message)
             {
                 e = API_EARGS;
                 break;


### PR DESCRIPTION
Don't trigger EARGS if the type of support ticket request is allowed (0-7)