### PR TITLE
#14515: Task/direct logging controled by logger

### DIFF
--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -403,8 +403,8 @@ public:
         {
             if (logger)
             {
-                const char **dm = new const char *[mDirectMessages.size()];
-                size_t *dms = new size_t[mDirectMessages.size()];
+                std::unique_ptr<const char *[]> dm(new const char *[mDirectMessages.size()]);
+                std::unique_ptr<size_t[]> dms(new size_t[mDirectMessages.size()]);
                 int i = 0;
                 for (const auto & d : mDirectMessages)
                 {
@@ -413,7 +413,7 @@ public:
                     i++;
                 }
 
-                logger->log(nullptr, level, nullptr, "", dm, dms, i);
+                logger->log(nullptr, level, nullptr, "", dm.get(), dms.get(), i);
             }
         }
         for (auto &s: mCopiedParts)

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -517,6 +517,9 @@ public:
 
     SimpleLogger& operator<<(const DirectMessage &obj)
     {
+#ifndef ENABLE_LOG_PERFORMANCE
+    *this << obj.constChar();
+#else
         if (!obj.isBigEnoughToOutputDirectly(std::distance(mBuffer.begin(), mBufferIt))) //don't bother with little msg
         {
             *this << obj.constChar();
@@ -537,6 +540,7 @@ public:
             mDirectMessages.push_back(DirectMessage(obj.constChar(), obj.size()));
         }
 
+#endif
         return *this;
     }
 

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -127,7 +127,7 @@ public:
     // Note: `time` and `source` are null in performance mode
     virtual void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-          , const std::vector<const char *> &directMessages = std::vector<const char *>(), const std::vector<size_t> &directMessagesSizes = std::vector<size_t>()
+          , const char **directMessages = nullptr, size_t *directMessagesSizes = nullptr, int numberMessages = 0
 #endif
                      ) = 0;
 };
@@ -403,15 +403,17 @@ public:
         {
             if (logger)
             {
-                std::vector<const char*> dm;
-                std::vector<size_t> dms;
+                const char **dm = new const char *[mDirectMessages.size()];
+                size_t *dms = new size_t[mDirectMessages.size()];
+                int i = 0;
                 for (const auto & d : mDirectMessages)
                 {
-                    dm.push_back(d.constChar());
-                    dms.push_back(d.size());
+                    dm[i] = d.constChar();
+                    dms[i] = d.size();
+                    i++;
                 }
 
-                logger->log(nullptr, level, nullptr, "", dm, dms);
+                logger->log(nullptr, level, nullptr, "", dm, dms, i);
             }
         }
         for (auto &s: mCopiedParts)

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -126,7 +126,7 @@ public:
     virtual ~Logger() = default;
     // Note: `time` and `source` are null in performance mode
     virtual void log(const char *time, int loglevel, const char *source, const char *message
-#ifdef ENABLE_LOG_PERFORMANCE)
+#ifdef ENABLE_LOG_PERFORMANCE
           , const std::vector<const char *> &directMessages = std::vector<const char *>(), const std::vector<size_t> &directMessagesSizes = std::vector<size_t>()
 #endif
                      ) = 0;

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -368,10 +368,12 @@ public:
      * @param directMessages: in ENABLE_LOG_PERFORMANCE MODE, this will indicate the logger that an array of const char* should
      * be written in the logs immediately without buffering the output. message can be discarded in that case.
      *
+     * @param directMessagesSizes: size of the previous const char *.
+     *
      */
     virtual void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , std::vector<const char *> directMessages
+                     , std::vector<const char *> directMessages, std::vector<size_t> directMessagesSizes
 #endif
                      );
     virtual ~MegaLogger(){}

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -365,8 +365,15 @@ public:
      *
      * The SDK retains the ownership of this string, it won't be valid after this funtion returns.
      *
+     * @param directMessages: in ENABLE_LOG_PERFORMANCE MODE, this will indicate the logger that an array of const char* should
+     * be written in the logs immediately without buffering the output. message can be discarded in that case.
+     *
      */
-    virtual void log(const char *time, int loglevel, const char *source, const char *message);
+    virtual void log(const char *time, int loglevel, const char *source, const char *message
+#ifdef ENABLE_LOG_PERFORMANCE
+                     , std::vector<const char *> directMessages
+#endif
+                     );
     virtual ~MegaLogger(){}
 };
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -373,7 +373,7 @@ public:
      */
     virtual void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , const std::vector<const char *> &directMessages, const std::vector<size_t> &directMessagesSizes
