### PR TITLE
#14801. Add and use crossref_ptr to manage the LocalNode <-> NewNode connection

### DIFF
--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -383,8 +383,8 @@ struct MEGA_API LocalNode : public File
 };
 #endif
 
-template <> inline crossref_ptr<NewNode, LocalNode>& crossref_other_ptr_ref<LocalNode, NewNode>(LocalNode* p) { return p->newnode; }
-template <> inline crossref_ptr<LocalNode, NewNode>& crossref_other_ptr_ref<NewNode, LocalNode>(NewNode* p) { return p->localnode; }
+template <> inline NewNode*& crossref_other_ptr_ref<LocalNode, NewNode>(LocalNode* p) { return p->newnode.ptr; }
+template <> inline LocalNode*& crossref_other_ptr_ref<NewNode, LocalNode>(NewNode* p) { return p->localnode.ptr; }
 
 } // namespace
 

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -58,7 +58,7 @@ struct MEGA_API NewNode : public NodeCore
     byte uploadtoken[UPLOADTOKENLEN]{};
 
     handle syncid = UNDEF;
-    LocalNode* localnode = nullptr; // non-owning
+    crossref_ptr<LocalNode, NewNode> localnode; // non-owning
     std::unique_ptr<string> fileattributes;
 
     bool added = false;
@@ -301,7 +301,7 @@ struct MEGA_API LocalNode : public File
     Node* node = nullptr;
 
     // related pending node creation or NULL
-    NewNode* newnode = nullptr;
+    crossref_ptr<NewNode, LocalNode> newnode;
 
     // FILENODE or FOLDERNODE
     nodetype_t type = TYPE_UNKNOWN;
@@ -382,6 +382,12 @@ struct MEGA_API LocalNode : public File
     ~LocalNode();
 };
 #endif
+
+template <> inline crossref_ptr<NewNode, LocalNode>& crossref_other_ptr_ref<LocalNode, NewNode>(LocalNode* p) { return p->newnode; }
+template <> inline crossref_ptr<LocalNode, NewNode>& crossref_other_ptr_ref<NewNode, LocalNode>(NewNode* p) { return p->localnode; }
+
 } // namespace
+
+
 
 #endif

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -803,8 +803,10 @@ public:
 
     void crossref(TO* to, FROM* from) 
     {
+        assert(to && from);
         assert(ptr == nullptr);
-        assert( !(crossref_other_ptr_ref<TO, FROM, crossref_ptr<FROM, TO>>(ptr).ptr) );
+        assert( !(crossref_other_ptr_ref<TO, FROM, crossref_ptr<FROM, TO>>(to).ptr) );
+        assert( (&crossref_other_ptr_ref<FROM, TO, crossref_ptr<TO, FROM>>(from) == this) );
         ptr = to;
         if (ptr) crossref_other_ptr_ref<TO, FROM, crossref_ptr<FROM, TO>>(ptr).ptr = from;
     }
@@ -814,7 +816,7 @@ public:
         if (ptr)
         {
             assert( !!(crossref_other_ptr_ref<TO, FROM, crossref_ptr<FROM, TO>>(ptr)) );
-            if (ptr) crossref_other_ptr_ref<TO, FROM, crossref_ptr<FROM, TO>>(ptr).ptr = nullptr;
+            crossref_other_ptr_ref<TO, FROM, crossref_ptr<FROM, TO>>(ptr).ptr = nullptr;
             ptr = nullptr;
         }
     }

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -783,12 +783,12 @@ bool operator==(const SyncConfig& lhs, const SyncConfig& rhs);
 
 
 // cross reference pointers.  For the case where two classes have pointers to each other, and they should
-// either always be NULL or always consistently referring to each other. 
+// either always be NULL or if one refers to the other, the other refers to the one.
 // This class makes sure that the two pointers are always consistent, and also prevents copy/move (unless the pointers are NULL)
