### PR TITLE
Prevent the discovered write_after_free by disabling the committer be…

### DIFF
--- a/include/mega/db.h
+++ b/include/mega/db.h
@@ -74,6 +74,7 @@ public:
     virtual void remove() = 0;
 
     void checkCommitter(DBTableTransactionCommitter*);
+    void checkNoCommitter();
 
     // autoincrement
     uint32_t nextid;
@@ -86,6 +87,7 @@ class MEGA_API DBTableTransactionCommitter
 {
     DbTable* mTable;
     bool mStarted = false;
+    MEGA_DISABLE_COPY_MOVE(DBTableTransactionCommitter)
 
 public:
     inline void beginOnce()
@@ -97,7 +99,7 @@ public:
         }
     }
 
-    inline void commitNow()
+    inline void commitNow(bool finalCommit = false)
     {
         if (mTable)
         {
@@ -105,6 +107,12 @@ public:
             {
                 mTable->commit();
                 mStarted = false;
+            }
+
+            if (finalCommit)
+            {
+                mTable->mCurrentTransactionCommiter = nullptr;
+                mTable = nullptr;
             }
         }
     }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1164,7 +1164,6 @@ void CommandPutNodes::procresult()
     {
         if (client->tctable)
         {
-            client->mTctableRequestCommitter->beginOnce();
             vector<uint32_t> &ids = it->second;
             for (unsigned int i = 0; i < ids.size(); i++)
             {

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -97,6 +97,11 @@ void DbTable::checkCommitter(DBTableTransactionCommitter* committer)
     assert(!committer || committer == mCurrentTransactionCommiter);
 }
 
+void DbTable::checkNoCommitter()
+{
+    assert(!mCurrentTransactionCommiter);
+}
+
 DbAccess::DbAccess()
 {
     currentDbVersion = LEGACY_DB_VERSION;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19112,6 +19112,7 @@ void MegaApiImpl::sendPendingRequests()
             }
             else
             {
+                committer.commitNow(true);
                 client->locallogout(false);
                 client->restag = nextTag;
                 logout_result(API_OK);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3832,6 +3832,11 @@ void MegaClient::logout()
 
 void MegaClient::locallogout(bool removecaches)
 {
+    if (tctable)
+    {
+        tctable->checkNoCommitter();
+    }
+
     if (removecaches)
     {
         removeCaches();

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -3874,7 +3874,7 @@ TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
 
     int64_t filesize = getFilesize(filename2);
     std::ifstream compareDecryptedFile(filename2.c_str(), ios::binary);
-    ::mega::byte* compareDecryptedData = new ::mega::byte[filesize];
+    ::mega::byte* compareDecryptedData = new ::mega::byte[size_t(filesize)];
     compareDecryptedFile.read((char*)compareDecryptedData, filesize);
 
     m_time_t starttime = m_time();

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -3,6 +3,9 @@
 #include "test.h"
 #include <stdio.h>
 #include <fstream>
+#include <megaconsole.h>
+
+using namespace mega;
 
 bool gRunningInCI = false;
 bool gTestingInvalidArgs = false;


### PR DESCRIPTION
…fore calling locallogout()

Rather than trying to cope with locallogout() clearing all the data structures when the call stack may still have an interest in those structures.
Assert added so we don't accidentally cause this again.
One unneeded commitNow() removed, the db->del() below will invoke it anyway, if needed.
A couple of warnings addressed (in 32 bit)