### PR TITLE
When transfer->failure() is called, the slot calling it is deleted

### DIFF
--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -105,7 +105,7 @@ struct MEGA_API Transfer : public FileFingerprint
     // returns true if the transfer contains foreign targets, false if targets are private
     bool isForeign();
 
-    // signal failure
+    // signal failure.  Either the transfer's slot or the transfer itself (including slot) will be deleted.
     void failed(error, DBTableTransactionCommitter&, dstime = 0, handle targetHandle = UNDEF);
 
     // signal completion

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -20929,9 +20929,10 @@ void MegaApiImpl::sendPendingRequests()
                 client->usehttps = usehttps;
                 for (int d = GET; d == GET || d == PUT; d += PUT - GET)
                 {
-                    for (transfer_map::iterator it = client->transfers[d].begin(); it != client->transfers[d].end(); it++)
+                    for (transfer_map::iterator it = client->transfers[d].begin(); it != client->transfers[d].end(); )
                     {
                         Transfer *t = it->second;
+                        it++; // in case the failed() call deletes the transfer (which removes it from the list)
                         if (t->slot)
                         {
                             t->failed(API_EAGAIN, committer);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13711,12 +13711,12 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
                 if (overquotauntil && overquotauntil > Waiter::ds)
                 {
                     dstime timeleft = dstime(overquotauntil - Waiter::ds);
-                    t->failed(API_EOVERQUOTA, committer, timeleft);
+                    t->failed(API_EOVERQUOTA, committer, timeleft);  // transfer may be deleted here
                 }
                 else if (d == PUT && ststatus == STORAGE_RED && !t->isForeign())
                 {
                     // only transfers with private targets should fail, since "foreign" transfers may not fail due to overquota
-                    t->failed(API_EOVERQUOTA, committer, 0, f->h);
+                    t->failed(API_EOVERQUOTA, committer, 0, f->h);  // transfer may be deleted here
                 }
             }
         }

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -1108,7 +1108,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
         if (!chunkfailed)
         {
             LOG_warn << "Transfer failed due to a timeout";
-            transfer->failed(API_EAGAIN, committer);
+            return transfer->failed(API_EAGAIN, committer);  // either the (this) slot has been deleted, or the whole transfer including slot has been deleted
         }
         else
         {


### PR DESCRIPTION
(failure() deletes either the transfer (including slot) or just the slot)
Also found a case where looping over transfers calling failure() did not take into account the iterator may be invalidated.