### PR TITLE
#14154. Initialize and cleanup c-url and c-ares just once

### DIFF
--- a/include/mega/posix/meganet.h
+++ b/include/mega/posix/meganet.h
@@ -208,6 +208,9 @@ public:
     CurlHttpIO();
     ~CurlHttpIO();
 
+private:
+    static std::atomic<int> instanceCount;
+
     CodeCounter::ScopeStats countCurlHttpIOAddevents = { "curl-httpio-addevents" };
     CodeCounter::ScopeStats countAddAresEventsCode = { "ares-add-events" };
     CodeCounter::ScopeStats countAddCurlEventsCode = { "curl-add-events" };

--- a/include/mega/posix/meganet.h
+++ b/include/mega/posix/meganet.h
@@ -209,7 +209,7 @@ public:
     ~CurlHttpIO();
 
 private:
-    static std::atomic<int> instanceCount;
+    static int instanceCount;
 
     CodeCounter::ScopeStats countCurlHttpIOAddevents = { "curl-httpio-addevents" };
     CodeCounter::ScopeStats countAddAresEventsCode = { "ares-add-events" };

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -275,9 +275,11 @@ CurlHttpIO::CurlHttpIO()
 
 #endif
 
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-    ares_library_init(ARES_LIB_INIT_ALL);
-
+    if (++instanceCount == 1)
+    {
+        curl_global_init(CURL_GLOBAL_DEFAULT);
+        ares_library_init(ARES_LIB_INIT_ALL);
+    }
 
 #if defined(__ANDROID__) && ARES_VERSION >= 0x010F00
     initialize_android();
@@ -718,13 +720,18 @@ CurlHttpIO::~CurlHttpIO()
     closecurlevents(PUT);
 
     curlMutex.lock();
-    ares_library_cleanup();
-    curl_global_cleanup();
+    if (--instanceCount == 0)
+    {
+        ares_library_cleanup();
+        curl_global_cleanup();
+    }
     curlMutex.unlock();
 
     curl_slist_free_all(contenttypejson);
     curl_slist_free_all(contenttypebinary);
 }
+
+std::atomic<int> CurlHttpIO::instanceCount{ 0 };
 
 void CurlHttpIO::setuseragent(string* u)
 {

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -731,7 +731,7 @@ CurlHttpIO::~CurlHttpIO()
     curl_slist_free_all(contenttypebinary);
 }
 
-std::atomic<int> CurlHttpIO::instanceCount{ 0 };
+int CurlHttpIO::instanceCount = 0;
 
 void CurlHttpIO::setuseragent(string* u)
 {


### PR DESCRIPTION
Even when there are multiple MegaApi, hence multiple CurlHttpIO.
Also taking startup on multiple threads into account.