### PR TITLE
Fixed (probably) standard-violating typo

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1674,7 +1674,7 @@ string escapewebdavchar(const char c)
     {
         escapesec[33] = "&#33;"; // !  //For some reason &Exclamation; was not properly handled (crashed) by gvfsd-dav
         escapesec[34] = "&quot;"; // "
-        escapesec[37] = "&percent;"; // %
+        escapesec[37] = "&percnt;"; // %
         escapesec[38] = "&amp;"; // &
         escapesec[39] = "&apos;"; // '
         escapesec[43] = "&add;"; // +


### PR DESCRIPTION
I have been having trouble getting 3rd party tools such as davfs2 and rclone to work with the WebDAV server feature in MEGAcmd; XML parse errors are produced referring to an invalid character entity `percent` or `&percent;`, respectively. Dumping the body showed an element similar to the following as the erroneous line:
`<d:displayname>FilenameWith&percent;InIt</d:displayname>`
According to [this webpage](https://dev.w3.org/html5/html-author/charref), '%' can be encoded as `&percnt;` but not `&percent;`, so this appears to be a simple typo in `src/utils.cpp`. However, for various reasons I cannot test this patch myself at this time so I apologise if I am mistaken in my reasoning.

### Steps to reproduce:
Upload a file containing % in its filename to the root of a MEGA drive via the web interface (have not tested others).
```
$ mega-cmd
person@example.com:/$ webdav / --port 1234
$ mkdir -p mega
$ yes | sudo mount -t davfs "http://127.1:1234/$HASH/Cloud Drive" mega
> XML parse error at line 347: Entity 'percent' not defined
$ rclone mount 'Mega WebDAV':"$HASH/Cloud Drive" mega
> Failed to create filesystem for "Mega WebDAV:$HASH/Cloud Drive": read metadata failed: XML syntax error on line 347: invalid character &percent;
```