### PR TITLE
Use pragma once for header file inclusions

### DIFF
--- a/bindings/qt/QTMegaEvent.h
+++ b/bindings/qt/QTMegaEvent.h
@@ -1,5 +1,4 @@
-#ifndef QTMEGAEVENT_H
-#define QTMEGAEVENT_H
+#pragma once
 
 #include <megaapi.h>
 #include <QEvent>
@@ -81,5 +80,3 @@ private:
 };
 
 }
-
-#endif // QTMEGAEVENT_H

--- a/bindings/qt/QTMegaGlobalListener.h
+++ b/bindings/qt/QTMegaGlobalListener.h
@@ -1,5 +1,4 @@
-#ifndef QTMEGAGLOBALLISTENER_H
-#define QTMEGAGLOBALLISTENER_H
+#pragma once
 
 #include <QObject>
 #include "megaapi.h"
@@ -28,5 +27,3 @@ protected:
     MegaGlobalListener *listener;
 };
 }
-
-#endif // QTMEGAGLOBALLISTENER_H

--- a/bindings/qt/QTMegaListener.h
+++ b/bindings/qt/QTMegaListener.h
@@ -1,5 +1,4 @@
-﻿#ifndef QTMEGALISTENER_H
-#define QTMEGALISTENER_H
+﻿#pragma once
 
 #include <QObject>
 #include "megaapi.h"
@@ -42,5 +41,3 @@ protected:
 	MegaListener *listener;
 };
 }
-
-#endif // QTMEGALISTENER_H

--- a/bindings/qt/QTMegaRequestListener.h
+++ b/bindings/qt/QTMegaRequestListener.h
@@ -1,5 +1,4 @@
-#ifndef QTMEGAREQUESTLISTENER_H
-#define QTMEGAREQUESTLISTENER_H
+#pragma once
 
 #include <QObject>
 #include "megaapi.h"
@@ -27,5 +26,3 @@ protected:
     MegaApi *megaApi;
 };
 }
-
-#endif // QTMEGAREQUESTLISTENER_H

--- a/bindings/qt/QTMegaSyncListener.h
+++ b/bindings/qt/QTMegaSyncListener.h
@@ -1,5 +1,4 @@
-#ifndef QTMEGALISTENER_H
-#define QTMEGALISTENER_H
+#pragma once
 
 #ifdef ENABLE_SYNC
 
@@ -28,5 +27,3 @@ protected:
 }
 
 #endif //ENABLE_SYNC
-
-#endif // QTMEGALISTENER_H

--- a/bindings/qt/QTMegaTransferListener.h
+++ b/bindings/qt/QTMegaTransferListener.h
@@ -1,5 +1,4 @@
-#ifndef QTMEGATRANSFERLISTENER_H
-#define QTMEGATRANSFERLISTENER_H
+#pragma once
 
 #include <QObject>
 #include <megaapi.h>
@@ -27,5 +26,3 @@ protected:
 	MegaTransferListener *listener;
 };
 }
-
-#endif // QTMEGATRANSFERLISTENER_H


### PR DESCRIPTION
Improve header inclusion using pragma once instead of include guards