### PR TITLE
#12549. Contact Alias iOS binding

### DIFF
--- a/bindings/ios/MEGARequest.h
+++ b/bindings/ios/MEGARequest.h
@@ -509,6 +509,16 @@ typedef NS_ENUM (NSInteger, MEGANodeAccessLevel) {
 @property (readonly, nonatomic) NSDictionary<NSString *, MEGAStringList*> *megaStringListDictionary;
 
 /**
+ * @brief Returns the attribute values as dictionary with key and value as string.
+ *
+ * This value is valid for these requests:
+ * - [MEGASdk getUserAttributeType:] - Returns the attribute value of the current account.
+ *
+ * @return Dictionary containing the key-value pairs of the attribute as string.
+ */
+@property (readonly, nonatomic) NSDictionary<NSString *, NSString*> *megaStringDictionary;
+
+/**
  * @brief Gets the string table response from a request mapped into a collection of NSArray of NSStrings.
  *
  * This value is valid for these requests:

--- a/bindings/ios/MEGARequest.mm
+++ b/bindings/ios/MEGARequest.mm
@@ -207,6 +207,21 @@ using namespace mega;
     return [dict copy];
 }
 
+- (NSDictionary<NSString *, NSString *> *)megaStringDictionary {
+    MegaStringMap *map = self.megaRequest->getMegaStringMap();
+    
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:map->size()];
+    MegaStringList *keyList = map->getKeys();
+    
+    for (int i = 0; i < keyList->size(); i++) {
+        const char *key = keyList->get(i);
+        dict[@(key)] = @(map->get(key));
+    }
+    
+    delete keyList;
+    return [dict copy];
+}
+
 - (NSInteger)transferTag {
     return self.megaRequest ? self.megaRequest->getTransferTag() : 0;
 }


### PR DESCRIPTION
Binding for the dictionary returned for the user attribute. 
For instance, this is used in getting the aliases of user contacts.