### PR TITLE
logging support for partial lines & log without buffering

### DIFF
--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -179,7 +179,11 @@ class SimpleLogger
         *mBufferIt = '\0';
         if (continues)
         {
-            *(mBufferIt+1) = (char)0x1F;
+            *(mBufferIt + 1) = (char)0x1F;
+        }
+        else
+        {
+            *(mBufferIt + 1) = '\0';
         }
         if (logger)
         {

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -151,7 +151,7 @@ class SimpleLogger
     static OutputStreams getOutput(enum LogLevel ll);
 #else
     std::array<char, 256> mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
-    std::array<char, 257>::iterator mBufferIt;
+    std::array<char, 256>::iterator mBufferIt;
     using DiffType = std::array<char, 256>::difference_type;
     using NumBuf = std::array<char, 24>;
     const char* filenameStr;
@@ -163,9 +163,9 @@ class SimpleLogger
         DiffType start = 0;
         while (currentSize > 0)
         {
-            const auto size = std::min(currentSize, std::distance(mBufferIt, mBuffer.end() - 1));
+            const auto size = std::min(currentSize, std::distance(mBufferIt, mBuffer.end() - 2));
             mBufferIt = std::copy(dataIt + start, dataIt + start + size, mBufferIt);
-            if (mBufferIt == mBuffer.end() - 1)
+            if (mBufferIt == mBuffer.end() - 2)
             {
                 outputBuffer(true);
             }

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -156,6 +156,9 @@ class SimpleLogger
     using NumBuf = std::array<char, 24>;
     const char* filenameStr;
     int lineNum;
+    int outputted = 0;
+    static const int immediate_threshold = 1024;
+    bool immediate = false;
 
     template<typename DataIterator>
     void copyToBuffer(const DataIterator dataIt, DiffType currentSize)
@@ -179,11 +182,27 @@ class SimpleLogger
         *mBufferIt = '\0';
         if (continues)
         {
-            *(mBufferIt + 1) = (char)0x1F;
+            if (outputted > immediate_threshold)
+            {
+                *(mBufferIt + 1) = (char)0x1E;
+                immediate = true;
+            }
+            else
+            {
+                outputted+=mBuffer.size() - 1;
+                *(mBufferIt + 1) = (char)0x1F;
+            }
         }
         else
         {
-            *(mBufferIt + 1) = '\0';
+            if (immediate)
+            {
+                *(mBufferIt + 1) = (char)0x1D;
+            }
+            else
+            {
+                *(mBufferIt + 1) = '\0';
+            }
         }
         if (logger)
         {

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -151,7 +151,7 @@ class SimpleLogger
     static OutputStreams getOutput(enum LogLevel ll);
 #else
     std::array<char, 256> mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
-    std::array<char, 256>::iterator mBufferIt;
+    std::array<char, 257>::iterator mBufferIt;
     using DiffType = std::array<char, 256>::difference_type;
     using NumBuf = std::array<char, 24>;
     const char* filenameStr;
@@ -167,16 +167,20 @@ class SimpleLogger
             mBufferIt = std::copy(dataIt + start, dataIt + start + size, mBufferIt);
             if (mBufferIt == mBuffer.end() - 1)
             {
-                outputBuffer();
+                outputBuffer(true);
             }
             start += size;
             currentSize -= size;
         }
     }
 
-    void outputBuffer()
+    void outputBuffer(bool continues = false)
     {
         *mBufferIt = '\0';
+        if (continues)
+        {
+            *(mBufferIt+1) = (char)0x1F;
+        }
         if (logger)
         {
             logger->log(nullptr, level, nullptr, mBuffer.data());

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -365,8 +365,21 @@ public:
      *
      * The SDK retains the ownership of this string, it won't be valid after this funtion returns.
      *
+     * @param partial the message is partial
+     *
+     * Only a part of a logging line has been provided.
+     *
+     * @param requiresDirectOutput the message should be written immediatly
+     *
+     * The SDK will set this value to true for very long lines, so that the application
+     * takes this into consideration in order no to buffer the line completely.
+     *
      */
-    virtual void log(const char *time, int loglevel, const char *source, const char *message);
+    virtual void log(const char *time, int loglevel, const char *source, const char *message
+                 #ifdef ENABLE_LOG_PERFORMANCE
+                                      , bool partial, bool requiresDirectOutput
+                 #endif
+                     );
     virtual ~MegaLogger(){}
 };
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -365,11 +365,9 @@ public:
      *
      * The SDK retains the ownership of this string, it won't be valid after this funtion returns.
      *
-     * @param partial the message is partial
+     * @param continues the log line continues: there will be more calls to log: no need for break line.
      *
-     * Only a part of a logging line has been provided.
-     *
-     * @param requiresDirectOutput the message should be written immediatly
+     * @param requiresDirectOutput the message should be written immediatly to disk before returning the execution.
      *
      * The SDK will set this value to true for very long lines, so that the application
      * takes this into consideration in order no to buffer the line completely.
@@ -377,7 +375,7 @@ public:
      */
     virtual void log(const char *time, int loglevel, const char *source, const char *message
                  #ifdef ENABLE_LOG_PERFORMANCE
-                                      , bool partial, bool requiresDirectOutput
+                                      , bool continues, bool requiresDirectOutput
                  #endif
                      );
     virtual ~MegaLogger(){}

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -138,7 +138,7 @@ public:
     void setLogToConsole(bool enable);
     void postLog(int logLevel, const char *message, const char *filename, int line);
 #ifdef ENABLE_LOG_PERFORMANCE
-    void log(const char *time, int loglevel, const char *source, const char *message, bool partial = false, bool requiresDirectOutput = false) override;
+    void log(const char *time, int loglevel, const char *source, const char *message, bool continues = false, bool requiresDirectOutput = false) override;
 #else
     void log(const char *time, int loglevel, const char *source, const char *message) override;
 #endif

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -137,7 +137,11 @@ public:
     void setLogLevel(int logLevel);
     void setLogToConsole(bool enable);
     void postLog(int logLevel, const char *message, const char *filename, int line);
+#ifdef ENABLE_LOG_PERFORMANCE
+    void log(const char *time, int loglevel, const char *source, const char *message, bool partial = false, bool requiresDirectOutput = false) override;
+#else
     void log(const char *time, int loglevel, const char *source, const char *message) override;
+#endif
 
 private:
     std::recursive_mutex mutex;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5257,7 +5257,12 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
     return false;
 }
 
-void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/)
+void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
+#ifdef ENABLE_LOG_PERFORMANCE
+                     , bool /*partial*/, bool /*requiresDirectOutput*/
+#endif
+
+                     )
 {
 
 }

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5259,7 +5259,7 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
 
 void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , bool /*partial*/, bool /*requiresDirectOutput*/
