### PR TITLE
#14277. use unique_ptr to guarantee ownership of FA data

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -101,7 +101,6 @@ struct MEGA_API HttpReqCommandPutFA : public HttpReq, public Command
 {
     handle th;    // if th is UNDEF, just report the handle back to the client app rather than attaching to a node
     fatype type;
-    string* data;
     m_off_t progressreported;
 
     void procresult();
@@ -109,8 +108,10 @@ struct MEGA_API HttpReqCommandPutFA : public HttpReq, public Command
     // progress information
     virtual m_off_t transferred(MegaClient*);
 
-    HttpReqCommandPutFA(MegaClient*, handle, fatype, string*, bool);
-    ~HttpReqCommandPutFA();
+    HttpReqCommandPutFA(MegaClient*, handle, fatype, std::unique_ptr<string> faData, bool);
+
+private:
+    std::unique_ptr<string> data;
 };
 
 class MEGA_API CommandGetFA : public Command

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -465,7 +465,7 @@ public:
     void putnodes(const char*, NewNode*, int);
 
     // attach file attribute to upload or node handle
-    void putfa(handle, fatype, SymmCipher*, string*, bool checkAccess = true);
+    void putfa(handle, fatype, SymmCipher*, std::unique_ptr<string>, bool checkAccess = true);
 
     // queue file attribute retrieval
     error getfa(handle h, string *fileattrstring, const string &nodekey, fatype, int = 0);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -32,10 +32,11 @@
 #include "mega/mediafileattribute.h"
 
 namespace mega {
-HttpReqCommandPutFA::HttpReqCommandPutFA(MegaClient* client, handle cth, fatype ctype, string* cdata, bool checkAccess)
+HttpReqCommandPutFA::HttpReqCommandPutFA(MegaClient* client, handle cth, fatype ctype, std::unique_ptr<string> cdata, bool checkAccess)
+    : data(move(cdata))
 {
     cmd("ufa");
-    arg("s", cdata->size());
+    arg("s", data->size());
 
     if (checkAccess)
     {
@@ -53,16 +54,10 @@ HttpReqCommandPutFA::HttpReqCommandPutFA(MegaClient* client, handle cth, fatype 
 
     th = cth;
     type = ctype;
-    data = cdata;
 
     binary = true;
 
     tag = client->reqtag;
-}
-
-HttpReqCommandPutFA::~HttpReqCommandPutFA()
-{
-    delete data;
 }
 
 void HttpReqCommandPutFA::procresult()

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -193,7 +193,7 @@ int GfxProc::checkevents(Waiter *)
                 mCheckEventsKey.setkey(job->key);
                 int creqtag = client->reqtag;
                 client->reqtag = 0;
-                client->putfa(job->h, job->imagetypes[i], &mCheckEventsKey, job->images[i], job->flag);
+                client->putfa(job->h, job->imagetypes[i], &mCheckEventsKey, std::unique_ptr<string>(job->images[i]), job->flag);
                 client->reqtag = creqtag;
             }
             else

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19423,7 +19423,7 @@ void MegaApiImpl::sendPendingRequests()
                     break;
                 }
 
-                client->putfa(node ? node->nodehandle : INVALID_HANDLE, (fatype)type, bu ? bu->nodecipher(client) : node->nodecipher(), attributedata.release());
+                client->putfa(node ? node->nodehandle : INVALID_HANDLE, (fatype)type, bu ? bu->nodecipher(client) : node->nodecipher(), std::move(attributedata));
             }
             break;
         }


### PR DESCRIPTION
Make sure that the compiler would complain if the string containing the file attribute data was changed between the API request and the metad upload.
Also make sure that the string is deleted correctly.
There was no functional problem, but knowing the compiler was checking those things would have made a recent investigation quicker.