### PR TITLE
#14444. Fix crashwhen the uploaded file was already modified upon completion

### DIFF
--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -1020,6 +1020,7 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
                     client->syncdownrequired = true;
                 }
 #endif
+                it++; // the next line will remove the current item and invalidate that iterator
                 removeTransferFile(API_EREAD, f, &committer);
             }
             else


### PR DESCRIPTION
`removeTransferFile()` removes the file from the transfer's list of files, so we have to take care that we don't use an invalidated iterator after calling it.
This is a long-standing bug, only occurring in rare cases.