+                     , bool /*continues*/, bool /*requiresDirectOutput*/
 #endif
 
                      )

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22372,7 +22372,11 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 #endif
 }
 
+#ifdef ENABLE_LOG_PERFORMANCE
+void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message, bool partial, bool requiresDirectOutput)
+#else
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message)
+#endif
 {
     if (!time)
     {
@@ -22394,7 +22398,12 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
 #endif
     for (auto logger : megaLoggers)
     {
+#ifdef ENABLE_LOG_PERFORMANCE
+        logger->log(time, loglevel, source, message, partial, requiresDirectOutput);
+#else
         logger->log(time, loglevel, source, message);
+#endif
+
     }
 
     if (logToConsole)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22373,7 +22373,7 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 }
 
 #ifdef ENABLE_LOG_PERFORMANCE
-void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message, bool partial, bool requiresDirectOutput)
+void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message, bool continues, bool requiresDirectOutput)
 #else
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message)
 #endif
@@ -22399,7 +22399,7 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
     for (auto logger : megaLoggers)
     {
 #ifdef ENABLE_LOG_PERFORMANCE
-        logger->log(time, loglevel, source, message, partial, requiresDirectOutput);
+        logger->log(time, loglevel, source, message, continues, requiresDirectOutput);
 #else
         logger->log(time, loglevel, source, message);
 #endif


### PR DESCRIPTION
change log call to include parameters that indicate the app that a message is to be continued (partial)
and that needs immediate outputting to disk (after reaching certain threshold size)