### PR TITLE
#14785. Event not sent when updating MEGAsync

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7357,15 +7357,6 @@ void MegaApiImpl::abortPendingActions(error preverror)
             delete transfer;   // committer needed here
         }
     }
-    MegaRequestPrivate *request;
-    while ((request = requestQueue.pop()))
-    {
-        delete request;
-    }
-    while ((request = scRequestQueue.pop()))
-    {
-        delete request;
-    }
 
     resetTotalDownloads();
     resetTotalUploads();


### PR DESCRIPTION
This reverts commit f70097129f7b80c19947a3612076f8189e789a5e. Queued requests should not be discarded upon login.