+                     , const char **directMessages = nullptr, size_t *directMessagesSizes = nullptr, int numberMessages = 0
 #endif
                      );
     virtual ~MegaLogger(){}

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -373,7 +373,7 @@ public:
      */
     virtual void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , std::vector<const char *> directMessages, std::vector<size_t> directMessagesSizes
+                     , const std::vector<const char *> &directMessages, const std::vector<size_t> &directMessagesSizes
 #endif
                      );
     virtual ~MegaLogger(){}

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -139,7 +139,7 @@ public:
     void postLog(int logLevel, const char *message, const char *filename, int line);
     void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-             , const std::vector<const char *> &directMessages, const std::vector<size_t> &directMessagesSizes
+             , const char **directMessages, size_t *directMessagesSizes, int numberMessages
 #endif
             ) override;
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -139,7 +139,7 @@ public:
     void postLog(int logLevel, const char *message, const char *filename, int line);
     void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-             , std::vector<const char *> directMessages
+             , std::vector<const char *> directMessages, std::vector<size_t> directMessagesSizes
 #endif
             ) override;
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -139,7 +139,7 @@ public:
     void postLog(int logLevel, const char *message, const char *filename, int line);
     void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-             , std::vector<const char *> directMessages, std::vector<size_t> directMessagesSizes
+             , const std::vector<const char *> &directMessages, const std::vector<size_t> &directMessagesSizes
 #endif
             ) override;
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -137,7 +137,11 @@ public:
     void setLogLevel(int logLevel);
     void setLogToConsole(bool enable);
     void postLog(int logLevel, const char *message, const char *filename, int line);
-    void log(const char *time, int loglevel, const char *source, const char *message) override;
+    void log(const char *time, int loglevel, const char *source, const char *message
+#ifdef ENABLE_LOG_PERFORMANCE
+             , std::vector<const char *> directMessages
+#endif
+            ) override;
 
 private:
     std::recursive_mutex mutex;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5264,7 +5264,7 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
 
 void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , std::vector<const char *> /*directMessages*/
+                     , std::vector<const char *> /*directMessages*/, std::vector<size_t> /*directSizes*/
 #endif
                      )
 {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5264,7 +5264,7 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
 
 void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , std::vector<const char *> /*directMessages*/, std::vector<size_t> /*directSizes*/
+                     , const std::vector<const char *> &/*directMessages*/, const std::vector<size_t> &/*directSizes*/
 #endif
                      )
 {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5262,7 +5262,11 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
     return false;
 }
 
-void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/)
+void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
+#ifdef ENABLE_LOG_PERFORMANCE
+                     , std::vector<const char *> /*directMessages*/
+#endif
+                     )
 {
 
 }

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5264,7 +5264,7 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
 
 void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , const char **/*directMessages*/, size_t */*directMessagesSizes*/, int /*numberMessages*/
