### PR TITLE
#14318. Notify failed transfer upon overquota

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -397,7 +397,7 @@ void DemoApp::transfer_update(Transfer* /*t*/)
     // (this is handled in the prompt logic)
 }
 
-void DemoApp::transfer_failed(Transfer* t, error e, dstime)
+void DemoApp::transfer_failed(Transfer* t, error e, dstime, handle)
 {
     displaytransferdetails(t, "failed (");
     cout << errorstring(e) << ")" << endl;

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -3779,7 +3779,6 @@ void uploadLocalPath(nodetype_t type, std::string name, std::string localname, N
     }
     else if (type == FOLDERNODE && recursive)
     {
-
         if (previousNode)
         {
             if (previousNode->type == FILENODE)

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -208,7 +208,7 @@ struct DemoApp : public MegaApp
     void transfer_added(Transfer*) override;
     void transfer_removed(Transfer*) override;
     void transfer_prepare(Transfer*) override;
-    void transfer_failed(Transfer*, error, dstime) override;
+    void transfer_failed(Transfer*, error, dstime, handle) override;
     void transfer_update(Transfer*) override;
     void transfer_complete(Transfer*) override;
 

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -506,11 +506,12 @@ class MEGA_API CommandPutNodes : public Command
     targettype_t type;
     putsource_t source;
     handle targethandle;
+    Transfer *transfer;
 
 public:
     void procresult();
 
-    CommandPutNodes(MegaClient*, handle, const char*, NewNode*, int, int, putsource_t = PUTNODES_APP, const char *cauth = NULL);
+    CommandPutNodes(MegaClient*, handle, const char*, NewNode*, int, int, putsource_t = PUTNODES_APP, const char *cauth = nullptr, Transfer *aTransfer = nullptr);
 };
 
 class MEGA_API CommandSetAttr : public Command

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -277,7 +277,7 @@ struct MEGA_API MegaApp
     virtual void transfer_added(Transfer*) { }
     virtual void transfer_removed(Transfer*) { }
     virtual void transfer_prepare(Transfer*) { }
-    virtual void transfer_failed(Transfer*, error, dstime = 0) { }
+    virtual void transfer_failed(Transfer*, error, dstime = 0, handle = UNDEF) { }
     virtual void transfer_update(Transfer*) { }
     virtual void transfer_complete(Transfer*) { }
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1539,9 +1539,6 @@ public:
     // manage overquota errors
     void activateoverquota(dstime timeleft);
 
-    // manage a foreign overquota error
-    void processForeignOverquota(handle targetHandle);
-
     // achievements enabled for the account
     bool achievements_enabled;
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1534,7 +1534,7 @@ public:
     void acknowledgeuseralerts();
 
     // manage overquota errors
-    void activateoverquota(dstime timeleft);
+    void activateoverquota(dstime timeleft, handle targetHandle = UNDEF);
 
     // manage a foreign overquota error
     void processForeignOverquota(handle targetHandle);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1537,7 +1537,7 @@ public:
     void acknowledgeuseralerts();
 
     // manage overquota errors
-    void activateoverquota(dstime timeleft, handle targetHandle = UNDEF);
+    void activateoverquota(dstime timeleft);
 
     // manage a foreign overquota error
     void processForeignOverquota(handle targetHandle);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1536,6 +1536,9 @@ public:
     // manage overquota errors
     void activateoverquota(dstime timeleft);
 
+    // manage a foreign overquota error
+    void processForeignOverquota(handle targetHandle);
+
     // achievements enabled for the account
     bool achievements_enabled;
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -416,6 +416,9 @@ public:
     // move node to new parent folder
     error rename(Node*, Node*, syncdel_t = SYNCDEL_NONE, handle = UNDEF);
 
+    // find a transfer by fingerprint and target type (private/foreign) in transfers or cached transfers
+    transfer_map::iterator getPutTransferByFileFingerprint(FileFingerprint *f, bool foreign, bool cached = false);
+
     // start/stop/pause file transfer
     bool startxfer(direction_t, File*, DBTableTransactionCommitter&, bool skipdupes = false, bool startfirst = false, bool donotpersist = false);
     void stopxfer(File* f, DBTableTransactionCommitter* committer);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -417,7 +417,7 @@ public:
     error rename(Node*, Node*, syncdel_t = SYNCDEL_NONE, handle = UNDEF);
 
     // find a transfer by fingerprint and target type (private/foreign) in transfers or cached transfers
-    transfer_map::iterator getTransferByFileFingerprint(FileFingerprint *f, direction_t d, bool foreign, bool cached = false);
+    transfer_map::iterator getTransferByFileFingerprint(FileFingerprint *f, transfer_map &transfers, bool foreign);
 
     // start/stop/pause file transfer
     bool startxfer(direction_t, File*, DBTableTransactionCommitter&, bool skipdupes = false, bool startfirst = false, bool donotpersist = false);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -417,7 +417,7 @@ public:
     error rename(Node*, Node*, syncdel_t = SYNCDEL_NONE, handle = UNDEF);
 
     // find a transfer by fingerprint and target type (private/foreign) in transfers or cached transfers
-    transfer_map::iterator getPutTransferByFileFingerprint(FileFingerprint *f, bool foreign, bool cached = false);
+    transfer_map::iterator getTransferByFileFingerprint(FileFingerprint *f, direction_t d, bool foreign, bool cached = false);
 
     // start/stop/pause file transfer
     bool startxfer(direction_t, File*, DBTableTransactionCommitter&, bool skipdupes = false, bool startfirst = false, bool donotpersist = false);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -462,10 +462,10 @@ public:
 
     // add nodes to specified parent node (complete upload, copy files, make
     // folders)
-    void putnodes(handle, NewNode*, int, const char * = NULL);
+    void putnodes(handle, NewNode*, int, const char * = nullptr, Transfer * = nullptr);
 
     // send files/folders to user
-    void putnodes(const char*, NewNode*, int);
+    void putnodes(const char*, NewNode*, int, Transfer * = nullptr);
 
     // attach file attribute to upload or node handle
     void putfa(handle, fatype, SymmCipher*, std::unique_ptr<string>, bool checkAccess = true);

--- a/include/mega/pubkeyaction.h
+++ b/include/mega/pubkeyaction.h
@@ -66,11 +66,12 @@ class MEGA_API PubKeyActionPutNodes : public PubKeyAction
 {
     NewNode* nn;    // nodes to add
     int nc;         // number of nodes to add
+    Transfer *transfer;
 
 public:
     void proc(MegaClient*, User*);
 
-    PubKeyActionPutNodes(NewNode*, int, int);
+    PubKeyActionPutNodes(NewNode*, int, int, Transfer *);
 };
 
 class MEGA_API PubKeyActionNotifyApp : public PubKeyAction

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -102,6 +102,9 @@ struct MEGA_API Transfer : public FileFingerprint
     MegaClient* client;
     int tag;
 
+    // returns true if the transfer contains any foreign target
+    bool isForeign();
+
     // signal failure
     void failed(error, DBTableTransactionCommitter&, dstime = 0);
 

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -106,7 +106,7 @@ struct MEGA_API Transfer : public FileFingerprint
     bool isForeign();
 
     // signal failure
-    void failed(error, DBTableTransactionCommitter&, dstime = 0);
+    void failed(error, DBTableTransactionCommitter&, dstime = 0, handle targetHandle = UNDEF);
 
     // signal completion
     void complete(DBTableTransactionCommitter&);

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -102,7 +102,7 @@ struct MEGA_API Transfer : public FileFingerprint
     MegaClient* client;
     int tag;
 
-    // returns true if the transfer contains any foreign target
+    // returns true if the transfer contains foreign targets, false if targets are private
     bool isForeign();
 
     // signal failure

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -309,7 +309,7 @@ typedef list<struct TransferSlot*> transferslot_list;
 typedef list<HttpReqCommandPutFA*> putfa_list;
 
 // map a FileFingerprint to the transfer for that FileFingerprint
-typedef map<FileFingerprint*, Transfer*, FileFingerprintCmp> transfer_map;
+typedef multimap<FileFingerprint*, Transfer*, FileFingerprintCmp> transfer_map;
 
 typedef deque<Transfer*> transfer_list;
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -308,7 +308,10 @@ typedef list<struct TransferSlot*> transferslot_list;
 // FIXME: use forward_list instad (C++11)
 typedef list<HttpReqCommandPutFA*> putfa_list;
 
-// map a FileFingerprint to the transfer for that FileFingerprint
+/* maps a FileFingerprint to the transfer for that FileFingerprint,
+ * this map can contain two items for the same key (FileFingerprint)
+ * depending on the type of target (private/foreign) associated to the PUT transfers
+ */
 typedef multimap<FileFingerprint*, Transfer*, FileFingerprintCmp> transfer_map;
 
 typedef deque<Transfer*> transfer_list;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2873,7 +2873,7 @@ protected:
         File* file_resume(string*, direction_t *type) override;
 
         void transfer_prepare(Transfer*) override;
-        void transfer_failed(Transfer*, error error, dstime timeleft) override;
+        void transfer_failed(Transfer*, error error, dstime timeleft, handle targetHandle = UNDEF) override;
         void transfer_update(Transfer*) override;
 
         dstime pread_failure(error, int, void*, dstime) override;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1349,6 +1349,7 @@ void CommandMoveNode::procresult()
         error e = (error)client->json.getint();
         if (e == API_EOVERQUOTA)
         {
+            assert(client->isPrivateNode(np));  // moves not allowed
             client->activateoverquota(0);
         }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1203,6 +1203,23 @@ void CommandPutNodes::procresult()
             {
                 client->activateoverquota(0);
             }
+//            else
+//            {
+//                // TBD: should ongoing foreign transfers fail in case we detect the target account is overquota?
+//                // It comes at the cost of iterate through all transfers upon EOVERQUOTA for any foreign target.
+//                for (auto &itTransfers : transfers[PUT])
+//                {
+//                    Transfer *transfer = itTransfers.second;
+//                    for (file_list::iterator itFiles = transfer->files.begin(); itFiles != transfer->files.end();)
+//                    {
+//                        File *file = (*itFiles++);
+//                        if (file->h == targetHandle)
+//                        {
+//                            transfer->failed(API_EOVERQUOTA, *mTctableRequestCommitter, 0, targetHandle);
+//                        }
+//                    }
+//                }
+//            }
         }
 #ifdef ENABLE_SYNC
         if (source == PUTNODES_SYNC)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1192,9 +1192,14 @@ void CommandPutNodes::procresult()
         LOG_debug << "Putnodes error " << e;
         if (e == API_EOVERQUOTA)
         {
-            (client->isForeignNode(targethandle))
-                ? client->activateoverquota(0)
-                : client->processForeignOverquota(targethandle);
+            if (client->isForeignNode(targethandle))
+            {
+                client->processForeignOverquota(targethandle);
+            }
+            else
+            {
+                client->activateoverquota(0);
+            }
         }
 #ifdef ENABLE_SYNC
         if (source == PUTNODES_SYNC)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1192,7 +1192,9 @@ void CommandPutNodes::procresult()
         LOG_debug << "Putnodes error " << e;
         if (e == API_EOVERQUOTA)
         {
-            client->activateoverquota(0);
+            (client->isForeignNode(targethandle))
+                ? client->activateoverquota(0)
+                : client->processForeignOverquota(targethandle);
         }
 #ifdef ENABLE_SYNC
         if (source == PUTNODES_SYNC)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1367,11 +1367,10 @@ void CommandMoveNode::procresult()
     if (client->json.isnumeric())
     {
         error e = (error)client->json.getint();
-        if (e == API_EOVERQUOTA)
-        {
-            assert(client->isPrivateNode(np));  // moves not allowed
-            client->activateoverquota(0);
-        }
+
+        // movements should not result on overquota error
+        // (also, a movement between different accounts is not allowed, but performed by copy+delete)
+        assert(e != API_EOVERQUOTA);
 
 #ifdef ENABLE_SYNC
         if (syncdel != SYNCDEL_NONE)

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -330,7 +330,7 @@ void File::completed(Transfer* t, LocalNode* l)
             // drop file into targetuser's inbox
             int creqtag = t->client->reqtag;
             t->client->reqtag = tag;
-            t->client->putnodes(targetuser.c_str(), newnode, 1);
+            t->client->putnodes(targetuser.c_str(), newnode, 1, t);
             t->client->reqtag = creqtag;
         }
         else
@@ -372,9 +372,9 @@ void File::completed(Transfer* t, LocalNode* l)
                                                                   newnode, 1,
                                                                   tag,
 #ifdef ENABLE_SYNC
-                                                                  l ? PUTNODES_SYNC : PUTNODES_APP));
+                                                                  l ? PUTNODES_SYNC : PUTNODES_APP, nullptr, t));
 #else
