### PR TITLE
#14965: Reuse previously built dependencies

### DIFF
--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -930,7 +930,7 @@ mediainfo_pkg() {
     local mediainfolib_dir_extract="MediaInfoLib-$mediainfolib_ver"
     local mediainfolib_dir="MediaInfoLib-$mediainfolib_ver/Project/GNU/Library"
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$mediainfolib_name.success -a `cat $status_dir/$mediainfolib_name.success` = $mediainfolib_md5]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$mediainfolib_name.success ] && [ `cat $status_dir/$mediainfolib_name.success` = $mediainfolib_md5]; then
         echo "$mediainfolib_name already built"
         return
     else

--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -930,7 +930,7 @@ mediainfo_pkg() {
     local mediainfolib_dir_extract="MediaInfoLib-$mediainfolib_ver"
     local mediainfolib_dir="MediaInfoLib-$mediainfolib_ver/Project/GNU/Library"
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$mediainfolib_name.success ] && [ `cat $status_dir/$mediainfolib_name.success` = $mediainfolib_md5]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$mediainfolib_name.success ] && [ `cat $status_dir/$mediainfolib_name.success` = $mediainfolib_md5 ]; then
         echo "$mediainfolib_name already built"
         return
     else

--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -57,6 +57,7 @@ cross_compiling=0
 configure_cross_options=""
 openssl_cross_option=""
 status_dir=""
