### PR TITLE
Fix for crash integration tests

### DIFF
--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -804,6 +804,11 @@ void SdkTest::getMegaApiAux(unsigned index)
 
 void SdkTest::releaseMegaApi(unsigned int apiIndex)
 {
+    if (mApi.size() <= apiIndex)
+    {
+        return;
+    }
+
     assert(megaApi[apiIndex].get() == mApi[apiIndex].megaApi);
     if (mApi[apiIndex].megaApi)
     {

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -238,6 +238,7 @@ void SdkTest::TearDown()
     deleteFile(AVATARDST);
 
     releaseMegaApi(1);
+    releaseMegaApi(2);
 
     if (megaApi[0])
     {        

--- a/tests/unit/Sync_test.cpp
+++ b/tests/unit/Sync_test.cpp
@@ -1064,7 +1064,7 @@ void test_SyncConfig_serialization(const mega::SyncConfig& config)
     std::string data;
     const_cast<mega::SyncConfig&>(config).serialize(&data);
     auto newConfig = mega::SyncConfig::unserialize(data);
-    ASSERT_TRUE(newConfig);
+    ASSERT_TRUE(newConfig != nullptr);
     ASSERT_EQ(config, *newConfig);
 }
 


### PR DESCRIPTION
The `SdkTest` instance is destroyed right after `TearDown`. For tests that instantiate a 3rd instance of `MegaApi`, since it used to not be deleted, the dtor of `SdkTest` destroys it (unique_ptr). During
destruction, it calls back the `SdkTest` --> segfault.