### PR TITLE
#14658. Prevent to confirm accounts other than the logged-in

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -1562,7 +1562,7 @@ typedef NS_ENUM(NSInteger, AffiliateType) {
 - (void)fastSendSignupLinkWithEmail:(NSString *)email base64pwkey:(NSString *)base64pwkey name:(NSString *)name __attribute__((deprecated("This function only works using the old registration method and will be removed soon. Please use [MEGASdk sendSignupLinkWithEmail:name:password:] instead.")));
 
 /**
- * @brief Get information about a confirmation link.
+ * @brief Get information about a confirmation link or a new signup link.
  *
  * The associated request type with this request is MEGARequestTypeQuerySignUpLink.
  * Valid data in the MEGARequest object received on all callbacks:
@@ -1572,6 +1572,20 @@ typedef NS_ENUM(NSInteger, AffiliateType) {
  * is MEGAErrorTypeApiOk:
  * - [MEGARequest email] - Return the email associated with the confirmation link.
  * - [MEGARequest name] - Returns the name associated with the confirmation link.
+ * - [MEGARequest flag] - Returns true if the account was automatically confirmed, otherwise false
+ 
+ * If [MEGARequest flag] returns YES, the account was automatically confirmed and it's not needed
+ * to call [MEGASdk confirmAccountWithLink:password:delegate]. If it returns NO, it's needed to call [MEGASdk confirmAccountWithLink:password:delegate]
+ * as usual. New accounts (V2, starting from April 2018) do not require a confirmation with the password,
+ * but old confirmation links (V1) require it, so it's needed to check that parameter in onRequestFinish
+ * to know how to proceed.
+ *
+ * If already logged-in into a different account, you will get the error code MEGAErrorTypeApiEAccess
+ * in onRequestFinish.
+ * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
+ * will get the error code MEGAErrorTypeApiEExpired in onRequestFinish.
+ * In both cases, the [MEGARequest email] will return the email of the account that was attempted
+ * to confirm, and the [MEGARequest name] will return the name.
  *
  * @param link Confirmation link
  * @param delegate Delegate to track this request
@@ -1579,7 +1593,7 @@ typedef NS_ENUM(NSInteger, AffiliateType) {
 - (void)querySignupLink:(NSString *)link delegate:(id<MEGARequestDelegate>)delegate;
 
 /**
- * @brief Get information about a confirmation link.
+ * @brief Get information about a confirmation link or a new signup link.
  *
  * The associated request type with this request is MEGARequestTypeQuerySignUpLink.
  * Valid data in the MEGARequest object received on all callbacks:
@@ -1589,6 +1603,20 @@ typedef NS_ENUM(NSInteger, AffiliateType) {
  * is MEGAErrorTypeApiOk:
  * - [MEGARequest email] - Return the email associated with the confirmation link.
  * - [MEGARequest name] - Returns the name associated with the confirmation link.
+ * - [MEGARequest flag] - Returns true if the account was automatically confirmed, otherwise false
+ 
+ * If [MEGARequest flag] returns YES, the account was automatically confirmed and it's not needed
+ * to call [MEGASdk confirmAccountWithLink:password:delegate]. If it returns NO, it's needed to call [MEGASdk confirmAccountWithLink:password:delegate]
+ * as usual. New accounts (V2, starting from April 2018) do not require a confirmation with the password,
+ * but old confirmation links (V1) require it, so it's needed to check that parameter in onRequestFinish
+ * to know how to proceed.
+ *
+ * If already logged-in into a different account, you will get the error code MEGAErrorTypeApiEAccess
+ * in onRequestFinish.
+ * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
+ * will get the error code MEGAErrorTypeApiEExpired in onRequestFinish.
+ * In both cases, the [MEGARequest email] will return the email of the account that was attempted
+ * to confirm, and the [MEGARequest name] will return the name.
  *
  * @param link Confirmation link.
  */
@@ -1606,6 +1634,18 @@ typedef NS_ENUM(NSInteger, AffiliateType) {
  * is MEGAErrorTypeApiOk:
  * - [MEGARequest email] - Email of the account
  * - [MEGARequest name] - Name of the user
+ *
+ * As a result of a successfull confirmation, the app will receive the callback
+ * [MEGADelegate onEvent: event:] and [MEGAGlobalDelegate onEvent: event:] with an event of type
+ * EventAccountConfirmation. You can check the email used to confirm
+ * the account by checking [MEGAEvent text]. @see [MEGADelegate onEvent: event:].
+ *
+ * If already logged-in into a different account, you will get the error code MEGAErrorTypeApiEAccess
+ * in onRequestFinish.
+ * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
+ * will get the error code MEGAErrorTypeApiEExpired in onRequestFinish.
+ * In both cases, the [MEGARequest email] will return the email of the account that was attempted
+ * to confirm, and the [MEGARequest name] will return the name.
  *
  * @param link Confirmation link.
  * @param password Password for the account.
@@ -1625,6 +1665,18 @@ typedef NS_ENUM(NSInteger, AffiliateType) {
  * is MEGAErrorTypeApiOk:
  * - [MEGARequest email] - Email of the account
  * - [MEGARequest name] - Name of the user
+ *
+ * As a result of a successfull confirmation, the app will receive the callback
+ * [MEGADelegate onEvent: event:] and [MEGAGlobalDelegate onEvent: event:] with an event of type
+ * EventAccountConfirmation. You can check the email used to confirm
+ * the account by checking [MEGAEvent text]. @see [MEGADelegate onEvent: event:].
+ *
+ * If already logged-in into a different account, you will get the error code MEGAErrorTypeApiEAccess
+ * in onRequestFinish.
+ * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
+ * will get the error code MEGAErrorTypeApiEExpired in onRequestFinish.
+ * In both cases, the [MEGARequest email] will return the email of the account that was attempted
+ * to confirm, and the [MEGARequest name] will return the name.
  *
  * @param link Confirmation link.
  * @param password Password for the account.

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -7909,10 +7909,11 @@ class MegaApi
          * to know how to proceed.
          *
          * If already logged-in into a different account, you will get the error code MegaError::API_EACCESS
-         * in onRequestFinish. The MegaRequest::getEmail will return the email of the account that was attempted
-         * to confirm.
+         * in onRequestFinish.
          * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
          * will get the error code MegaError::API_EEXPIRED in onRequestFinish.
+         * In both cases, the MegaRequest::getEmail will return the email of the account that was attempted
+         * to confirm, and the MegaRequest::getName will return the name.
          *
          * @param link Confirmation link (#confirm) or new signup link (#newsignup)
          * @param listener MegaRequestListener to track this request
@@ -7938,10 +7939,11 @@ class MegaApi
          * the account by checking MegaEvent::getText. @see MegaListener::onEvent.
          *
          * If already logged-in into a different account, you will get the error code MegaError::API_EACCESS
-         * in onRequestFinish. The MegaRequest::getEmail will return the email of the account that was attempted
-         * to confirm.
+         * in onRequestFinish.
          * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
          * will get the error code MegaError::API_EEXPIRED in onRequestFinish.
+         * In both cases, the MegaRequest::getEmail will return the email of the account that was attempted
+         * to confirm, and the MegaRequest::getName will return the name.
          *
          * @param link Confirmation link
          * @param password Password of the account

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -7895,7 +7895,6 @@ class MegaApi
          * The associated request type with this request is MegaRequest::TYPE_QUERY_SIGNUP_LINK.
          * Valid data in the MegaRequest object received on all callbacks:
          * - MegaRequest::getLink - Returns the confirmation link
-         * - MegaRequest::getParamType - Returns 1 for V1 accounts, 2 for V2 accounts (available only for confirmation links)
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
@@ -7927,7 +7926,6 @@ class MegaApi
          * Valid data in the MegaRequest object received on callbacks:
          * - MegaRequest::getLink - Returns the confirmation link
          * - MegaRequest::getPassword - Returns the password
-         * - MegaRequest::getParamType - Returns 1 for V1 accounts, 2 for V2 accounts (available only for confirmation links)
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -7895,6 +7895,7 @@ class MegaApi
          * The associated request type with this request is MegaRequest::TYPE_QUERY_SIGNUP_LINK.
          * Valid data in the MegaRequest object received on all callbacks:
          * - MegaRequest::getLink - Returns the confirmation link
+         * - MegaRequest::getParamType - Returns 1 for V1 accounts, 2 for V2 accounts (available only for confirmation links)
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
@@ -7904,8 +7905,15 @@ class MegaApi
          *
          * If MegaRequest::getFlag returns true, the account was automatically confirmed and it's not needed
          * to call MegaApi::confirmAccount. If it returns false, it's needed to call MegaApi::confirmAccount
-         * as usual. New accounts do not require a confirmation with the password, but old confirmation links
-         * require it, so it's needed to check that parameter in onRequestFinish to know how to proceed.
+         * as usual. New accounts (V2, starting from April 2018) do not require a confirmation with the password,
+         * but old confirmation links (V1) require it, so it's needed to check that parameter in onRequestFinish
+         * to know how to proceed.
+         *
+         * If already logged-in into a different account, you will get the error code MegaError::API_EACCESS
+         * in onRequestFinish. The MegaRequest::getEmail will return the email of the account that was attempted
+         * to confirm.
+         * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
+         * will get the error code MegaError::API_EEXPIRED in onRequestFinish.
          *
          * @param link Confirmation link (#confirm) or new signup link (#newsignup)
          * @param listener MegaRequestListener to track this request
@@ -7919,6 +7927,7 @@ class MegaApi
          * Valid data in the MegaRequest object received on callbacks:
          * - MegaRequest::getLink - Returns the confirmation link
          * - MegaRequest::getPassword - Returns the password
+         * - MegaRequest::getParamType - Returns 1 for V1 accounts, 2 for V2 accounts (available only for confirmation links)
          *
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
@@ -7929,6 +7938,12 @@ class MegaApi
          * MegaListener::onEvent and MegaGlobalListener::onEvent with an event of type
          * MegaEvent::EVENT_ACCOUNT_CONFIRMATION. You can check the email used to confirm
          * the account by checking MegaEvent::getText. @see MegaListener::onEvent.
+         *
+         * If already logged-in into a different account, you will get the error code MegaError::API_EACCESS
+         * in onRequestFinish. The MegaRequest::getEmail will return the email of the account that was attempted
+         * to confirm.
+         * If logged-in into the account that is attempted to confirm and the account is already confirmed, you
+         * will get the error code MegaError::API_EEXPIRED in onRequestFinish.
          *
          * @param link Confirmation link
          * @param password Password of the account

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19929,7 +19929,24 @@ void MegaApiImpl::sendPendingRequests()
                 {
                     if (len > 13 && !memcmp("ConfirmCodeV2", c, 13))
                     {
-                        client->confirmsignuplink2(c, len);
+                        // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars)
+                        if (len >= 13+16+5)
+                        {
+                            const byte *email = c + 13 + 16;
+                            size_t lenEmail = len - 13 - 16;
+                            if (strncmp(client->uid.c_str(), (const char *)email, lenEmail) == 0)
+                            {
+                                client->confirmsignuplink2(c, len);
+                            }
+                            else
+                            {
+                                e = API_EACCESS;
+                            }
+                        }
+                        else
+                        {
+                            e = API_EARGS;
+                        }
                     }
                     else
                     {
@@ -20005,7 +20022,24 @@ void MegaApiImpl::sendPendingRequests()
             {
                 if (len > 13 && !memcmp("ConfirmCodeV2", c, 13))
                 {
-                    client->confirmsignuplink2(c, len);
+                    // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars)
+                    if (len >= 13+16+5)
+                    {
+                        const byte *email = c + 13 + 16;
+                        size_t lenEmail = len - 13 - 16;
+                        if (strncmp(client->uid.c_str(), (const char *)email, lenEmail) == 0)
+                        {
+                            client->confirmsignuplink2(c, len);
+                        }
+                        else
+                        {
+                            e = API_EACCESS;
+                        }
+                    }
+                    else
+                    {
+                        e = API_EARGS;
+                    }
                 }
                 else if (!password && !pwkey)
                 {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19929,14 +19929,14 @@ void MegaApiImpl::sendPendingRequests()
                 {
                     if (code.find("ConfirmCodeV2") != string::npos)
                     {
-                        // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname || Hash (15B)
+                        // “ConfirmCodeV2” (13B) || Email Confirmation Token (15B) || Email (>=5B) || \t || Fullname || Hash (8B)
                         size_t posEmail = 13 + 15;
                         size_t endEmail = code.find("\t", posEmail);
                         if (endEmail != string::npos)
                         {
                             string email = code.substr(posEmail, endEmail - posEmail);
                             request->setEmail(email.c_str());
-                            request->setName(code.substr(endEmail, code.size() - 15).c_str());
+                            request->setName(code.substr(endEmail + 1, code.size() - endEmail - 9).c_str());
 
                             sessiontype_t session = client->loggedin();
                             if (session == FULLACCOUNT)
@@ -20024,14 +20024,14 @@ void MegaApiImpl::sendPendingRequests()
             {
                 if (code.find("ConfirmCodeV2") != string::npos)
                 {
-                    // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname || Hash (15B)
+                    // “ConfirmCodeV2” (13B) || Email Confirmation Token (15B) || Email (>=5B) || \t || Fullname || Hash (8B)
                     size_t posEmail = 13 + 15;
                     size_t endEmail = code.find("\t", posEmail);
                     if (endEmail != string::npos)
                     {
                         string email = code.substr(posEmail, endEmail - posEmail);
                         request->setEmail(email.c_str());
-                        request->setName(code.substr(endEmail, code.size() - 15).c_str());
+                        request->setName(code.substr(endEmail + 1, code.size() - endEmail - 9).c_str());
 
                         sessiontype_t session = client->loggedin();
                         if (session == FULLACCOUNT)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19922,21 +19922,19 @@ void MegaApiImpl::sendPendingRequests()
             {
                 ptr = tptr+8;
 
-                unsigned len = unsigned((strlen(link)-(ptr-link))*3/4+4);
-                byte *c = new byte[len];
-                len = Base64::atob(ptr,c,len);
-                if (len)
+                string code = Base64::atob(string(ptr));
+                if (!code.empty())
                 {
-                    if (len > 13 && !memcmp("ConfirmCodeV2", c, 13))
+                    if (code.find("ConfirmCodeV2") != string::npos)
                     {
                         // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars)
-                        if (len >= 13+16+5)
+
+                        if (code.size() >= 13+16+5)
                         {
-                            const byte *email = c + 13 + 16;
-                            size_t lenEmail = len - 13 - 16;
-                            if (strncmp(client->uid.c_str(), (const char *)email, lenEmail) == 0)
+                            string email = code.substr(13+15, code.find("\t", 13+15));
+                            if (client->uid == email)
                             {
-                                client->confirmsignuplink2(c, len);
+                                client->confirmsignuplink2((const byte*)code.data(), code.size());
                             }
                             else
                             {
@@ -19950,14 +19948,13 @@ void MegaApiImpl::sendPendingRequests()
                     }
                     else
                     {
-                        client->querysignuplink(c, len);
+                        client->querysignuplink((const byte*)code.data(), code.size());
                     }
                 }
                 else
                 {
                     e = API_EARGS;
                 }
-                delete[] c;
                 break;
             }
             else if ((tptr = strstr(ptr,"#newsignup")))
@@ -20015,21 +20012,19 @@ void MegaApiImpl::sendPendingRequests()
 
             if ((tptr = strstr(ptr,"#confirm"))) ptr = tptr+8;
 
-            unsigned len = unsigned((strlen(link)-(ptr-link))*3/4+4);
-            byte *c = new byte[len];
-            len = Base64::atob(ptr,c,len);
-            if (len)
+            string code = Base64::atob(string(ptr));
+            if (!code.empty())
             {
-                if (len > 13 && !memcmp("ConfirmCodeV2", c, 13))
+                if (code.find("ConfirmCodeV2") != string::npos)
                 {
                     // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars)
-                    if (len >= 13+16+5)
+
+                    if (code.size() >= 13+16+5)
                     {
-                        const byte *email = c + 13 + 16;
-                        size_t lenEmail = len - 13 - 16;
-                        if (strncmp(client->uid.c_str(), (const char *)email, lenEmail) == 0)
+                        string email = code.substr(13+15, code.find("\t", 13+15));
+                        if (client->uid == email)
                         {
-                            client->confirmsignuplink2(c, len);
+                            client->confirmsignuplink2((const byte*)code.data(), code.size());
                         }
                         else
                         {
@@ -20047,14 +20042,13 @@ void MegaApiImpl::sendPendingRequests()
                 }
                 else
                 {
-                    client->querysignuplink(c, len);
+                    client->querysignuplink((const byte*)code.data(), code.size());
                 }
             }
             else
             {
                 e = API_EARGS;
             }
-            delete[] c;
             break;
         }
         case MegaRequest::TYPE_GET_RECOVERY_LINK:

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -15329,7 +15329,6 @@ void MegaApiImpl::querysignuplink_result(handle uh, const char* email, const cha
         e = API_EACCESS;
     }
     
-    // TODO: decide whether finish the request here for V2, or to proceed with auto-confirmation, as by now
     if(request->getType() == MegaRequest::TYPE_QUERY_SIGNUP_LINK || e)
     {
         fireOnRequestFinish(request, MegaError(e));
@@ -15392,6 +15391,7 @@ void MegaApiImpl::confirmsignuplink2_result(handle, const char *name, const char
     if (!e)
     {
         assert(strcmp(email, request->getEmail()) == 0);
+        assert(strcmp(name, request->getName()) == 0);
         request->setName(name);
         request->setEmail(email);
         request->setFlag(true);
@@ -19929,13 +19929,14 @@ void MegaApiImpl::sendPendingRequests()
                 {
                     if (code.find("ConfirmCodeV2") != string::npos)
                     {
-                        // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname || Hash
+                        // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname || Hash (15B)
                         size_t posEmail = 13 + 15;
                         size_t endEmail = code.find("\t", posEmail);
                         if (endEmail != string::npos)
                         {
                             string email = code.substr(posEmail, endEmail - posEmail);
                             request->setEmail(email.c_str());
+                            request->setName(code.substr(endEmail, code.size() - 15).c_str());
 
                             sessiontype_t session = client->loggedin();
                             if (session == FULLACCOUNT)
@@ -20023,13 +20024,14 @@ void MegaApiImpl::sendPendingRequests()
             {
                 if (code.find("ConfirmCodeV2") != string::npos)
                 {
-                    // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname || Hash
+                    // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname || Hash (15B)
                     size_t posEmail = 13 + 15;
                     size_t endEmail = code.find("\t", posEmail);
                     if (endEmail != string::npos)
                     {
-                        string email = code.substr(posEmail, endEmail);
+                        string email = code.substr(posEmail, endEmail - posEmail);
                         request->setEmail(email.c_str());
+                        request->setName(code.substr(endEmail, code.size() - 15).c_str());
 
                         sessiontype_t session = client->loggedin();
                         if (session == FULLACCOUNT)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19927,11 +19927,12 @@ void MegaApiImpl::sendPendingRequests()
                 {
                     if (code.find("ConfirmCodeV2") != string::npos)
                     {
-                        // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars)
-
-                        if (code.size() >= 13+16+5)
+                        // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname
+                        size_t posEmail = 13 + 15;
+                        size_t endEmail = code.find("\t", posEmail);
+                        if (endEmail != string::npos)
                         {
-                            string email = code.substr(13+15, code.find("\t", 13+15));
+                            string email = code.substr(posEmail, endEmail);
                             if (client->uid == email)
                             {
                                 client->confirmsignuplink2((const byte*)code.data(), code.size());
@@ -20017,11 +20018,12 @@ void MegaApiImpl::sendPendingRequests()
             {
                 if (code.find("ConfirmCodeV2") != string::npos)
                 {
-                    // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars)
-
-                    if (code.size() >= 13+16+5)
+                    // “ConfirmCodeV2” || Email Confirmation Token (128 bits) || Email (>=5 chars) || \t || Fullname
+                    size_t posEmail = 13 + 15;
+                    size_t endEmail = code.find("\t", posEmail);
+                    if (endEmail != string::npos)
                     {
-                        string email = code.substr(13+15, code.find("\t", 13+15));
+                        string email = code.substr(posEmail, endEmail);
                         if (client->uid == email)
                         {
                             client->confirmsignuplink2((const byte*)code.data(), code.size());

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -15313,7 +15313,7 @@ void MegaApiImpl::querysignuplink_result(error e)
     fireOnRequestFinish(request, megaError);
 }
 
-void MegaApiImpl::querysignuplink_result(handle, const char* email, const char* name, const byte* pwc, const byte*, const byte* c, size_t len)
+void MegaApiImpl::querysignuplink_result(handle uh, const char* email, const char* name, const byte* pwc, const byte*, const byte* c, size_t len)
 {
     if(requestMap.find(client->restag) == requestMap.end()) return;
     MegaRequestPrivate* request = requestMap.at(client->restag);
@@ -15323,9 +15323,15 @@ void MegaApiImpl::querysignuplink_result(handle, const char* email, const char* 
     request->setEmail(email);
     request->setName(name);
 
-    if(request->getType() == MegaRequest::TYPE_QUERY_SIGNUP_LINK)
+    error e = API_OK;
+    if (uh != client->me)
     {
-        fireOnRequestFinish(request, MegaError(API_OK));
+        e = API_EACCESS;
+    }
+    
+    if(request->getType() == MegaRequest::TYPE_QUERY_SIGNUP_LINK || e)
+    {
+        fireOnRequestFinish(request, MegaError(e));
         return;
     }
 


### PR DESCRIPTION
The SDK must check the confirmation link does not correspond to a different account than the logged-in account. If so, it should return `API_EACCESS`. Additionally, for a confirmation request when the SDK is logged into the account that wants to be confirmed, it should return `API_EEXPIRED`.