### PR TITLE
#14834. Use mega::m_gmtime for thread safety

### DIFF
--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -26,7 +26,9 @@ public:
         {
             auto t = std::time(NULL);
             char ts[50];
-            if (!std::strftime(ts, sizeof(ts), "%H:%M:%S", std::gmtime(&t)))
+            struct tm dt;
+            mega::m_gmtime(t, &dt);
+            if (!std::strftime(ts, sizeof(ts), "%H:%M:%S", &dt))
             {
                 ts[0] = '\0';
             }


### PR DESCRIPTION
Use of gmtime could be the culprit of #14834. However, I cannot reproduce the crash so this is a stab into the dark to see if Jenkins still experiences the crash. 