-                                                                  PUTNODES_APP));
+                                                                  PUTNODES_APP, nullptr, t));
 #endif
         }
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -11320,7 +11320,7 @@ char *MegaApiImpl::getFingerprint(MegaNode *n)
     return MegaApi::strdup(n->getFingerprint());
 }
 
-void MegaApiImpl::transfer_failed(Transfer* t, error e, dstime timeleft)
+void MegaApiImpl::transfer_failed(Transfer* t, error e, dstime timeleft, handle targetHandle)
 {
     for (file_list::iterator it = t->files.begin(); it != t->files.end(); it++)
     {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -11325,7 +11325,11 @@ void MegaApiImpl::transfer_failed(Transfer* t, error e, dstime timeleft, handle 
     for (file_list::iterator it = t->files.begin(); it != t->files.end(); it++)
     {
         MegaTransferPrivate* transfer = getMegaTransferPrivate((*it)->tag);
-        if (!transfer)
+
+        // uploads with multiple targets may fail for some targets, but success for other ones --> only notify failed ones
+        if (!transfer
+            || (t->type == PUT && targetHandle != UNDEF
+                    && (transfer->getParentHandle() != targetHandle)))
         {
             continue;
         }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17780,7 +17780,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                         else
                         {
                             MegaTransferPrivate* prevTransfer = NULL;
-                            transfer_map::iterator it = client->getTransferByFileFingerprint(f, PUT, client->isForeignNode(f->h));
+                            transfer_map::iterator it = client->getTransferByFileFingerprint(f, client->transfers[PUT], client->isForeignNode(f->h));
                             if (it != client->transfers[PUT].end())
                             {
                                 Transfer *t = it->second;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17780,9 +17780,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                         else
                         {
                             MegaTransferPrivate* prevTransfer = NULL;
-                            transfer_map::iterator it = client->transfers[PUT].find(f);
-                            // TODO: need to find the corresponding transfer for the given target (the foreign one, or the private one)
-                            // transfer_map::iterator it = client->transfers[PUT].find(pair<FileFingerprint*, bool>(f, client->isForeignNode(f->h)));
+                            transfer_map::iterator it = client->getPutTransferByFileFingerprint(f, client->isForeignNode(f->h));
                             if (it != client->transfers[PUT].end())
                             {
                                 Transfer *t = it->second;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17780,7 +17780,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                         else
                         {
                             MegaTransferPrivate* prevTransfer = NULL;
-                            transfer_map::iterator it = client->getPutTransferByFileFingerprint(f, client->isForeignNode(f->h));
+                            transfer_map::iterator it = client->getTransferByFileFingerprint(f, PUT, client->isForeignNode(f->h));
                             if (it != client->transfers[PUT].end())
                             {
                                 Transfer *t = it->second;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -11328,8 +11328,7 @@ void MegaApiImpl::transfer_failed(Transfer* t, error e, dstime timeleft, handle 
 
         // uploads with multiple targets may fail for some targets, but success for other ones --> only notify failed ones
         if (!transfer
-            || (t->type == PUT && targetHandle != UNDEF
-                    && (transfer->getParentHandle() != targetHandle)))
+            || (t->type == PUT && !ISUNDEF(targetHandle) && transfer->getParentHandle() != targetHandle))
         {
             continue;
         }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -17781,6 +17781,8 @@ unsigned MegaApiImpl::sendPendingTransfers()
                         {
                             MegaTransferPrivate* prevTransfer = NULL;
                             transfer_map::iterator it = client->transfers[PUT].find(f);
+                            // TODO: need to find the corresponding transfer for the given target (the foreign one, or the private one)
+                            // transfer_map::iterator it = client->transfers[PUT].find(pair<FileFingerprint*, bool>(f, client->isForeignNode(f->h)));
                             if (it != client->transfers[PUT].end())
                             {
                                 Transfer *t = it->second;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -942,9 +942,8 @@ void MegaClient::activateoverquota(dstime timeleft)
             }
         }
     }
-    else
+    else if (setstoragestatus(STORAGE_RED))
     {
-        setstoragestatus(STORAGE_RED);
         for (transfer_map::iterator it = transfers[PUT].begin(); it != transfers[PUT].end(); it++)
         {
             Transfer *t = it->second;
@@ -955,8 +954,8 @@ void MegaClient::activateoverquota(dstime timeleft)
                 continue;
             }
 
-            if (t->slot && t->state != TRANSFERSTATE_RETRYING)
             t->bt.backoff(NEVER);
+            if (t->slot)
             {
                 t->state = TRANSFERSTATE_RETRYING;
                 t->slot->retrybt.backoff(NEVER);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -927,6 +927,7 @@ void MegaClient::activateoverquota(dstime timeleft)
     }
     else if (setstoragestatus(STORAGE_RED))
     {
+        LOG_warn << "Storage overquota";
         for (transfer_map::iterator it = transfers[PUT].begin(); it != transfers[PUT].end(); it++)
         {
             Transfer *t = it->second;
@@ -4857,7 +4858,6 @@ bool MegaClient::setstoragestatus(storagestatus_t status)
         app->notify_storage(ststatus);
         if (pststatus == STORAGE_RED)
         {
-            LOG_warn << "Storage overquota";
             abortbackoff(true);
         }
         return true;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -900,7 +900,6 @@ void MegaClient::acknowledgeuseralerts()
     useralerts.acknowledgeAll();
 }
 
-void MegaClient::activateoverquota(dstime timeleft)
 void MegaClient::processForeignOverquota(handle targetHandle)
 {
     assert(!ISUNDEF(targetHandle));
@@ -929,6 +928,7 @@ void MegaClient::processForeignOverquota(handle targetHandle)
     }
 }
 
+void MegaClient::activateoverquota(dstime timeleft, handle targetHandle)
 {
     if (timeleft)
     {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -948,7 +948,6 @@ void MegaClient::activateoverquota(dstime timeleft)
         for (transfer_map::iterator it = transfers[PUT].begin(); it != transfers[PUT].end(); it++)
         {
             Transfer *t = it->second;
-            t->bt.backoff(NEVER);
 
             // skip transfers with foreign targets
             if (t->isForeign())
@@ -957,6 +956,7 @@ void MegaClient::activateoverquota(dstime timeleft)
             }
 
             if (t->slot && t->state != TRANSFERSTATE_RETRYING)
+            t->bt.backoff(NEVER);
             {
                 t->state = TRANSFERSTATE_RETRYING;
                 t->slot->retrybt.backoff(NEVER);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13527,11 +13527,11 @@ void MegaClient::putnodes_syncdebris_result(error, NewNode* nn)
 }
 #endif
 
-transfer_map::iterator MegaClient::getPutTransferByFileFingerprint(FileFingerprint *f, bool foreign, bool cached)
+transfer_map::iterator MegaClient::getTransferByFileFingerprint(FileFingerprint *f, direction_t d, bool foreign, bool cached)
 {
-    transfer_map &auxTransfers = cached ? cachedtransfers[PUT] : transfers[PUT];
+    transfer_map &auxTransfers = cached ? cachedtransfers[d] : transfers[d];
     pair<transfer_map::iterator, transfer_map::iterator> itMultimap = auxTransfers.equal_range(f);
-    assert(std::distance(itMultimap.first, itMultimap.second) <= 2);
+    assert(d != PUT || std::distance(itMultimap.first, itMultimap.second) <= 2);
     for (transfer_map::iterator itTransfers = itMultimap.first; itTransfers != itMultimap.second; ++itTransfers)
     {
         if (itTransfers->second->isForeign() == foreign)
@@ -13585,7 +13585,7 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
 
         Transfer* t = NULL;
         bool reuseTransfer = false;
-        transfer_map::iterator it = getPutTransferByFileFingerprint(f, isForeignNode(f->h));
+        transfer_map::iterator it = getTransferByFileFingerprint(f, d, isForeignNode(f->h));
         bool foundTransfer = it != transfers[d].end();
         if (foundTransfer)
         {
@@ -13639,7 +13639,7 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
         }
         else // No transfer found
         {
-            transfer_map::iterator it = getPutTransferByFileFingerprint(f, isForeignNode(f->h), true);
+            transfer_map::iterator it = getTransferByFileFingerprint(f, d, isForeignNode(f->h), true);
             if (it != cachedtransfers[d].end())
             {
                 LOG_debug << "Resumable transfer detected";

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13588,8 +13588,8 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
         Transfer* t = NULL;
         bool reuseTransfer = false;
         transfer_map::iterator it = transfers[d].find(f);
+        // TODO: need to find the corresponding transfer for the given target (the foreign one, or the private one)
         bool foundTransfer = it != transfers[d].end();
-
         if (foundTransfer)
         {
             t = it->second;
@@ -13643,6 +13643,7 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
         else // No transfer found
         {
             it = cachedtransfers[d].find(f);
+            // TODO: need to find the corresponding transfer for the given target (the foreign one, or the private one)
             if (it != cachedtransfers[d].end())
             {
                 LOG_debug << "Resumable transfer detected";
@@ -13735,7 +13736,7 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
             t->lastaccesstime = m_time();
             t->tag = reqtag;
             f->tag = reqtag;
-            t->transfers_it = transfers[d].insert(pair<FileFingerprint*, Transfer*>((FileFingerprint*)t, t)).first;
+            t->transfers_it = transfers[d].insert(pair<FileFingerprint*, Transfer*>((FileFingerprint*)t, t));
 
             f->file_it = t->files.insert(t->files.end(), f);
             f->transfer = t;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -909,7 +909,7 @@ void MegaClient::processForeignOverquota(handle targetHandle)
         for (file_list::iterator itFiles = transfer->files.begin(); itFiles != transfer->files.end();)
         {
             File *file = (*itFiles++);
-            if (file->h == targetHandle)// && file->tag == transfer->tag)
+            if (file->h == targetHandle)
             {
                 transfer->failed(API_EOVERQUOTA, *mTctableRequestCommitter, 0, targetHandle);
             }
@@ -6823,13 +6823,13 @@ void MegaClient::putnodes_prepareOneFolder(NewNode* newnode, std::string foldern
 }
 
 // send new nodes to API for processing
-void MegaClient::putnodes(handle h, NewNode* newnodes, int numnodes, const char *cauth)
+void MegaClient::putnodes(handle h, NewNode* newnodes, int numnodes, const char *cauth, Transfer *t)
 {
-    reqs.add(new CommandPutNodes(this, h, NULL, newnodes, numnodes, reqtag, PUTNODES_APP, cauth));
+    reqs.add(new CommandPutNodes(this, h, NULL, newnodes, numnodes, reqtag, PUTNODES_APP, cauth, t));
 }
 
 // drop nodes into a user's inbox (must have RSA keypair)
-void MegaClient::putnodes(const char* user, NewNode* newnodes, int numnodes)
+void MegaClient::putnodes(const char* user, NewNode* newnodes, int numnodes, Transfer *transfer)
 {
     User* u;
 
@@ -6840,7 +6840,7 @@ void MegaClient::putnodes(const char* user, NewNode* newnodes, int numnodes)
         return app->putnodes_result(API_EARGS, USER_HANDLE, newnodes);
     }
 
-    queuepubkeyreq(user, new PubKeyActionPutNodes(newnodes, numnodes, reqtag));
+    queuepubkeyreq(user, new PubKeyActionPutNodes(newnodes, numnodes, reqtag, transfer));
 }
 
 // returns 1 if node has accesslevel a or better, 0 otherwise

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -917,7 +917,7 @@ void MegaClient::processForeignOverquota(handle targetHandle)
     }
 }
 
-void MegaClient::activateoverquota(dstime timeleft, handle targetHandle)
+void MegaClient::activateoverquota(dstime timeleft)
 {
     if (timeleft)
     {
@@ -961,7 +961,7 @@ void MegaClient::activateoverquota(dstime timeleft, handle targetHandle)
                 t->state = TRANSFERSTATE_RETRYING;
                 t->slot->retrybt.backoff(NEVER);
                 t->slot->retrying = true;
-                app->transfer_failed(t, API_EOVERQUOTA, 0, targetHandle);
+                app->transfer_failed(t, API_EOVERQUOTA, 0);
                 ++performanceStats.transferTempErrors;
             }
         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13531,6 +13531,7 @@ transfer_map::iterator MegaClient::getPutTransferByFileFingerprint(FileFingerpri
 {
     transfer_map &auxTransfers = cached ? cachedtransfers[PUT] : transfers[PUT];
     pair<transfer_map::iterator, transfer_map::iterator> itMultimap = auxTransfers.equal_range(f);
+    assert(std::distance(itMultimap.first, itMultimap.second) <= 2);
     for (transfer_map::iterator itTransfers = itMultimap.first; itTransfers != itMultimap.second; ++itTransfers)
     {
         if (itTransfers->second->isForeign() == foreign)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -900,23 +900,6 @@ void MegaClient::acknowledgeuseralerts()
     useralerts.acknowledgeAll();
 }
 
-void MegaClient::processForeignOverquota(handle targetHandle)
-{
-    assert(!ISUNDEF(targetHandle));
-    for (auto &itTransfers : transfers[PUT])
-    {
-        Transfer *transfer = itTransfers.second;
-        for (file_list::iterator itFiles = transfer->files.begin(); itFiles != transfer->files.end();)
-        {
-            File *file = (*itFiles++);
-            if (file->h == targetHandle)
-            {
-                transfer->failed(API_EOVERQUOTA, *mTctableRequestCommitter, 0, targetHandle);
-            }
-        }
-    }
-}
-
 void MegaClient::activateoverquota(dstime timeleft)
 {
     if (timeleft)

--- a/src/pubkeyaction.cpp
+++ b/src/pubkeyaction.cpp
@@ -29,11 +29,12 @@ PubKeyAction::PubKeyAction()
     cmd = NULL; 
 }
 
-PubKeyActionPutNodes::PubKeyActionPutNodes(NewNode* newnodes, int numnodes, int ctag)
+PubKeyActionPutNodes::PubKeyActionPutNodes(NewNode* newnodes, int numnodes, int ctag, Transfer *aTransfer)
 {
     nn = newnodes;
     nc = numnodes;
     tag = ctag;
+    transfer = aTransfer;
 }
 
 void PubKeyActionPutNodes::proc(MegaClient* client, User* u)
@@ -54,7 +55,7 @@ void PubKeyActionPutNodes::proc(MegaClient* client, User* u)
             nn[i].nodekey.assign((char*)buf, t);
         }
 
-        client->reqs.add(new CommandPutNodes(client, UNDEF, u->uid.c_str(), nn, nc, tag));
+        client->reqs.add(new CommandPutNodes(client, UNDEF, u->uid.c_str(), nn, nc, tag, PUTNODES_APP, nullptr, transfer));
     }
     else
     {

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -414,7 +414,7 @@ void Transfer::failed(error e, DBTableTransactionCommitter& committer, dstime ti
         }
         else
         {
-            // if storage overquota and transfer with foreign targets, tranfer failed permanently
+            // if storage overquota and transfer with foreign targets, transfer failed permanently
             if (!timeleft && isForeign())
             {
                 client->app->transfer_failed(this, API_EOVERQUOTA, 0, targetHandle);

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -373,6 +373,16 @@ void Transfer::removeTransferFile(error e, File* f, DBTableTransactionCommitter*
     f->terminated();
 }
 
+bool Transfer::isForeign()
+{
+    if (files.empty())
+    {
+        return false;
+    }
+
+    return client->isForeignNode((*files.begin())->h);
+}
+
 // transfer attempt failed, notify all related files, collect request on
 // whether to abort the transfer, kill transfer if unanimous
 void Transfer::failed(error e, DBTableTransactionCommitter& committer, dstime timeleft)

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -404,9 +404,9 @@ void Transfer::failed(error e, DBTableTransactionCommitter& committer, dstime ti
     {
         if (!slot)
         {
-            bt.backoff(timeleft ? timeleft : NEVER);
             if (!isForeign())
             {
+                bt.backoff(timeleft ? timeleft : NEVER);
                 client->activateoverquota(timeleft);
             }
             client->app->transfer_failed(this, e, timeleft, targetHandle);

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -385,7 +385,7 @@ bool Transfer::isForeign()
 
 // transfer attempt failed, notify all related files, collect request on
 // whether to abort the transfer, kill transfer if unanimous
-void Transfer::failed(error e, DBTableTransactionCommitter& committer, dstime timeleft)
+void Transfer::failed(error e, DBTableTransactionCommitter& committer, dstime timeleft, handle targetHandle)
 {
     bool defer = false;
 

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -381,7 +381,7 @@ bool Transfer::isForeign()
     }
 
     // only need to check one target, since all target should be foreign or private, but not a mix
-    return client->isForeignNode((*files.begin())->h);
+    return client->isForeignNode(files.front()->h);
 }
 
 // transfer attempt failed, notify all related files, collect request on


### PR DESCRIPTION
**Introduction:** the storage used by inshares does not count on for your own account, but for the foreign account. Hence, overquota errors need to consider whether the error is relative to our own account being/becoming overquota, or it's relative to the foreign account being overquota. 
The management of transfers failed by overquota should depend on the target: foreign account or private account. Private transfers should fail temporary upon overquota, while foreign transfers should fail permanently (despite the temporary error is also notified).

**Solution:** since a fresh upload may fail for certain targets, but not all of them, the final `p` for each target (a `Transfer` may have multiple targets), we have decided to not mix foreign targets and private targets in the same `Transfer` object, since it overcomplicates things upon an overquota error. To achieve that, the `transfer_map` has been changed to a multimap (that way, for the same file, it can store a transfer with private targets and another one with foreign targets).
Finally, the `p` commands are linked to the corresponding `Transfer`, so in case of overquota the corresponding `MegaTransfer` is reported as failed, but not the other `MegaTransfer`s associated with the `Transfer`.