### PR TITLE
WIP: #14964. create local nodes for symlinks and avoid their uploads

### DIFF
--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -279,6 +279,9 @@ struct MEGA_API LocalNode : public File
 {
     class Sync* sync = nullptr;
 
+    // is symlink?
+    bool mIsSymlink = false;
+
     // parent linkage
     LocalNode* parent = nullptr;
 

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -280,7 +280,7 @@ struct MEGA_API LocalNode : public File
     class Sync* sync = nullptr;
 
     // is symlink?
-    bool mIsSymlink = false;
+    bool mIsSymlink = false; //TODO: serialize this
 
     // parent linkage
     LocalNode* parent = nullptr;

--- a/src/filefingerprint.cpp
+++ b/src/filefingerprint.cpp
@@ -147,6 +147,12 @@ bool FileFingerprint::genfingerprint(FileAccess* fa, bool ignoremtime)
 
     if (size <= (m_off_t)sizeof crc)
     {
+        if (fa->mIsSymLink)
+        {
+            //TODO: get CRC from appointed target instead of contents
+            fa->closef();
+            return true;
+        }
         // tiny file: read verbatim, NUL pad
         if (!fa->frawread((byte*)newcrc.data(), static_cast<unsigned>(size), 0, true))
         {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -12715,13 +12715,6 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
 
         rit = nchildren.find(&localname);
 
-        string localpath;
-        unique_ptr<FileAccess> fa(fsaccess->newfileaccess(false));
-
-        ll->getlocalpath(&localpath);
-        fa->fopen(&localpath);
-        bool isSymLink = fa->mIsSymLink;
-
         // do we have a corresponding remote child?
         if (rit != nchildren.end())
         {
@@ -12730,10 +12723,10 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
             // local: file, remote: folder - overwrite
             // local: folder, remote: folder - recurse
             // local: file, remote: file - overwrite if newer
-            if (ll->type != rit->second->type || fa->mIsSymLink)
+            if (ll->type != rit->second->type || ll->mIsSymlink)
             {
                 insync = false;
-                LOG_warn << "Type changed: " << localname << " LNtype: " << ll->type << " Ntype: " << rit->second->type << " isSymLink = " << fa->mIsSymLink;
+                LOG_warn << "Type changed: " << localname << " LNtype: " << ll->type << " Ntype: " << rit->second->type << " isSymLink = " << ll->mIsSymlink;
                 movetosyncdebris(rit->second, l->sync->inshare);
             }
             else
@@ -12911,8 +12904,9 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
             }
         }
 
-        if (isSymLink)
+        if (ll->mIsSymlink)
         {
+            LOG_warn << "skipping node creation (symlink): " << ll->name;
             continue; //Do nothing for the moment
         }
         else if (ll->type == FILENODE)
@@ -13100,7 +13094,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
         {
             ll->created = true;
 
-            assert (!isSymLink);
+            assert (!ll->mIsSymlink);
             // create remote folder or send file
             LOG_debug << "Adding local file to synccreate: " << ll->name << " " << synccreate.size();
             synccreate.push_back(ll);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2590,7 +2590,10 @@ void MegaClient::exec()
                             }
 
                             // delete files that were overwritten by folders in syncup()
-                            execsyncdeletions();  
+                            {
+                                DBTableTransactionCommitter committer(tctable);
+                                execsyncdeletions();
+                            }
 
                             if (synccreate.size())
                             {
@@ -2679,7 +2682,10 @@ void MegaClient::exec()
         }
         else
         {
-            notifypurge();
+            {
+                DBTableTransactionCommitter committer(tctable);
+                notifypurge();
+            }
 
             // sync timer: retry syncdown() ops in case of local filesystem lock clashes
             if (syncdownretry && syncdownbt.armed())

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -12723,7 +12723,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
             // local: file, remote: folder - overwrite
             // local: folder, remote: folder - recurse
             // local: file, remote: file - overwrite if newer
-            if (ll->type != rit->second->type || ll->mIsSymlink)
+            if (ll->type != rit->second->type || ll->mIsSymlink) //TODO: when Node has mIsSymlink, check !=
             {
                 insync = false;
                 LOG_warn << "Type changed: " << localname << " LNtype: " << ll->type << " Ntype: " << rit->second->type << " isSymLink = " << ll->mIsSymlink;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1362,7 +1362,7 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
         {
             if (l)
             {
-                if (l->type == fa->type)
+                if (l->type == fa->type && l->mIsSymlink == fa->mIsSymLink)
                 {
                     // mark as present
                     l->setnotseen(0);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1508,6 +1508,7 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
                 if (fa->fsidvalid && (it = client->fsidnode.find(fa->fsid)) != client->fsidnode.end()
                     // additional checks to prevent wrong fsid matches
                     && it->second->type == fa->type
+                    && it->second->mIsSymlink == fa->mIsSymLink
                     && (!parent
                         || (it->second->sync == parent->sync)
                         || ((fp1 = it->second->sync->dirnotify->fsfingerprint())
@@ -1656,11 +1657,6 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
                         scan(localname ? localpath : &tmppath, fa.get());
                     }
                 }
-                else if (fa->mIsSymLink)
-                {
-                    LOG_debug << "checked path is a symlink.  Parent: " << (parent ? parent->name : "NO");
-                    //doing nothing for the moment
-                }
                 else
                 {
                     // this is a new node: add
@@ -1672,6 +1668,8 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
                     {
                         l->setfsid(fa->fsid, client->fsidnode);
                     }
+
+                    l->mIsSymlink = fa->mIsSymLink;
 
                     newnode = true;
                 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1679,7 +1679,7 @@ LocalNode* Sync::checkpath(LocalNode* l, string* localpath, string* localname, d
         if (l)
         {
             // detect file changes or recurse into new subfolders
-            if (l->type == FOLDERNODE)
+            if (l->type == FOLDERNODE && !l->mIsSymlink)
             {
                 if (newnode)
                 {

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -2848,6 +2848,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkUponSyncDown)
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
 
+    //create a file in client 2 that will be synced down and move link to sync debris in 1
     ASSERT_TRUE(createFile(clientA2.syncSet[2].localpath, "linked"));
 
     // let them catch up


### PR DESCRIPTION
remove `fa->fopen` call within ::syncup that slowed down sync engine