### PR TITLE
#13944. Adjust c-ares initialization for Android

### DIFF
--- a/bindings/megaapi.i
+++ b/bindings/megaapi.i
@@ -41,7 +41,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)
 {
     MEGAjvm = jvm;
     JNIEnv* jenv = NULL;
-    jvm->GetEnv((void**)&jenv, JNI_VERSION_1_4);
+    jvm->GetEnv((void**)&jenv, JNI_VERSION_1_6);
 
     jclass clsStringLocal = jenv->FindClass("java/lang/String");
     clsString = (jclass)jenv->NewGlobalRef(clsStringLocal);
@@ -141,7 +141,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)
     ares_library_init_jvm(jvm);
 #endif
 
-    return JNI_VERSION_1_4;
+    return JNI_VERSION_1_6;
 }
 #endif
 %}

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -2767,7 +2767,7 @@ void CurlHttpIO::initialize_android()
     try
     {
         JNIEnv *env;
-        int result = MEGAjvm->GetEnv((void **)&env, JNI_VERSION_1_4);
+        int result = MEGAjvm->GetEnv((void **)&env, JNI_VERSION_1_6);
         if (result == JNI_EDETACHED)
         {
             if (MEGAjvm->AttachCurrentThread(&env, NULL) != JNI_OK)
@@ -2879,7 +2879,9 @@ void CurlHttpIO::initialize_android()
             return;
         }
 
+        ares_library_init_jvm(MEGAjvm);
         ares_library_init_android(connectivityManager);
+        assert(ares_library_android_initialized() == ARES_SUCCESS);
 
         if (detach)
         {


### PR DESCRIPTION
The `JNI_OnLoad()` that sets the JavaVM (`ares_library_init_jvm()`) for Android in c-ares is executed too early, before the `ares_init_library()` itself. It results in a crash when the `android_jvm` is used by c-ares at `ares_get_android_server_list()`, since the variable is not set.
This commit aims to ensure that the virtual-machine is always valid by calling `ares_library_init_jvm()` right after the `ares_library_init()` and before `ares_library_init_android()`.