### PR TITLE
#14228. Send the fetchnodes "f" command in a separate batch

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -158,7 +158,7 @@ static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::
 {
     auto toLower = [](std::string& s)
     {
-        for (char& c : s) { c = static_cast<char>(std::tolower(c)); };
+        for (char& c : s) { c = static_cast<char>(tolower(c)); };
     };
 
     toLower(type);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1943,6 +1943,9 @@ void CommandLogin::procresult()
                     client->sessionkey.assign((const char *)sek, sizeof(sek));
                 }
 
+                // fetch the unshareable key straight away, so we have it before fetchnodes-from-server completes .
+                client->reqs.add(new CommandUnshareableUA(client, true, 5));
+
                 return client->app->login_result(API_OK);
 
             default:

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4917,6 +4917,9 @@ CommandFetchNodes::CommandFetchNodes(MegaClient* client, bool nocache)
         arg("ca", 1);
     }
 
+    // The servers are more efficient with this command when it's the only one in the batch
+    batchSeparately = true;
+
     tag = client->reqtag;
 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -10905,21 +10905,13 @@ void MegaClient::fetchnodes(bool nocache)
                 getuserdata();
             }
 
+            reqs.add(new CommandGetUA(this, uid.c_str(), ATTR_DISABLE_VERSIONS, NULL, 0));
+
             fetchtimezone();
             reqs.add(new CommandGetUA(this, uid.c_str(), ATTR_PUSH_SETTINGS, NULL, 0));
         }
 
         reqs.add(new CommandFetchNodes(this, nocache));
-
-        if (!loggedinfolderlink())
-        {
-            reqs.add(new CommandGetUA(this, uid.c_str(), ATTR_DISABLE_VERSIONS, NULL, 0));
-        }
-    }
-
-    if (unshareablekey.empty() && !loggedinfolderlink())
-    {
-        reqs.add(new CommandUnshareableUA(this, true, 5));
     }
 }
 


### PR DESCRIPTION
The servers can process that more efficiently
Also, fixed std::tolower call in megacli which expects two parameters - just call ::tolower.