### PR TITLE
Fix early evaluation of ENABLE_CHAT ENABLE_SYNC

### DIFF
--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -21,7 +21,7 @@
 
 // Many of these tests are still being worked on.
 // The file uses some C++17 mainly for the very convenient std::filesystem library, though the main SDK must still build with C++11 (and prior)
-#ifdef ENABLE_SYNC
+
 
 #include "test.h"
 #include <mega.h>
@@ -34,6 +34,8 @@
 #include <atomic>
 
 #include <megaapi_impl.h>
+
+#ifdef ENABLE_SYNC
 
 using namespace ::mega;
 using namespace ::std;

--- a/tests/unit/Sync_test.cpp
+++ b/tests/unit/Sync_test.cpp
@@ -15,7 +15,6 @@
  * You should have received a copy of the license along with this
  * program.
  */
-#ifdef ENABLE_SYNC
 
 #include <memory>
 
@@ -33,6 +32,8 @@
 #include "DefaultedFileAccess.h"
 #include "DefaultedFileSystemAccess.h"
 #include "utils.h"
+
+#ifdef ENABLE_SYNC
 
 namespace {
 

--- a/tests/unit/TextChat_test.cpp
+++ b/tests/unit/TextChat_test.cpp
@@ -15,7 +15,7 @@
  * You should have received a copy of the license along with this
  * program.
  */
-#ifdef ENABLE_CHAT
+
 #include <gtest/gtest.h>
 
 #include <mega/megaclient.h>
@@ -24,6 +24,8 @@
 
 #include "DefaultedFileSystemAccess.h"
 #include "utils.h"
+
+#ifdef ENABLE_CHAT
 
 namespace
 {


### PR DESCRIPTION
Using the current Qt configuration the macros ENABLE_CHAT and ENABLE_SYNC are given with -D to the compiler, but the autotools left the definitions in the config.h file. If ENABLE_CHAT and ENABLE_SYNC are evaluated before the header where they are defined is loaded, they will always appear as undefined.
The evaluation of the macros has been moved after the #includes, so they could be evaluated with the value in config.h