-template<typename TO, typename FROM, typename FROMS_CROSSREFPTR>
-FROMS_CROSSREFPTR& crossref_other_ptr_ref(typename TO* s);  // to be supplied for each pair of classes (to assign to the right member thereof) (gets around circular declarations)
+template<class TO, class FROM, class FROMS_CROSSREFPTR>
+FROMS_CROSSREFPTR& crossref_other_ptr_ref(TO* s);  // to be supplied for each pair of classes (to assign to the right member thereof) (gets around circular declarations)
 
-template <typename  TO, typename  FROM>
+template <class  TO, class  FROM>
 class MEGA_API  crossref_ptr 
 {
     friend class crossref_ptr<FROM, TO>;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -811,9 +811,8 @@ public:
         assert(to && from);
         assert(ptr == nullptr);
         assert( !(crossref_other_ptr_ref<TO, FROM>(to)) );
-        assert( (crossref_other_ptr_ref<FROM, TO>(from) == ptr) );
         ptr = to;
-        if (ptr) crossref_other_ptr_ref<TO, FROM>(ptr) = from;
+        crossref_other_ptr_ref<TO, FROM>(ptr) = from;
     }
 
     void reset()
@@ -826,9 +825,8 @@ public:
         }
     }
 
-    explicit operator bool() { return !!ptr; }
-    TO* operator->() { return ptr; }
-    operator TO*() { return ptr; }
+    TO* operator->() const { return ptr; }
+    operator TO*() const { return ptr; }
 
     // no copying
     crossref_ptr(const crossref_ptr&) = delete;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1235,10 +1235,7 @@ void CommandPutNodes::procresult()
 
             for (int i=0; i < nnsize; i++)
             {
-                if (nn[i].localnode)
-                {
-                    nn[i].localnode->newnode = NULL;
-                }
+                nn[i].localnode.reset();
             }
 
             return client->putnodes_sync_result(e, nn, nnsize);

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -304,9 +304,9 @@ void File::completed(Transfer* t, LocalNode* l)
         newnode->type = FILENODE;
         newnode->parenthandle = UNDEF;
 #ifdef ENABLE_SYNC
-        if ((newnode->localnode = l))
+        if (l)
         {
-            l->newnode = newnode;
+            l->newnode.crossref(newnode, l);
             newnode->syncid = l->syncid;
         }
 #endif

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7526,11 +7526,11 @@ int MegaClient::readnodes(JSON* j, int notify, putsource_t source, NewNode* nn, 
                         {
                             // overwrites/updates: associate LocalNode with newly created Node
                             nn[nni].localnode->setnode(n);
-                            nn[nni].localnode->newnode = NULL;
                             nn[nni].localnode->treestate(TREESTATE_SYNCED);
 
                             // updates cache with the new node associated
                             nn[nni].localnode->sync->statecacheadd(nn[nni].localnode);
+                            nn[nni].localnode->newnode.reset(); // localnode ptr now null also
                         }
                     }
 #endif
@@ -13180,8 +13180,7 @@ void MegaClient::syncupdate()
                 nnp->source = NEW_NODE;
                 nnp->type = l->type;
                 nnp->syncid = l->syncid;
-                nnp->localnode = l;
-                l->newnode = nnp;
+                nnp->localnode.crossref(l, nnp);  // also sets l->newnode to nnp
                 nnp->nodehandle = n ? n->nodehandle : l->syncid;
                 nnp->parenthandle = i > start ? l->parent->syncid : UNDEF;
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1341,7 +1341,7 @@ void LocalNode::init(Sync* csync, nodetype_t ctype, LocalNode* cparent, string* 
     created = false;
     reported = false;
     syncxfer = true;
-    newnode = NULL;
+    newnode.reset();
     parent_dbid = 0;
     slocalname = NULL;
 
@@ -1550,10 +1550,7 @@ LocalNode::~LocalNode()
 
     setnotseen(0);
 
-    if (newnode)
-    {
-        newnode->localnode = NULL;
-    }
+    newnode.reset();
 
     if (sync->dirnotify.get())
     {


### PR DESCRIPTION
Some crashes were seen when destroying localnodes and trying to disconnect from the NewNode.
crossref_ptr ensures that whichever is destroyed first removes the connection, and also adds lots of other checks to ensure the connection between them is consistent.