### PR TITLE
removed extra definition of USER_AGENT

### DIFF
--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -37,8 +37,6 @@ using namespace std;
 
 MegaFileSystemAccess fileSystemAccess;
 
-string USER_AGENT = "Integration Tests with GoogleTest framework";
-
 #ifdef _WIN32
 #if (__cplusplus >= 201700L)
 namespace fs = std::filesystem;


### PR DESCRIPTION
Due to changes in PR 1728 and PR 1758 USER_AGENT ended up declared twice, both in SdkTest_test.cpp and main.cpp, which generates compilation problems.
The one in SdkTest_test.cpp is removed so only the one in main.cpp is left.

