### PR TITLE
#14108. Always set target handle for NewNodes in LocalNodes

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13010,6 +13010,11 @@ void MegaClient::syncupdate()
             n = NULL;
             l = synccreate[i];
 
+            if (l->type == FILENODE && l->parent->node)
+            {
+                l->h = l->parent->node->nodehandle;
+            }
+
             if (l->type == FOLDERNODE || (n = nodebyfingerprint(l)))
             {
                 // create remote folder or copy file if it already exists
@@ -13076,11 +13081,6 @@ void MegaClient::syncupdate()
 
                 // the overwrite will happen upon PUT completion
                 string tmppath, tmplocalpath;
-
-                if (l->parent->node)
-                {
-                    l->h = l->parent->node->nodehandle;
-                }
 
                 nextreqtag();
                 startxfer(PUT, l, committer);


### PR DESCRIPTION
When a file is copied locally into a folder contained in a synced folder, it results on a remote copy and the assert fails. This hotfix solves the issue.

Risk Areas
========
producing a remote copy by a local syncup copy