### PR TITLE
#14159. Ensure the sync's resumable flag is not reset

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -450,6 +450,9 @@ public:
 
     // A collection of sync configs backed by a database table
     std::unique_ptr<SyncConfigBag> syncConfigs;
+
+    // whether we allow the automatic resumption of syncs
+    bool allowAutoResumeSyncs = true;
 #endif
 
     // if set, symlinks will be followed except in recursive deletions

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19024,19 +19024,9 @@ void MegaApiImpl::sendPendingRequests()
                 nocache = false;
             }
 
-#ifdef ENABLE_SYNC
-            const bool resumeSyncs = request->getNumber();
-            if (!resumeSyncs && client->syncConfigs)
-            {
-                for (auto config : client->syncConfigs->all())
-                {
-                    config.setResumable(false);
-                    client->syncConfigs->insert(config);
-                }
-            }
-#endif
-
+            client->allowAutoResumeSyncs = request->getNumber();
             client->fetchnodes();
+            client->allowAutoResumeSyncs = true;
             break;
         }
         case MegaRequest::TYPE_GET_CLOUD_STORAGE_USED:

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3704,7 +3704,8 @@ void MegaClient::freeq(direction_t d)
 #ifdef ENABLE_SYNC
 void MegaClient::resumeResumableSyncs()
 {
-    if (!syncConfigs)
+
+    if (!syncConfigs || !allowAutoResumeSyncs)
     {
         return;
     }


### PR DESCRIPTION
Previously, if a client would call `fetchNodes` they would cause all sync configs to become unresumable so a subsequent call to `fetchNodesAndResumeSyncs` would not resume syncs. This PR fixes that by adding a simple boolean to MegaClient.
