### PR TITLE
WIP: Address issues with Cachable interface

### DIFF
--- a/include/mega/crypto/cryptopp.h
+++ b/include/mega/crypto/cryptopp.h
@@ -299,7 +299,7 @@ public:
      *     (AsymmCipher::PRIVKEY or AsymmCipher::PUBKEY).
      * @return 0 on an invalid key pair.
      */
-    int isvalid(int keytype = PUBKEY);
+    int isvalid(int keytype = PUBKEY) const;
 
     /**
      * @brief Encrypts a randomly padded plain text into a buffer.
@@ -346,7 +346,7 @@ public:
      */
     unsigned rawdecrypt(const byte* cipher, size_t cipherlen, byte* buf, size_t buflen);
 
-    static void serializeintarray(CryptoPP::Integer*, int, std::string*, bool headers = true);
+    static void serializeintarray(const CryptoPP::Integer*, int, std::string*, bool headers = true);
 
     /**
      * @brief Serialises a key to a string.
@@ -356,7 +356,7 @@ public:
      *     (AsymmCipher::PRIVKEY or AsymmCipher::PUBKEY).
      * @return Void.
      */
-    void serializekey(std::string* d, int keytype);
+    void serializekey(std::string* d, int keytype) const;
 
     /**
      * @brief Serialize public key for compatibility with the webclient.

--- a/include/mega/db.h
+++ b/include/mega/db.h
@@ -53,7 +53,7 @@ public:
     // update or add specific record
     virtual bool put(uint32_t, char*, unsigned) = 0;
     bool put(uint32_t, string*);
-    bool put(uint32_t, Cachable *, SymmCipher*);
+    bool put(uint32_t, Cacheable *, SymmCipher*);
 
     // delete specific record
     virtual bool del(uint32_t) = 0;

--- a/include/mega/file.h
+++ b/include/mega/file.h
@@ -100,7 +100,7 @@ struct MEGA_API File: public FileFingerprint
     virtual ~File();
 
     // serialize the File object
-    virtual bool serialize(string*);
+    bool serialize(string*) const override;
 
     static File* unserialize(string*);
 

--- a/include/mega/filefingerprint.h
+++ b/include/mega/filefingerprint.h
@@ -29,7 +29,7 @@
 namespace mega {
 
 // sparse file fingerprint, including size and mtime
-struct MEGA_API FileFingerprint : public Cachable
+struct MEGA_API FileFingerprint : public Cacheable
 {
     m_off_t size = -1;
     m_time_t mtime = 0;
@@ -53,7 +53,7 @@ struct MEGA_API FileFingerprint : public Cachable
     FileFingerprint(const FileFingerprint&);
     FileFingerprint& operator=(const FileFingerprint& other);
 
-    virtual bool serialize(string* d);
+    virtual bool serialize(string* d) const override;
     static FileFingerprint* unserialize(string* d);
 };
 

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -249,7 +249,7 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
 
     void setpubliclink(handle, m_time_t, m_time_t, bool);
 
-    bool serialize(string*);
+    bool serialize(string*) const override;
     static Node* unserialize(MegaClient*, const string*, node_vector*);
 
     Node(MegaClient*, vector<Node*>*, handle, handle, nodetype_t, m_off_t, handle, const char*, m_time_t);
@@ -383,7 +383,7 @@ struct MEGA_API LocalNode : public File
     LocalNode();
     void init(Sync*, nodetype_t, LocalNode*, string*);
 
-    virtual bool serialize(string*);
+    bool serialize(string*) const override;
     static LocalNode* unserialize( Sync* sync, const string* sData );
 
     ~LocalNode();

--- a/include/mega/pendingcontactrequest.h
+++ b/include/mega/pendingcontactrequest.h
@@ -27,7 +27,7 @@
 namespace mega {
 
 // pending contact request
-struct MEGA_API PendingContactRequest : public Cachable
+struct MEGA_API PendingContactRequest : public Cacheable
 {
     // id of the request
     handle id;
@@ -61,7 +61,7 @@ struct MEGA_API PendingContactRequest : public Cachable
         bool reminded : 1;
     } changed;
 
-    bool serialize(string*);
+    bool serialize(string*) const override;
     static PendingContactRequest* unserialize(string*);
 
     PendingContactRequest(const handle id, const char *oemail, const char *temail, const m_time_t ts, const m_time_t uts, const char *msg, bool outgoing);

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -73,7 +73,7 @@ public:
     bool inshare = false;
     
     // deletion queue
-    set<int32_t> deleteq;
+    set<uint32_t> deleteq;
 
     // insertion/update queue
     localnode_set insertq;

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -142,7 +142,7 @@ struct MEGA_API Transfer : public FileFingerprint
     virtual ~Transfer();
 
     // serialize the Transfer object
-    virtual bool serialize(string*);
+    bool serialize(string*) const override;
 
     // unserialize a Transfer and add it to the transfer map
     static Transfer* unserialize(MegaClient *, string*, transfer_map *);

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -248,16 +248,15 @@ const int FOLDERNODEKEYLENGTH = 16;
 typedef list<class Sync*> sync_list;
 
 // persistent resource cache storage
-struct Cachable
+class Cacheable
 {
-    virtual bool serialize(string*) = 0;
+public:
+    virtual ~Cacheable() = default;
 
-    int32_t dbid;
+    virtual bool serialize(string*) const = 0;
 
-    bool notified;
-
-    Cachable();
-    virtual ~Cachable() { }
+    uint32_t dbid = 0;
+    bool notified = false;
 };
 
 // numeric representation of string (up to 8 chars)
@@ -483,7 +482,7 @@ typedef enum { PRIV_UNKNOWN = -2, PRIV_RM = -1, PRIV_RO = 0, PRIV_STANDARD = 2, 
 typedef pair<handle, privilege_t> userpriv_pair;
 typedef vector< userpriv_pair > userpriv_vector;
 typedef map <handle, set <handle> > attachments_map;
-struct TextChat : public Cachable
+struct TextChat : public Cacheable
 {
     enum {
         FLAG_OFFSET_ARCHIVE = 0
@@ -510,7 +509,7 @@ public:
     TextChat();
     ~TextChat();
 
-    bool serialize(string *d);
+    bool serialize(string *d) const override;
     static TextChat* unserialize(class MegaClient *client, string *d);
 
     void setTag(int tag);

--- a/include/mega/user.h
+++ b/include/mega/user.h
@@ -26,7 +26,7 @@
 
 namespace mega {
 // user/contact
-struct MEGA_API User : public Cachable
+struct MEGA_API User : public Cacheable
 {
     // user handle
     handle userhandle;
@@ -103,7 +103,7 @@ private:
 public:
     void set(visibility_t, m_time_t);
 
-    bool serialize(string*);
+    bool serialize(string*) const override;
     static User* unserialize(class MegaClient *, string*);
 
     // attribute methods: set/get/invalidate...

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -372,7 +372,7 @@ public:
     void onTransferFinish(MegaApi*, MegaTransfer *t, MegaError *e) override;
 };
 
-class MegaNodePrivate : public MegaNode, public Cachable
+class MegaNodePrivate : public MegaNode, public Cacheable
 {
     public:
         MegaNodePrivate(const char *name, int type, int64_t size, int64_t ctime, int64_t mtime,
@@ -452,7 +452,7 @@ class MegaNodePrivate : public MegaNode, public Cachable
         MegaNode *copy() override;
 
         char *serialize() override;
-        bool serialize(string*) override;
+        bool serialize(string*) const override;
         static MegaNodePrivate* unserialize(string*);
 
     protected:
@@ -611,7 +611,7 @@ class MegaSharePrivate : public MegaShare
         bool pending;
 };
 
-class MegaTransferPrivate : public MegaTransfer, public Cachable
+class MegaTransferPrivate : public MegaTransfer, public Cacheable
 {
 	public:
 		MegaTransferPrivate(int type, MegaTransferListener *listener = NULL);
@@ -699,7 +699,7 @@ class MegaTransferPrivate : public MegaTransfer, public Cachable
         virtual unsigned long long getPriority() const;
         virtual long long getNotificationNumber() const;
 
-        virtual bool serialize(string*);
+        bool serialize(string*) const override;
         static MegaTransferPrivate* unserialize(string*);
 
         void startRecursiveOperation(unique_ptr<MegaRecursiveOperation>, MegaNode* node); // takes ownership of both
@@ -1776,7 +1776,7 @@ struct MegaFile : public File
 
     void setTransfer(MegaTransferPrivate *transfer);
     MegaTransferPrivate *getTransfer();
-    virtual bool serialize(string*);
+    bool serialize(string*) const override;
 
     static MegaFile* unserialize(string*);
 
@@ -1795,7 +1795,7 @@ struct MegaFileGet : public MegaFile
     MegaFileGet(MegaClient *client, MegaNode* n, string dstPath);
     ~MegaFileGet() {}
 
-    virtual bool serialize(string*);
+    bool serialize(string*) const override;
     static MegaFileGet* unserialize(string*);
 
 private:
@@ -1809,7 +1809,7 @@ struct MegaFilePut : public MegaFile
     MegaFilePut(MegaClient *client, string* clocalname, string *filename, handle ch, const char* ctargetuser, int64_t mtime = -1, bool isSourceTemporary = false);
     ~MegaFilePut() {}
 
-    virtual bool serialize(string*);
+    bool serialize(string*) const override;
     static MegaFilePut* unserialize(string*);
 
 protected:

--- a/src/crypto/cryptopp.cpp
+++ b/src/crypto/cryptopp.cpp
@@ -499,12 +499,12 @@ void AsymmCipher::serializekeyforjs(string& d)
     }
 }
 
-void AsymmCipher::serializekey(string* d, int keytype)
+void AsymmCipher::serializekey(string* d, int keytype) const
 {
     serializeintarray(key, keytype, d);
 }
 
-void AsymmCipher::serializeintarray(Integer* t, int numints, string* d, bool headers)
+void AsymmCipher::serializeintarray(const Integer* t, int numints, string* d, bool headers)
 {
     unsigned size = 0;
     char c;
@@ -569,7 +569,7 @@ int AsymmCipher::decodeintarray(Integer* t, int numints, const byte* data, int l
     return i == numints && len - p < 16;
 }
 
-int AsymmCipher::isvalid(int keytype)
+int AsymmCipher::isvalid(int keytype) const
 {
     if (keytype == PUBKEY)
     {

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -37,7 +37,7 @@ bool DbTable::put(uint32_t index, string* data)
 }
 
 // add or update record with padding and encryption
-bool DbTable::put(uint32_t type, Cachable* record, SymmCipher* key)
+bool DbTable::put(uint32_t type, Cacheable* record, SymmCipher* key)
 {
     string data;
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -50,7 +50,7 @@ File::~File()
     delete [] chatauth;
 }
 
-bool File::serialize(string *d)
+bool File::serialize(string *d) const
 {
     char type = char(transfer->type);
     d->append((const char*)&type, sizeof(type));

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -65,7 +65,7 @@ bool operator==(const FileFingerprint& lhs, const FileFingerprint& rhs)
     return !memcmp(lhs.crc.data(), rhs.crc.data(), sizeof lhs.crc);
 }
 
-bool FileFingerprint::serialize(string *d)
+bool FileFingerprint::serialize(string *d) const
 {
     d->append((const char*)&size, sizeof(size));
     d->append((const char*)&mtime, sizeof(mtime));

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -492,7 +492,7 @@ char *MegaNodePrivate::serialize()
     return ret;
 }
 
-bool MegaNodePrivate::serialize(string *d)
+bool MegaNodePrivate::serialize(string *d) const
 {
     CacheableWriter w(*d);
     w.serializecstr(name, true);
@@ -2456,7 +2456,7 @@ long long MegaTransferPrivate::getNotificationNumber() const
     return notificationNumber;
 }
 
-bool MegaTransferPrivate::serialize(string *d)
+bool MegaTransferPrivate::serialize(string *d) const
 {
     d->append((const char*)&type, sizeof(type));
     d->append((const char*)&nodeHandle, sizeof(nodeHandle));
@@ -4622,7 +4622,7 @@ MegaTransferPrivate *MegaFile::getTransfer()
     return megaTransfer;
 }
 
-bool MegaFile::serialize(string *d)
+bool MegaFile::serialize(string *d) const
 {
     if (!megaTransfer)
     {
@@ -4768,7 +4768,7 @@ MegaFileGet::MegaFileGet(MegaClient *client, MegaNode *n, string dstPath) : Mega
     chatauth = n->getChatAuth() ? MegaApi::strdup(n->getChatAuth()) : NULL;
 }
 
-bool MegaFileGet::serialize(string *d)
+bool MegaFileGet::serialize(string *d) const
 {
     if (!MegaFile::serialize(d))
     {
@@ -4903,7 +4903,7 @@ MegaFilePut::MegaFilePut(MegaClient *, string* clocalname, string *filename, han
     temporaryfile = isSourceTemporary;
 }
 
-bool MegaFilePut::serialize(string *d)
+bool MegaFilePut::serialize(string *d) const
 {
     if (!MegaFile::serialize(d))
     {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -454,16 +454,16 @@ Node* Node::unserialize(MegaClient* client, const string* d, node_vector* dp)
 }
 
 // serialize node - nodes with pending or RSA keys are unsupported
-bool Node::serialize(string* d)
+bool Node::serialize(string* d) const
 {
     // do not serialize encrypted nodes
     if (attrstring)
     {
         LOG_warn << "Trying to serialize an encrypted node";
 
-        //Last attempt to decrypt the node
-        applykey();
-        setattr();
+        //Last attempt to decrypt the node. TODO: Move this outside of serialize()
+        const_cast<Node*>(this)->applykey();
+        const_cast<Node*>(this)->setattr();
 
         if (attrstring)
         {
@@ -1783,7 +1783,7 @@ void LocalNode::completed(Transfer* t, LocalNode*)
 // - corresponding Node handle
 // - local name
 // - fingerprint crc/mtime (filenodes only)
-bool LocalNode::serialize(string* d)
+bool LocalNode::serialize(string* d) const
 {
     m_off_t s = type ? -type : size;
 

--- a/src/pendingcontactrequest.cpp
+++ b/src/pendingcontactrequest.cpp
@@ -70,7 +70,7 @@ bool PendingContactRequest::removed()
     return changed.accepted || changed.denied || changed.ignored || changed.deleted;
 }
 
-bool PendingContactRequest::serialize(string *d)
+bool PendingContactRequest::serialize(string *d) const
 {
     unsigned char l;
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -782,7 +782,7 @@ void Sync::cachenodes()
         statecachetable->begin();
 
         // deletions
-        for (set<int32_t>::iterator it = deleteq.begin(); it != deleteq.end(); it++)
+        for (auto it = deleteq.begin(); it != deleteq.end(); it++)
         {
             statecachetable->del(*it);
         }

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -115,7 +115,7 @@ Transfer::~Transfer()
     }
 }
 
-bool Transfer::serialize(string *d)
+bool Transfer::serialize(string *d) const
 {
     unsigned short ll;
 

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -73,7 +73,7 @@ bool User::mergeUserAttribute(attr_t type, const string_map &newValuesMap, TLVst
     return modified;
 }
 
-bool User::serialize(string* d)
+bool User::serialize(string* d) const
 {
     unsigned char l;
     unsigned short ll;
@@ -100,7 +100,7 @@ bool User::serialize(string* d)
     // serialization of attributes
     l = (unsigned char)attrs.size();
     d->append((char*)&l, sizeof l);
-    for (userattr_map::iterator it = attrs.begin(); it != attrs.end(); it++)
+    for (auto it = attrs.cbegin(); it != attrs.cend(); it++)
     {
         d->append((char*)&it->first, sizeof it->first);
 
@@ -108,11 +108,12 @@ bool User::serialize(string* d)
         d->append((char*)&ll, sizeof ll);
         d->append(it->second.data(), ll);
 
-        if (attrsv.find(it->first) != attrsv.end())
+        auto attrsvIt = attrsv.find(it->first);
+        if (attrsvIt != attrsv.cend())
         {
-            ll = (unsigned short)attrsv[it->first].size();
+            ll = (unsigned short)attrsvIt->second.size();
             d->append((char*)&ll, sizeof ll);
-            d->append(attrsv[it->first].data(), ll);
+            d->append(attrsvIt->second.data(), ll);
         }
         else
         {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -50,12 +50,6 @@ string toHandle(handle h)
     return string(base64Handle);
 }
 
-Cachable::Cachable()
-{
-    dbid = 0;
-    notified = 0;
-}
-
 CacheableWriter::CacheableWriter(string& d)
     : dest(d)
 {
@@ -394,7 +388,7 @@ TextChat::~TextChat()
     delete userpriv;
 }
 
-bool TextChat::serialize(string *d)
+bool TextChat::serialize(string *d) const
 {
     unsigned short ll;
 
@@ -447,7 +441,7 @@ bool TextChat::serialize(string *d)
         ll = (unsigned short)attachedNodes.size();  // number of nodes with granted access
         d->append((char*)&ll, sizeof ll);
 
-        for (attachments_map::iterator it = attachedNodes.begin(); it != attachedNodes.end(); it++)
+        for (auto it = attachedNodes.cbegin(); it != attachedNodes.cend(); it++)
         {
             d->append((char*)&it->first, sizeof it->first); // nodehandle
 


### PR DESCRIPTION
- Fix spelling from `Cachable` to `Cacheable`
- Make `Cacheable::serialize` const
- Fix type of `Cacheable::dbid`

Note: Making `serialize` const is controversial because `Node::serialize` currently calls non-const methods (applykey, setattr). Calling these methods from outside of  `Node::serialize` is a non-trivial change.