+persistent_path="/opt/persistent"
 
 on_exit_error() {
     echo "ERROR! Please check log files. Exiting.."
@@ -284,9 +285,10 @@ package_install() {
     local name=$1
     local dir=$2
     local install_dir=$3
+    local md5=$4
 
-    if [ "$#" -eq 4 ]; then
-        local target=$4
+    if [ "$#" -eq 5 ]; then
+        local target=$5
     else
         local target=""
     fi
@@ -310,7 +312,7 @@ package_install() {
         cd $cwd
     else
         cd $cwd
-        echo $exit_code > $status_dir/$name.success
+        echo $md5 > $status_dir/$name.success
     fi
 
     # some packages install libraries to "lib64" folder
@@ -338,7 +340,7 @@ openssl_pkg() {
     fi
     local loc_make_opts=$make_opts
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $openssl_md5 ]; then
         echo "$name already built"
         return
     else
@@ -383,7 +385,7 @@ openssl_pkg() {
     package_build $name $openssl_dir
     make_opts=$loc_make_opts
 
-    package_install $name $openssl_dir $install_dir
+    package_install $name $openssl_dir $install_dir $openssl_md5
 }
 
 cryptopp_pkg() {
@@ -396,7 +398,7 @@ cryptopp_pkg() {
     local cryptopp_file="cryptopp$cryptopp_ver.zip"
     local cryptopp_dir="cryptopp$cryptopp_ver"
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $cryptopp_md5 ]; then
         echo "$name already built"
         return
     else
@@ -417,10 +419,10 @@ cryptopp_pkg() {
         cp ${ANDROID_NDK_ROOT}/sources/android/cpufeatures/cpu-features.h $cryptopp_dir/
         cp ${ANDROID_NDK_ROOT}/sources/android/cpufeatures/cpu-features.c $cryptopp_dir/
         package_build $name $cryptopp_dir "static -f GNUmakefile-cross"
-        package_install $name $cryptopp_dir $install_dir "-f GNUmakefile-cross"
+        package_install $name $cryptopp_dir $install_dir $cryptopp_md5 "-f GNUmakefile-cross"
     else
         package_build $name $cryptopp_dir static
-        package_install $name $cryptopp_dir $install_dir
+        package_install $name $cryptopp_dir $install_dir $cryptopp_md5
    fi
 }
 
@@ -439,7 +441,7 @@ sodium_pkg() {
         local sodium_params="--disable-shared --enable-static --disable-pie"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $sodium_md5 ]; then
         echo "$name already built"
         return
     else
@@ -454,7 +456,7 @@ sodium_pkg() {
     package_extract $name $sodium_file $sodium_dir
     package_configure $name $sodium_dir $install_dir "$sodium_params"
     package_build $name $sodium_dir
-    package_install $name $sodium_dir $install_dir
+    package_install $name $sodium_dir $install_dir $sodium_md5
 }
 
 libuv_pkg() {
@@ -472,7 +474,7 @@ libuv_pkg() {
         local libuv_params="--disable-shared --enable-static"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $libuv_md5 ]; then
         echo "$name already built"
         return
     else
@@ -497,7 +499,7 @@ libuv_pkg() {
     export CFLAGS="$OLD_CFLAGS"
 
     package_build $name $libuv_dir
-    package_install $name $libuv_dir $install_dir
+    package_install $name $libuv_dir $install_dir $libuv_md5
 }
 
 libraw_pkg() {
@@ -515,7 +517,7 @@ libraw_pkg() {
         local libraw_params="--disable-shared --enable-static"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $libraw_md5 ]; then
         echo "$name already built"
         return
     else
@@ -540,7 +542,7 @@ libraw_pkg() {
     export LIBS="$OLD_LIBS"
 
     package_build $name $libraw_dir
-    package_install $name $libraw_dir $install_dir
+    package_install $name $libraw_dir $install_dir $libraw_md5
 }
 
 zlib_pkg() {
@@ -561,7 +563,7 @@ zlib_pkg() {
         local zlib_params="--static"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $zlib_md5 ]; then
         echo "$name already built"
         return
     else
@@ -583,13 +585,13 @@ zlib_pkg() {
     if [ "$(expr substr $(uname -s) 1 10)" != "MINGW32_NT" ]; then
         package_configure $name $zlib_dir $install_dir "$zlib_params"
         package_build $name $zlib_dir
-        package_install $name $zlib_dir $install_dir
+        package_install $name $zlib_dir $install_dir $zlib_md5
     else
         export BINARY_PATH=$install_dir/bin
         export INCLUDE_PATH=$install_dir/include
         export LIBRARY_PATH=$install_dir/lib
         package_build $name $zlib_dir "-f win32/Makefile.gcc"
-        package_install $name $zlib_dir $install_dir "-f win32/Makefile.gcc"
+        package_install $name $zlib_dir $install_dir $zlib_md5 "-f win32/Makefile.gcc"
         unset BINARY_PATH
         unset INCLUDE_PATH
         unset LIBRARY_PATH
@@ -614,7 +616,7 @@ sqlite_pkg() {
         local sqlite_params="--disable-shared --enable-static"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $sqlite_md5 ]; then
         echo "$name already built"
         return
     else
@@ -629,7 +631,7 @@ sqlite_pkg() {
     package_extract $name $sqlite_file $sqlite_dir
     package_configure $name $sqlite_dir $install_dir "$sqlite_params"
     package_build $name $sqlite_dir
-    package_install $name $sqlite_dir $install_dir
+    package_install $name $sqlite_dir $install_dir $sqlite_md5
 }
 
 cares_pkg() {
@@ -647,7 +649,7 @@ cares_pkg() {
         local cares_params="--disable-shared --enable-static"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $cares_md5 ]; then
         echo "$name already built"
         return
     else
@@ -662,7 +664,7 @@ cares_pkg() {
     package_extract $name $cares_file $cares_dir
     package_configure $name $cares_dir $install_dir "$cares_params"
     package_build $name $cares_dir
-    package_install $name $cares_dir $install_dir
+    package_install $name $cares_dir $install_dir $cares_md5
 }
 
 curl_pkg() {
@@ -695,7 +697,7 @@ curl_pkg() {
             --without-brotli --disable-shared --with-zlib=$install_dir --enable-ares=$install_dir $openssl_flags"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $curl_md5 ]; then
         echo "$name already built"
         return
     else
@@ -710,7 +712,7 @@ curl_pkg() {
     package_extract $name $curl_file $curl_dir
     package_configure $name $curl_dir $install_dir "$curl_params" "-ldl"  
     package_build $name $curl_dir
-    package_install $name $curl_dir $install_dir
+    package_install $name $curl_dir $install_dir $curl_md5
 }
 
 readline_pkg() {
@@ -728,7 +730,7 @@ readline_pkg() {
         local readline_params="--disable-shared --enable-static"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $readline_md5 ]; then
         echo "$name already built"
         return
     else
@@ -743,7 +745,7 @@ readline_pkg() {
     package_extract $name $readline_file $readline_dir
     package_configure $name $readline_dir $install_dir "$readline_params"
     package_build $name $readline_dir
-    package_install $name $readline_dir $install_dir
+    package_install $name $readline_dir $install_dir $readline_md5
 }
 
 termcap_pkg() {
@@ -761,7 +763,7 @@ termcap_pkg() {
         local termcap_params="--disable-shared --enable-static"
     fi
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $termcap_md5 ]; then
         echo "$name already built"
         return
     else
@@ -776,7 +778,7 @@ termcap_pkg() {
     package_extract $name $termcap_file $termcap_dir
     package_configure $name $termcap_dir $install_dir "$termcap_params"
     package_build $name $termcap_dir
-    package_install $name $termcap_dir $install_dir
+    package_install $name $termcap_dir $install_dir $termcap_md5
 }
 
 freeimage_pkg() {
@@ -791,7 +793,7 @@ freeimage_pkg() {
     local freeimage_dir_extract="freeimage-$freeimage_ver"
     local freeimage_dir="freeimage-$freeimage_ver/FreeImage"
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $freeimage_md5 ]; then
         echo "$name already built"
         return
     else
@@ -862,7 +864,7 @@ EOF
         # manually copy header and library
         cp $freeimage_dir/Dist/FreeImage.h $install_dir/include || exit 1
         cp $freeimage_dir/Dist/libfreeimage* $install_dir/lib || exit 1
-        echo $? > $status_dir/$name.success
+        echo $freeimage_md5 > $status_dir/$name.success
     # MinGW
     else
         package_build $name $freeimage_dir "-f Makefile.mingw"
@@ -872,7 +874,7 @@ EOF
         cp $freeimage_dir/Dist/FreeImage.dll $install_dir/lib || 1
         cp $freeimage_dir/Dist/FreeImage.lib $install_dir/lib || 1
         cp $freeimage_dir/Dist/libFreeImage.a $install_dir/lib || 1
-        echo $? > $status_dir/$name.success
+        echo $freeimage_md5 > $status_dir/$name.success
     fi
 }
 
@@ -887,7 +889,7 @@ readline_win_pkg() {
     local readline_file="readline-bin.zip"
     local readline_dir="readline-bin"
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $readline_md5 ]; then
         echo "$name already built"
         return
     else
@@ -905,6 +907,7 @@ readline_win_pkg() {
     cp -R $readline_dir/include/* $install_dir/include/ || exit 1
     # fix library name
     cp $readline_dir/lib/libreadline.dll.a $install_dir/lib/libreadline.a || exit 1
+    echo $readline_md5 > $status_dir/$name.success
 }
 
 mediainfo_pkg() {
@@ -927,7 +930,7 @@ mediainfo_pkg() {
     local mediainfolib_dir_extract="MediaInfoLib-$mediainfolib_ver"
     local mediainfolib_dir="MediaInfoLib-$mediainfolib_ver/Project/GNU/Library"
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$mediainfolib_name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$mediainfolib_name.success -a `cat $status_dir/$mediainfolib_name.success` = $mediainfolib_md5]; then
         echo "$mediainfolib_name already built"
         return
     else
@@ -970,7 +973,7 @@ mediainfo_pkg() {
 
     package_build $zenlib_name $zenlib_dir
     #package_install $zenlib_name $zenlib_dir $install_dir
-    package_install $zenlib_name $zenlib_dir "$build_dir/ZenLib"
+    package_install $zenlib_name $zenlib_dir "$build_dir/ZenLib" $zenlib_md5
 
     package_configure $mediainfolib_name $mediainfolib_dir $install_dir "$mediainfolib_params" #TODO: tal vez install dir ha de ser ./ZenLib!!! casi 100% seguro
     CR=$(printf '\r')
@@ -1008,7 +1011,7 @@ EOF
     package_build $mediainfolib_name $mediainfolib_dir
 
     pushd $build_dir/ZenLib >/dev/null
-    package_install $mediainfolib_name $build_dir/$mediainfolib_dir $install_dir
+    package_install $mediainfolib_name $build_dir/$mediainfolib_dir $install_dir $mediainfolib_md5
     popd
 
 }
@@ -1024,7 +1027,7 @@ readline_win_pkg() {
     local readline_file="readline-bin.zip"
     local readline_dir="readline-bin"
 
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ]; then
+    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $readline_md5 ]; then
         echo "$name already built"
         return
     else
@@ -1042,6 +1045,7 @@ readline_win_pkg() {
     cp -R $readline_dir/include/* $install_dir/include/ || exit 1
     # fix library name
     cp $readline_dir/lib/libreadline.dll.a $install_dir/lib/libreadline.a || exit 1
+    echo $readline_md5 > $status_dir/$name.success
 }
 
 build_sdk() {
@@ -1283,6 +1287,7 @@ main() {
                 ;;
             I)
                 echo "* Incremental build - skipping already built/downloaded dependencies"
+                [ -d $persistent_path ] && echo "* Using $persistent_path as a backup for dependecies."
                 incremental=1
                 ;;
             l)
@@ -1410,6 +1415,13 @@ main() {
 
     if [ $incremental -eq 0 ]; then
         rm -fr *.log
+    else
+        # Check if backup exists on persistent path and restore previous status.
+        if [ -d $persistent_path/sdk/ ];then
+            echo "Recovering previous libs and staus, if any."
+            [ -d $persistent_path/sdk/3rdparty ] && cp --preserve=timestamps -r $persistent_path/sdk/3rdparty/* $install_dir/
+            [ -d $persistent_path/sdk/3rdparty_status ] && cp --preserve=timestamps $persistent_path/sdk/3rdparty_status/* $status_dir/
+        fi
     fi
 
     export PREFIX=$install_dir
@@ -1487,6 +1499,19 @@ main() {
         fi
         export "CXXFLAGS=$CXXFLAGS -DCRYPTOPP_MAINTAIN_BACKWARDS_COMPATIBILITY_562"
         build_sdk $install_dir $debug
+    fi
+
+    if [ $incremental -eq 1 ]; then
+        # Check if persistent path exists to backup current build status.
+        if [ -d $persistent_path ];then
+            # Creating directories to store current libraries and status.
+            mkdir -p $persistent_path/sdk/3rdparty
+            mkdir -p $persistent_path/sdk/3rdparty_status
+            echo "Using $persistent_path/sdk/ as persistent path to store current build status."
+            cp --preserve=timestamps -r $install_dir/* $persistent_path/sdk/3rdparty/
+            rm $persistent_path/sdk/3rdparty_status/*
+            cp --preserve=timestamps $status_dir/*.success $persistent_path/sdk/3rdparty_status/
+        fi
     fi
 
     unset PREFIX

--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -878,38 +878,6 @@ EOF
     fi
 }
 
-# we can't build vanilla ReadLine under MinGW
-readline_win_pkg() {
-    local build_dir=$1
-    local install_dir=$2
-    local name="Readline"
-    local readline_ver="5.0.1"
-    local readline_url="http://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-bin.zip?r=&ts=1468492036&use_mirror=freefr"
-    local readline_md5="91beae8726edd7ad529f67d82153e61a"
-    local readline_file="readline-bin.zip"
-    local readline_dir="readline-bin"
-
-    if [ $incremental -eq 1 ] && [ -e $status_dir/$name.success ] && [ `cat $status_dir/$name.success` = $readline_md5 ]; then
-        echo "$name already built"
-        return
-    else
-        rm -f $status_dir/$name.success
-    fi
-
-    package_download $name $readline_url $readline_file $readline_md5
-    if [ $download_only -eq 1 ]; then
-        return
-    fi
-
-    package_extract $name $readline_file $readline_dir
-
-    # manually copy binary files
-    cp -R $readline_dir/include/* $install_dir/include/ || exit 1
-    # fix library name
-    cp $readline_dir/lib/libreadline.dll.a $install_dir/lib/libreadline.a || exit 1
-    echo $readline_md5 > $status_dir/$name.success
-}
-
 mediainfo_pkg() {
     local build_dir=$1
     local install_dir=$2

--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -1509,7 +1509,7 @@ main() {
             mkdir -p $persistent_path/sdk/3rdparty_status
             echo "Using $persistent_path/sdk/ as persistent path to store current build status."
             cp --preserve=timestamps -r $install_dir/* $persistent_path/sdk/3rdparty/
-            rm $persistent_path/sdk/3rdparty_status/*
+            rm -f $persistent_path/sdk/3rdparty_status/*
             cp --preserve=timestamps $status_dir/*.success $persistent_path/sdk/3rdparty_status/
         fi
     fi


### PR DESCRIPTION
If incremental flag is enabled and previously built dependencies are
found in a backup directory, they are copied and reused in the current
build.
In case a dependency MD5 changes (e.g. new version), the new dependency
is built and copied back into the backup directory.

*Risk areas*
----------------
package building mechanism that use the incremental building (param `-I`). So, barely none