+                     , const char ** /*directMessages*/, size_t * /*directMessagesSizes*/, int /*numberMessages*/
 #endif
                      )
 {

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5264,7 +5264,7 @@ bool MegaAccountDetails::isTemporalBandwidthValid()
 
 void MegaLogger::log(const char* /*time*/, int /*loglevel*/, const char* /*source*/, const char* /*message*/
 #ifdef ENABLE_LOG_PERFORMANCE
-                     , const std::vector<const char *> &/*directMessages*/, const std::vector<size_t> &/*directSizes*/
+                     , const char **/*directMessages*/, size_t */*directMessagesSizes*/, int /*numberMessages*/
 #endif
                      )
 {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22426,7 +22426,7 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-          , const std::vector<const char *> &directMessages, const std::vector<size_t> &directMessagesSizes
+          , const char **directMessages = nullptr, size_t *directMessagesSizes = nullptr, int numberMessages = 0
 #endif
                          )
 {
@@ -22452,7 +22452,7 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
     {
         logger->log(time, loglevel, source, message
 #ifdef ENABLE_LOG_PERFORMANCE
-                    , directMessages, directMessagesSizes
+                    , directMessages, directMessagesSizes, numberMessages
 #endif
                     );
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22417,13 +22417,18 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 #ifndef ENABLE_LOG_PERFORMANCE
     mutex.lock();
 #endif
+    //For direct logging, we could use DirectMessage(message) here
     SimpleLogger{static_cast<LogLevel>(logLevel), filename, line} << message;
 #ifndef ENABLE_LOG_PERFORMANCE
     mutex.unlock();
 #endif
 }
 
-void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message)
+void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message
+#ifdef ENABLE_LOG_PERFORMANCE
+          , std::vector<const char *> directMessages
+#endif
+                         )
 {
     if (!time)
     {
@@ -22445,7 +22450,11 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
 #endif
     for (auto logger : megaLoggers)
     {
-        logger->log(time, loglevel, source, message);
+        logger->log(time, loglevel, source, message
+#ifdef ENABLE_LOG_PERFORMANCE
+                    , directMessages
+#endif
+                    );
     }
 
     if (logToConsole)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22426,7 +22426,7 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-          , std::vector<const char *> directMessages
+          , std::vector<const char *> directMessages, std::vector<size_t> directMessagesSizes
 #endif
                          )
 {
@@ -22452,7 +22452,7 @@ void ExternalLogger::log(const char *time, int loglevel, const char *source, con
     {
         logger->log(time, loglevel, source, message
 #ifdef ENABLE_LOG_PERFORMANCE
-                    , directMessages
+                    , directMessages, directMessagesSizes
 #endif
                     );
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22426,7 +22426,7 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-          , std::vector<const char *> directMessages, std::vector<size_t> directMessagesSizes
+          , const std::vector<const char *> &directMessages, const std::vector<size_t> &directMessagesSizes
 #endif
                          )
 {

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -1346,9 +1346,9 @@ void CurlHttpIO::send_request(CurlHttpContext* httpctx)
         else
         {
             LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": "
-                      << DirectMessage(req->out->substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str(), SimpleLogger::maxPayloadLogSize / 2)
-                      << " [...] " <<
-                         DirectMessage(req->out->substr(req->out->size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str(), SimpleLogger::maxPayloadLogSize / 2);
+                      << DirectMessage(req->out->c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                      << " [...] "
+                      << DirectMessage(req->out->c_str() + req->out->size() - SimpleLogger::maxPayloadLogSize / 2, SimpleLogger::maxPayloadLogSize / 2);
         }
     }
 
@@ -2144,10 +2144,10 @@ bool CurlHttpIO::multidoio(CURLM *curlmhandle)
                         }
                         else
                         {
-                            LOG_debug << req->logname << "Received " << req->in.size() << ": " <<
-                                         DirectMessage(req->in.substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                            LOG_debug << req->logname << "Received " << req->in.size() << ": "
+                                      << DirectMessage(req->in.c_str(), SimpleLogger::maxPayloadLogSize / 2)
                                       << " [...] "
-                                      << DirectMessage(req->in.substr(req->in.size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str(), SimpleLogger::maxPayloadLogSize / 2);
+                                      << DirectMessage(req->in.c_str() + req->in.size() - SimpleLogger::maxPayloadLogSize / 2, SimpleLogger::maxPayloadLogSize / 2);
                         }
                     }
                 }

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -1341,12 +1341,14 @@ void CurlHttpIO::send_request(CurlHttpContext* httpctx)
     {
         if (req->out->size() < SimpleLogger::maxPayloadLogSize)
         {
-            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": " << *req->out;
+            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": " << DirectMessage(req->out->c_str(), req->out->size());
         }
         else
         {
-            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": " << req->out->substr(0, SimpleLogger::maxPayloadLogSize / 2)
-                      << " [...] " << req->out->substr(req->out->size() - SimpleLogger::maxPayloadLogSize / 2, string::npos);
+            LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": "
+                      << DirectMessage(req->out->substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                      << " [...] " <<
+                         DirectMessage(req->out->substr(req->out->size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str(), SimpleLogger::maxPayloadLogSize / 2);
         }
     }
 
@@ -2138,12 +2140,14 @@ bool CurlHttpIO::multidoio(CURLM *curlmhandle)
                     {
                         if (req->in.size() < SimpleLogger::maxPayloadLogSize)
                         {
-                            LOG_debug << req->logname << "Received " << req->in.size() << ": " << req->in.c_str();
+                            LOG_debug << req->logname << "Received " << req->in.size() << ": " << DirectMessage(req->in.c_str(), req->in.size());
                         }
                         else
                         {
-                            LOG_debug << req->logname << "Received " << req->in.size() << ": " << req->in.substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str()
-                                      << " [...] " << req->in.substr(req->in.size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str();
+                            LOG_debug << req->logname << "Received " << req->in.size() << ": " <<
+                                         DirectMessage(req->in.substr(0, SimpleLogger::maxPayloadLogSize / 2).c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                                      << " [...] "
+                                      << DirectMessage(req->in.substr(req->in.size() - SimpleLogger::maxPayloadLogSize / 2, string::npos).c_str(), SimpleLogger::maxPayloadLogSize / 2);
                         }
                     }
                 }


### PR DESCRIPTION
have Logger::log include a vector of const char* to pass to the app for
direct logging and another of sizes
add DirectMessage class to wrap const char* messages when sent to log
via LOG_XXXX macros
small messages will still be logged normally
SimpleLogger will gather a vector of all message parts that need direct
outputing and pass it to Logger::log upon its destruction