### PR TITLE
#14515: support direct logging

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -365,8 +365,15 @@ public:
      *
      * The SDK retains the ownership of this string, it won't be valid after this funtion returns.
      *
+     * @param directMessages: in ENABLE_LOG_PERFORMANCE MODE, this will indicate the logger that an array of const char* should
+     * be written in the logs immediately without buffering the output. message can be discarded in that case.
+     *
      */
-    virtual void log(const char *time, int loglevel, const char *source, const char *message);
+    virtual void log(const char *time, int loglevel, const char *source, const char *message
+#ifdef ENABLE_LOG_PERFORMANCE
+                     , std::vector<const char *> directMessages
+#endif
+                     );
     virtual ~MegaLogger(){}
 };
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -25,6 +25,9 @@
 #include <string>
 #include <vector>
 #include <inttypes.h>
+#ifdef ENABLE_LOG_PERFORMANCE
+#include <functional>
+#endif
 
 #ifdef __APPLE__
 #include <TargetConditionals.h>
@@ -371,7 +374,7 @@ public:
      */
     virtual void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , std::vector<const char *> directMessages
+                     , std::function<void(std::ostream&)> largeMessageFunction
 #endif
                      );
     virtual ~MegaLogger(){}

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -139,7 +139,7 @@ public:
     void postLog(int logLevel, const char *message, const char *filename, int line);
     void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-             , std::vector<const char *> directMessages
+             , LogLargeFunction
 #endif
             ) override;
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -137,7 +137,11 @@ public:
     void setLogLevel(int logLevel);
     void setLogToConsole(bool enable);
     void postLog(int logLevel, const char *message, const char *filename, int line);
-    void log(const char *time, int loglevel, const char *source, const char *message) override;
+    void log(const char *time, int loglevel, const char *source, const char *message
+#ifdef ENABLE_LOG_PERFORMANCE
+             , std::vector<const char *> directMessages
+#endif
+            ) override;
 
 private:
     std::recursive_mutex mutex;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -40,7 +40,7 @@ Logger *SimpleLogger::logger = nullptr;
 
 // by the default, display logs with level equal or less than logInfo
 enum LogLevel SimpleLogger::logCurrentLevel = logInfo;
-long long SimpleLogger::maxPayloadLogSize  = 10240;
+uint64_t SimpleLogger::maxPayloadLogSize  = 10240;
 
 #ifndef ENABLE_LOG_PERFORMANCE
 // static member initialization

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5264,7 +5264,7 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
 
 void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , std::vector<const char *> /*directMessages*/
+                     , std::function<void(std::ostream&)> largeMessageFunction /*directMessages*/
 #endif
                      )
 {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5262,7 +5262,11 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
     return false;
 }
 
-void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/)
+void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
+#ifdef ENABLE_LOG_PERFORMANCE
+                     , std::vector<const char *> /*directMessages*/
+#endif
+                     )
 {
 
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22426,7 +22426,7 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-          , std::vector<const char *> directMessages
+          , LogLargeFunction logLargeFunction
 #endif
                          )
 {
@@ -22452,7 +22452,7 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
     {
         logger->log(time, loglevel, source, message
 #ifdef ENABLE_LOG_PERFORMANCE
-                    , directMessages
+                    , logLargeFunction
 #endif
                     );
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22417,13 +22417,18 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 #ifndef ENABLE_LOG_PERFORMANCE
     mutex.lock();
 #endif
+    //For direct logging, we could use DirectMessage(message) here
     SimpleLogger{static_cast<LogLevel>(logLevel), filename, line} << message;
 #ifndef ENABLE_LOG_PERFORMANCE
     mutex.unlock();
 #endif
 }
 
-void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message)
+void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message
+#ifdef ENABLE_LOG_PERFORMANCE
+          , std::vector<const char *> directMessages
+#endif
+                         )
 {
     if (!time)
     {
@@ -22445,7 +22450,11 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
 #endif
     for (auto logger : megaLoggers)
     {
-        logger->log(time, loglevel, source, message);
+        logger->log(time, loglevel, source, message
+#ifdef ENABLE_LOG_PERFORMANCE
+                    , directMessages
+#endif
+                    );
     }
 
     if (logToConsole)

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -1341,12 +1341,14 @@ void CurlHttpIO::send_request(CurlHttpContext* httpctx)
     {
         if (req->out->size() < SimpleLogger::maxPayloadLogSize)
         {
-            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": " << *req->out;
+            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": " << DirectMessage(req->out->c_str(), req->out->size());
         }
         else
         {
-            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": " << req->out->substr(0, SimpleLogger::maxPayloadLogSize / 2)
-                      << " [...] " << req->out->substr(req->out->size() - SimpleLogger::maxPayloadLogSize / 2, string::npos);
+            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": "
+                      << DirectMessage(req->out->substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                      << " [...] " <<
+                         DirectMessage(req->out->substr(req->out->size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str(), SimpleLogger::maxPayloadLogSize / 2);
         }
     }
 
@@ -2138,12 +2140,14 @@ bool CurlHttpIO::multidoio(CURLM *curlmhandle)
                     {
                         if (req->in.size() < SimpleLogger::maxPayloadLogSize)
                         {
-                            LOG_debug << req->logname << "Received " << req->in.size() << ": " << req->in.c_str();
+                            LOG_debug << req->logname << "Received " << req->in.size() << ": " << DirectMessage(req->in.c_str(), req->in.size());
                         }
                         else
                         {
-                            LOG_debug << req->logname << "Received " << req->in.size() << ": " << req->in.substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str()
-                                      << " [...] " << req->in.substr(req->in.size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str();
+                            LOG_debug << req->logname << "Received " << req->in.size() << ": " <<
+                                         DirectMessage(req->in.substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                                      << " [...] "
+                                      << DirectMessage(req->in.substr(req->in.size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str(), SimpleLogger::maxPayloadLogSize / 2);
                         }
                     }
                 }


### PR DESCRIPTION
have Logger::log include a vector of const char* to pass to the app for
direct logging
add DirectMessage class to wrap const char* messages when sent to log
via LOG_XXXX macros
small messages will still be logged normally
SimpleLogger will gather a vector of all message parts that need direct
outputing and pass it to Logger::log upon its destruction