### PR TITLE
#14906. Process API_EBLOCKED on sc channel

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -6758,19 +6758,34 @@ void DemoApp::whyamiblocked_result(int code)
         {
             reason = "Your account has been suspended due to multiple breaches of Mega's Terms of Service. Please check your email inbox.";
         }
+        else if (code == 300)
+        {
+            reason = "Your account has been suspended due to copyright violations. Please check your email inbox.";
+        }
+        else if (code == 400)
+        {
+            reason = "Your account has been disabled by your administrator. You may contact your business account administrator for further details.";
+        }
+        else if (code == 401)
+        {
+            reason = "Your account has been removed by your administrator. You may contact your business account administrator for further details.";
+        }
         else if (code == 500)
         {
-            reason = "Your account has been blocked, pending verification via SMS.";
+            reason = "Your account has been blocked pending verification via SMS.";
         }
-        //else if (code == 300) --> default reason
-
+        else if (code == 700)
+        {
+            reason = "Your account has been temporarily suspended for your safety. Please verify your email and follow its steps to unlock your account.";
+        }
+        //else if (code == ACCOUNT_BLOCKED_DEFAULT) --> default reason
 
         cout << "Reason: " << reason << endl;
 
-        if (code != 500)
+        if (code != 500 && code != 700)
         {
             cout << "Logging out..." << endl;
-            client->locallogout(false);
+            client->locallogout(true);
         }
     }
 }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -10823,6 +10823,10 @@ class MegaApi
          * is that the logout action has been notified before the reception of the
          * logout response itself.
          *
+         * In case of an automatic logout (ie. when the account become blocked by
+         * ToS infringment), the MegaRequest::getParamType indicates the error that
+         * triggered the automatic logout (MegaError::API_EBLOCKED for the example).
+         *
          * @param listener MegaRequestListener to track this request
          */
         void logout(MegaRequestListener *listener = NULL);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14964,6 +14964,10 @@ void MegaApiImpl::whyamiblocked_result(int code)
         {
             reason = "Your account has been suspended due to multiple breaches of Mega's Terms of Service. Please check your email inbox.";
         }
+        else if (code == MegaApi::ACCOUNT_BLOCKED_TOS_COPYRIGHT)
+        {
+            reason = "Your account has been suspended due to copyright violations. Please check your email inbox.";
+        }
         else if (code == MegaApi::ACCOUNT_BLOCKED_SUBUSER_DISABLED)
         {
             reason = "Your account has been disabled by your administrator. You may contact your business account administrator for further details.";

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -14025,9 +14025,6 @@ void MegaApiImpl::logout_result(error e)
         mPushSettings = NULL;
         delete mTimezones;
         mTimezones = NULL;
-
-        fireOnRequestFinish(request, MegaError(preverror));
-        return;
     }
     fireOnRequestFinish(request,MegaError(e));
 }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1967,6 +1967,7 @@ void MegaClient::exec()
                     else if (e == API_EBLOCKED)
                     {
                         app->request_error(API_EBLOCKED);
+                        stopsc = true;
                     }
                     else
                     {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1964,6 +1964,10 @@ void MegaClient::exec()
                             fnstats.eAgainCount++;
                         }
                     }
+                    else if (e == API_EBLOCKED)
+                    {
+                        app->request_error(API_EBLOCKED);
+                    }
                     else
                     {
                         LOG_err << "Unexpected sc response: " << pendingsc->in;


### PR DESCRIPTION
Rather than waiting for a cs request that triggers a `API_EBLOCKED` when the account has been blocked, the API sends the correspondieng -16 on the sc channel, so we can immediately handle the situation