### PR TITLE
Address warnings from logging.h when trying to build test_integration…

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -889,6 +889,9 @@ target_compile_definitions(test_integration PRIVATE _SILENCE_TR1_NAMESPACE_DEPRE
 target_compile_definitions(tool_purge_account PRIVATE _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
 target_link_libraries(test_unit gtest Mega )
 target_link_libraries(test_integration gtest Mega )
+if(APPLE)
+    target_link_libraries(test_integration "-framework Security" )
+endif()
 target_link_libraries(tool_purge_account gtest Mega )
 
 if(WIN32)

--- a/examples/megasimplesync.cpp
+++ b/examples/megasimplesync.cpp
@@ -114,7 +114,11 @@ public:
 
     // Logger interface
 public:
-    void log(const char *time, int loglevel, const char *source, const char *message);
+    void log(const char *time, int loglevel, const char *source, const char *message
+        #ifdef ENABLE_LOG_PERFORMANCE
+            , const char **directMessages = nullptr, size_t *directMessagesSizes = nullptr, unsigned numberMessages = 0
+        #endif
+    );
 };
 
 // globals
@@ -344,7 +348,11 @@ SyncApp:: SyncApp(string local_folder_, string remote_folder_) :
     local_folder(local_folder_), remote_folder(remote_folder_), cwd(UNDEF), initial_fetch(true)
 {}
 
-void SyncApp::log(const char *time, int loglevel, const char *source, const char *message)
+void SyncApp::log(const char *time, int loglevel, const char *source, const char *message
+#ifdef ENABLE_LOG_PERFORMANCE
+                 , const char **directMessages, size_t *directMessagesSizes, unsigned numberMessages
+#endif
+                 )
 {
     if (!time)
     {
@@ -361,7 +369,13 @@ void SyncApp::log(const char *time, int loglevel, const char *source, const char
         message = "";
     }
 
+#ifdef ENABLE_LOG_PERFORMANCE
     cout << "[" << time << "][" << SimpleLogger::toStr((LogLevel)loglevel) << "] " << message << endl;
+#else
+    cout << "[" << time << "][" << SimpleLogger::toStr((LogLevel)loglevel) << "] ";
+    for (unsigned i = 0; i < numberMessages; ++i) cout.write(directMessages[i], directMessagesSizes[i]);
+    cout << endl;
+#endif
 }
 
 void SyncApp::prelogin_result(int version, std::string* email, std::string *salt, error e)

--- a/examples/megasimplesync.cpp
+++ b/examples/megasimplesync.cpp
@@ -369,7 +369,7 @@ void SyncApp::log(const char *time, int loglevel, const char *source, const char
         message = "";
     }
 
-#ifdef ENABLE_LOG_PERFORMANCE
+#ifndef ENABLE_LOG_PERFORMANCE
     cout << "[" << time << "][" << SimpleLogger::toStr((LogLevel)loglevel) << "] " << message << endl;
 #else
     cout << "[" << time << "][" << SimpleLogger::toStr((LogLevel)loglevel) << "] ";

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -407,7 +407,7 @@ public:
                     i++;
                 }
 
-                logger->log(nullptr, level, nullptr, "", dm.get(), dms.get(), static_cast<int>(i));
+                logger->log(nullptr, level, nullptr, "", dm.get(), dms.get(), i);
             }
         }
         for (auto &s: mCopiedParts)

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -362,8 +362,8 @@ struct MEGA_API LocalNode : public File
     handle dirnotifytag = mega::UNDEF;
 #endif
 
-    void prepare();
-    void completed(Transfer*, LocalNode*);
+    void prepare() override;
+    void completed(Transfer*, LocalNode*) override;
 
     void setnode(Node*);
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -139,7 +139,7 @@ public:
     void postLog(int logLevel, const char *message, const char *filename, int line);
     void log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-             , const char **directMessages, size_t *directMessagesSizes, int numberMessages
+             , const char **directMessages, size_t *directMessagesSizes, unsigned numberMessages
 #endif
             ) override;
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22428,7 +22428,7 @@ void ExternalLogger::postLog(int logLevel, const char *message, const char *file
 
 void ExternalLogger::log(const char *time, int loglevel, const char *source, const char *message
 #ifdef ENABLE_LOG_PERFORMANCE
-          , const char **directMessages = nullptr, size_t *directMessagesSizes = nullptr, int numberMessages = 0
+          , const char **directMessages = nullptr, size_t *directMessagesSizes = nullptr, unsigned numberMessages = 0
 #endif
                          )
 {

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -1346,9 +1346,9 @@ void CurlHttpIO::send_request(CurlHttpContext* httpctx)
         else
         {
             LOG_debug << httpctx->req->logname << "Sending " << req->out->size() << ": "
-                      << DirectMessage(req->out->c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                      << DirectMessage(req->out->c_str(), static_cast<size_t>(SimpleLogger::maxPayloadLogSize / 2))
                       << " [...] "
-                      << DirectMessage(req->out->c_str() + req->out->size() - SimpleLogger::maxPayloadLogSize / 2, SimpleLogger::maxPayloadLogSize / 2);
+                      << DirectMessage(req->out->c_str() + req->out->size() - SimpleLogger::maxPayloadLogSize / 2, static_cast<size_t>(SimpleLogger::maxPayloadLogSize / 2));
         }
     }
 
@@ -2145,9 +2145,9 @@ bool CurlHttpIO::multidoio(CURLM *curlmhandle)
                         else
                         {
                             LOG_debug << req->logname << "Received " << req->in.size() << ": "
-                                      << DirectMessage(req->in.c_str(), SimpleLogger::maxPayloadLogSize / 2)
+                                      << DirectMessage(req->in.c_str(), static_cast<size_t>(SimpleLogger::maxPayloadLogSize / 2))
                                       << " [...] "
-                                      << DirectMessage(req->in.c_str() + req->in.size() - SimpleLogger::maxPayloadLogSize / 2, SimpleLogger::maxPayloadLogSize / 2);
+                                      << DirectMessage(req->in.c_str() + req->in.size() - SimpleLogger::maxPayloadLogSize / 2, static_cast<size_t>(SimpleLogger::maxPayloadLogSize / 2));
                         }
                     }
                 }

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -706,7 +706,7 @@ bool SdkTest::waitForResponse(bool *responseReceived, unsigned int timeout)
     return true;    // response is received
 }
 
-bool SdkTest::synchronousTransfer(int apiIndex, int type, std::function<void()> f, unsigned int timeout)
+bool SdkTest::synchronousTransfer(unsigned apiIndex, int type, std::function<void()> f, unsigned int timeout)
 {
     auto& flag = mApi[apiIndex].transferFlags[type];
     flag = false;
@@ -717,7 +717,7 @@ bool SdkTest::synchronousTransfer(int apiIndex, int type, std::function<void()> 
     return result;
 }
 
-bool SdkTest::synchronousRequest(int apiIndex, int type, std::function<void()> f, unsigned int timeout)
+bool SdkTest::synchronousRequest(unsigned apiIndex, int type, std::function<void()> f, unsigned int timeout)
 {
     auto& flag = mApi[apiIndex].requestFlags[type];
     flag = false;

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -156,8 +156,8 @@ public:
     std::unique_ptr<MegaEvent> lastEvent;
 
 protected:
-    virtual void SetUp();
-    virtual void TearDown();
+    void SetUp() override;
+    void TearDown() override;
 
     int getApiIndex(MegaApi* api);
 
@@ -174,7 +174,7 @@ protected:
     void onTransferTemporaryError(MegaApi *api, MegaTransfer *transfer, MegaError* error) override {}
     void onUsersUpdate(MegaApi* api, MegaUserList *users) override;
     void onNodesUpdate(MegaApi* api, MegaNodeList *nodes) override;
-    void onAccountUpdate(MegaApi *api);
+    void onAccountUpdate(MegaApi *api) override;
     void onContactRequestsUpdate(MegaApi* api, MegaContactRequestList* requests) override;
     void onReloadNeeded(MegaApi *api) override {}
 #ifdef ENABLE_SYNC
@@ -200,32 +200,32 @@ public:
     void purgeTree(MegaNode *p, bool depthfirst = true);
     bool waitForResponse(bool *responseReceived, unsigned int timeout = maxTimeout);
 
-    bool synchronousRequest(int apiIndex, int type, std::function<void()> f, unsigned int timeout = maxTimeout);
-    bool synchronousTransfer(int apiIndex, int type, std::function<void()> f, unsigned int timeout = maxTimeout);
+    bool synchronousRequest(unsigned apiIndex, int type, std::function<void()> f, unsigned int timeout = maxTimeout);
+    bool synchronousTransfer(unsigned apiIndex, int type, std::function<void()> f, unsigned int timeout = maxTimeout);
 
     // convenience functions - template args just make it easy to code, no need to copy all the exact argument types with listener defaults etc. To add a new one, just copy a line and change the flag and the function called.
-    template<typename ... Args> int synchronousStartUpload(int apiIndex, Args... args) { synchronousTransfer(apiIndex, MegaTransfer::TYPE_UPLOAD, [this, apiIndex, args...]() { megaApi[apiIndex]->startUpload(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousCatchup(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CATCHUP, [this, apiIndex, args...]() { megaApi[apiIndex]->catchup(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousCreateAccount(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CREATE_ACCOUNT, [this, apiIndex, args...]() { megaApi[apiIndex]->createAccount(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousResumeCreateAccount(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CREATE_ACCOUNT, [this, apiIndex, args...]() { megaApi[apiIndex]->resumeCreateAccount(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousSendSignupLink(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SEND_SIGNUP_LINK, [this, apiIndex, args...]() { megaApi[apiIndex]->sendSignupLink(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousFastLogin(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_LOGIN, [this, apiIndex, args...]() { megaApi[apiIndex]->fastLogin(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousRemove(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REMOVE, [this, apiIndex, args...]() { megaApi[apiIndex]->remove(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousInviteContact(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_INVITE_CONTACT, [this, apiIndex, args...]() { megaApi[apiIndex]->inviteContact(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousReplyContactRequest(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REPLY_CONTACT_REQUEST, [this, apiIndex, args...]() { megaApi[apiIndex]->replyContactRequest(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousRemoveContact(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REMOVE_CONTACT, [this, apiIndex, args...]() { megaApi[apiIndex]->removeContact(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousShare(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SHARE, [this, apiIndex, args...]() { megaApi[apiIndex]->share(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousExportNode(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_EXPORT, [this, apiIndex, args...]() { megaApi[apiIndex]->exportNode(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousGetRegisteredContacts(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_REGISTERED_CONTACTS, [this, apiIndex, args...]() { megaApi[apiIndex]->getRegisteredContacts(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousGetCountryCallingCodes(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_COUNTRY_CALLING_CODES, [this, apiIndex, args...]() { megaApi[apiIndex]->getCountryCallingCodes(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousGetUserAvatar(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_ATTR_USER, [this, apiIndex, args...]() { megaApi[apiIndex]->getUserAvatar(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousGetUserAttribute(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_ATTR_USER, [this, apiIndex, args...]() { megaApi[apiIndex]->getUserAttribute(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousSetNodeDuration(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SET_ATTR_NODE, [this, apiIndex, args...]() { megaApi[apiIndex]->setNodeDuration(args...); }); return mApi[apiIndex].lastError; }
-    template<typename ... Args> int synchronousSetNodeCoordinates(int apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SET_ATTR_NODE, [this, apiIndex, args...]() { megaApi[apiIndex]->setNodeCoordinates(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousStartUpload(unsigned apiIndex, Args... args) { synchronousTransfer(apiIndex, MegaTransfer::TYPE_UPLOAD, [this, apiIndex, args...]() { megaApi[apiIndex]->startUpload(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousCatchup(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CATCHUP, [this, apiIndex, args...]() { megaApi[apiIndex]->catchup(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousCreateAccount(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CREATE_ACCOUNT, [this, apiIndex, args...]() { megaApi[apiIndex]->createAccount(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousResumeCreateAccount(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_CREATE_ACCOUNT, [this, apiIndex, args...]() { megaApi[apiIndex]->resumeCreateAccount(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousSendSignupLink(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SEND_SIGNUP_LINK, [this, apiIndex, args...]() { megaApi[apiIndex]->sendSignupLink(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousFastLogin(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_LOGIN, [this, apiIndex, args...]() { megaApi[apiIndex]->fastLogin(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousRemove(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REMOVE, [this, apiIndex, args...]() { megaApi[apiIndex]->remove(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousInviteContact(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_INVITE_CONTACT, [this, apiIndex, args...]() { megaApi[apiIndex]->inviteContact(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousReplyContactRequest(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REPLY_CONTACT_REQUEST, [this, apiIndex, args...]() { megaApi[apiIndex]->replyContactRequest(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousRemoveContact(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_REMOVE_CONTACT, [this, apiIndex, args...]() { megaApi[apiIndex]->removeContact(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousShare(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SHARE, [this, apiIndex, args...]() { megaApi[apiIndex]->share(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousExportNode(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_EXPORT, [this, apiIndex, args...]() { megaApi[apiIndex]->exportNode(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetRegisteredContacts(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_REGISTERED_CONTACTS, [this, apiIndex, args...]() { megaApi[apiIndex]->getRegisteredContacts(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetCountryCallingCodes(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_COUNTRY_CALLING_CODES, [this, apiIndex, args...]() { megaApi[apiIndex]->getCountryCallingCodes(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetUserAvatar(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_ATTR_USER, [this, apiIndex, args...]() { megaApi[apiIndex]->getUserAvatar(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousGetUserAttribute(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_GET_ATTR_USER, [this, apiIndex, args...]() { megaApi[apiIndex]->getUserAttribute(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousSetNodeDuration(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SET_ATTR_NODE, [this, apiIndex, args...]() { megaApi[apiIndex]->setNodeDuration(args...); }); return mApi[apiIndex].lastError; }
+    template<typename ... Args> int synchronousSetNodeCoordinates(unsigned apiIndex, Args... args) { synchronousRequest(apiIndex, MegaRequest::TYPE_SET_ATTR_NODE, [this, apiIndex, args...]() { megaApi[apiIndex]->setNodeCoordinates(args...); }); return mApi[apiIndex].lastError; }
 
 
     // convenience functions - make a request and wait for the result via listener, return the result code.  To add new functions to call, just copy the line
-    template<typename ... requestArgs> int doRequestLogout(int apiIndex, requestArgs... args) { RequestTracker rt; megaApi[apiIndex]->logout(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doRequestLogout(unsigned apiIndex, requestArgs... args) { RequestTracker rt; megaApi[apiIndex]->logout(args..., &rt); return rt.waitForResult(); }
 
     void createFile(string filename, bool largeFile = true);
     int64_t getFilesize(string filename);

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -50,18 +50,6 @@ static const string EMPTYFILE   = "empty-file.txt";
 static const string AVATARSRC   = "logo.png";
 static const string AVATARDST   = "deleteme.png";
 
-class MegaLoggerSDK : public MegaLogger {
-
-public:
-    MegaLoggerSDK(const char *filename);
-    ~MegaLoggerSDK();
-
-private:
-    std::ofstream sdklog;
-
-protected:
-    void log(const char *time, int loglevel, const char *source, const char *message);
-};
 
 struct TransferTracker : public ::mega::MegaTransferListener
 {
@@ -160,8 +148,6 @@ public:
     string sid;
     std::unique_ptr<MegaStringListMap> stringListMap;
     std::unique_ptr<MegaStringTable> stringTable;
-
-    MegaLoggerSDK *logger;
 
     m_off_t onTransferUpdate_progress;
     m_off_t onTransferUpdate_filesize;

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -35,6 +35,8 @@
 
 #include <megaapi_impl.h>
 
+#define DEFAULTWAIT std::chrono::seconds(20)
+
 #ifdef ENABLE_SYNC
 
 using namespace ::mega;
@@ -467,7 +469,7 @@ struct StandardClient : public MegaApp
         nextfunctionMCpromise = promise<bool>();
         nextfunctionMC = std::move(f);
         waiter.notify();
-        while (!functionDone.wait_until(guard, chrono::steady_clock::now() + 600s, [this]() { return !nextfunctionMC; }))
+        while (!functionDone.wait_until(guard, chrono::steady_clock::now() + chrono::seconds(600), [this]() { return !nextfunctionMC; }))
         {
             if (!debugging)
             {
@@ -484,7 +486,7 @@ struct StandardClient : public MegaApp
         nextfunctionSCpromise = promise<bool>();
         nextfunctionSC = std::move(f);
         waiter.notify();
-        while (!functionDone.wait_until(guard, chrono::steady_clock::now() + 600s, [this]() { return !nextfunctionSC; }))
+        while (!functionDone.wait_until(guard, chrono::steady_clock::now() + chrono::seconds(600), [this]() { return !nextfunctionSC; }))
         {
             if (!debugging)
             {
@@ -1253,7 +1255,7 @@ struct StandardClient : public MegaApp
 
 
 
-    void waitonsyncs(chrono::seconds d = 2s)
+    void waitonsyncs(chrono::seconds d = chrono::seconds(2))
     {
         auto start = chrono::steady_clock::now();
         for (;;)
@@ -1413,7 +1415,7 @@ struct StandardClient : public MegaApp
 };
 
 
-void waitonsyncs(chrono::seconds d = 4s, StandardClient* c1 = nullptr, StandardClient* c2 = nullptr, StandardClient* c3 = nullptr, StandardClient* c4 = nullptr)
+void waitonsyncs(chrono::seconds d = std::chrono::seconds(4), StandardClient* c1 = nullptr, StandardClient* c2 = nullptr, StandardClient* c3 = nullptr, StandardClient* c4 = nullptr)
 {
     auto start = chrono::steady_clock::now();
     std::vector<StandardClient*> v{ c1, c2, c3, c4 };
@@ -1598,7 +1600,7 @@ GTEST_TEST(Sync, BasicSync_DelRemoteFolder)
 
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     Model model;
@@ -1611,7 +1613,7 @@ GTEST_TEST(Sync, BasicSync_DelRemoteFolder)
     // delete something remotely and let sync catch up
     future<bool> fb = clientA1.thread_do([](StandardClient& sc, promise<bool>& pb) { sc.deleteremote("f/f_2/f_2_1", pb); });
     ASSERT_TRUE(waitonresults(&fb));
-    waitonsyncs(60s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(60), &clientA1, &clientA2);
 
     // check everything matches in both syncs (model has expected state of remote and local)
     ASSERT_TRUE(model.movetosynctrash("f/f_2/f_2_1", "f"));
@@ -1633,7 +1635,7 @@ GTEST_TEST(Sync, BasicSync_DelLocalFolder)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1647,7 +1649,7 @@ GTEST_TEST(Sync, BasicSync_DelLocalFolder)
     ASSERT_TRUE(fs::remove_all(clientA1.syncSet[1].localpath / "f_2" / "f_2_1", e) != static_cast<std::uintmax_t>(-1)) << e;
 
     // let them catch up
-    waitonsyncs(60s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(60), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(model.movetosynctrash("f/f_2/f_2_1", "f"));
@@ -1673,7 +1675,7 @@ GTEST_TEST(Sync, BasicSync_MoveLocalFolder)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1686,7 +1688,7 @@ GTEST_TEST(Sync, BasicSync_MoveLocalFolder)
     ASSERT_TRUE(!rename_error) << rename_error;
 
     // let them catch up
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(model.movenode("f/f_2/f_2_1", "f"));
@@ -1713,7 +1715,7 @@ GTEST_TEST(Sync, BasicSync_MoveLocalFolderBetweenSyncs)
     ASSERT_TRUE(clientA2.setupSync_mainthread("syncA2_1", "f/f_0", 21));
     ASSERT_TRUE(clientA2.setupSync_mainthread("syncA2_2", "f/f_2", 22));
     ASSERT_TRUE(clientA3.setupSync_mainthread("syncA3", "f", 31));
-    waitonsyncs(4s, &clientA1, &clientA2, &clientA3);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2, &clientA3);
     clientA1.logcb = clientA2.logcb = clientA3.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1733,7 +1735,7 @@ GTEST_TEST(Sync, BasicSync_MoveLocalFolderBetweenSyncs)
     ASSERT_TRUE(!rename_error) << rename_error;
 
     // let them catch up
-    waitonsyncs(4s, &clientA1, &clientA2, &clientA3);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2, &clientA3);
 
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(model.movenode("f/f_0/f_0_1", "f/f_2/f_2_1/f_2_1_0"));
@@ -1763,7 +1765,7 @@ GTEST_TEST(Sync, BasicSync_AddLocalFolder)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1774,7 +1776,7 @@ GTEST_TEST(Sync, BasicSync_AddLocalFolder)
     ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath / "f_2", "newkid", 2, 2, 2));
 
     // let them catch up
-    waitonsyncs(30s, &clientA1, &clientA2);  // two minutes should be long enough to get past API_ETEMPUNAVAIL == -18 for sync2 downloading the files uploaded by sync1
+    waitonsyncs(std::chrono::seconds(30), &clientA1, &clientA2);  // two minutes should be long enough to get past API_ETEMPUNAVAIL == -18 for sync2 downloading the files uploaded by sync1
 
     // check everything matches (model has expected state of remote and local)
     model.findnode("f/f_2")->addkid(model.buildModelSubdirs("newkid", 2, 2, 2));
@@ -1802,7 +1804,7 @@ GTEST_TEST(Sync, BasicSync_MAX_NEWNODES1)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1814,7 +1816,7 @@ GTEST_TEST(Sync, BasicSync_MAX_NEWNODES1)
     ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath, "g", 5, 5, 0));  // 5^5=3125 leaf folders, 625 pre-leaf etc
 
     // let them catch up
-    waitonsyncs(30s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(30), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     model.findnode("f")->addkid(model.buildModelSubdirs("g", 5, 5, 0));
@@ -1842,7 +1844,7 @@ GTEST_TEST(Sync, BasicSync_MAX_NEWNODES2)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1854,7 +1856,7 @@ GTEST_TEST(Sync, BasicSync_MAX_NEWNODES2)
     ASSERT_TRUE(buildLocalFolders(clientA1.syncSet[1].localpath, "g", 3000, 1, 0));
 
     // let them catch up
-    waitonsyncs(30s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(30), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     model.findnode("f")->addkid(model.buildModelSubdirs("g", 3000, 1, 0));
@@ -1880,7 +1882,7 @@ GTEST_TEST(Sync, BasicSync_MoveExistingIntoNewLocalFolder)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1897,7 +1899,7 @@ GTEST_TEST(Sync, BasicSync_MoveExistingIntoNewLocalFolder)
     ASSERT_TRUE(!rename_error) << rename_error;
 
     // let them catch up
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     auto f = model.makeModelSubfolder("new");
@@ -1924,7 +1926,7 @@ GTEST_TEST(Sync, DISABLED_BasicSync_MoveSeveralExistingIntoDeepNewLocalFolders)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -1943,7 +1945,7 @@ GTEST_TEST(Sync, DISABLED_BasicSync_MoveSeveralExistingIntoDeepNewLocalFolders)
     ASSERT_TRUE(!rename_error) << rename_error;
 
     // let them catch up
-    waitonsyncs(30s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(30), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     model.findnode("f")->addkid(model.buildModelSubdirs("new", 3, 3, 3));
@@ -1978,7 +1980,7 @@ GTEST_TEST(Sync, BasicSync_SyncDuplicateNames)
     // set up syncs, they should build matching local folders
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -2006,7 +2008,7 @@ GTEST_TEST(Sync, BasicSync_RemoveLocalNodeBeforeSessionResume)
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(pclientA1->setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, pclientA1.get(), &clientA2);
+    waitonsyncs(std::chrono::seconds(4), pclientA1.get(), &clientA2);
     pclientA1->logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -2029,7 +2031,7 @@ GTEST_TEST(Sync, BasicSync_RemoveLocalNodeBeforeSessionResume)
     pclientA1.reset(new StandardClient(localtestroot, "clientA1"));
     ASSERT_TRUE(pclientA1->login_fetchnodes_resumesync(string((char*)session, sessionsize), sync1path.u8string(), "f", 1));
 
-    waitonsyncs(4s, pclientA1.get(), &clientA2);
+    waitonsyncs(std::chrono::seconds(4), pclientA1.get(), &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(model.movetosynctrash("f/f_2", "f"));
@@ -2054,7 +2056,7 @@ GTEST_TEST(Sync, BasicSync_RemoteFolderCreationRaceSamename)
     // set up sync for both, it should build matching local folders (empty initially)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // now have both clients create the same remote folder structure simultaneously.  We should end up with just one copy of it on the server and in both syncs
@@ -2063,7 +2065,7 @@ GTEST_TEST(Sync, BasicSync_RemoteFolderCreationRaceSamename)
     ASSERT_TRUE(waitonresults(&p1, &p2));
 
     // let them catch up
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     Model model;
@@ -2088,7 +2090,7 @@ GTEST_TEST(Sync, BasicSync_LocalFolderCreationRaceSamename)
     // set up sync for both, it should build matching local folders (empty initially)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "", 2));
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
 
     // now have both clients create the same folder structure simultaneously.  We should end up with just one copy of it on the server and in both syncs
@@ -2097,7 +2099,7 @@ GTEST_TEST(Sync, BasicSync_LocalFolderCreationRaceSamename)
     ASSERT_TRUE(waitonresults(&p1, &p2));
 
     // let them catch up
-    waitonsyncs(30s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(30), &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     Model model;
@@ -2120,7 +2122,7 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterNonclashingLocalAndRemoteCh
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(pclientA1->setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, pclientA1.get(), &clientA2);
+    waitonsyncs(std::chrono::seconds(4), pclientA1.get(), &clientA2);
     pclientA1->logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -2162,13 +2164,13 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterNonclashingLocalAndRemoteCh
     model2.movetosynctrash("f/f_2", "f");
 
     cout << "*********************  get sync2 activity out of the way" << endl;
-    waitonsyncs(20s, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA2);
 
     cout << "*********************  resume A1 session (with sync), see if A2 nodes and localnodes get in sync again" << endl;
     pclientA1.reset(new StandardClient(localtestroot, "clientA1"));
     ASSERT_TRUE(pclientA1->login_fetchnodes_resumesync(string((char*)session, sessionsize), sync1path.u8string(), "f", 1));
     ASSERT_EQ(pclientA1->basefolderhandle, clientA2.basefolderhandle);
-    waitonsyncs(20s, pclientA1.get(), &clientA2);
+    waitonsyncs(DEFAULTWAIT, pclientA1.get(), &clientA2);
 
     cout << "*********************  check everything matches (model has expected state of remote and local)" << endl;
     ASSERT_TRUE(pclientA1->confirmModel_mainthread(model1.findnode("f"), 1));
@@ -2192,7 +2194,7 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterClashingLocalAddRemoteDelet
     // set up sync for A1, it should build matching local folders
     ASSERT_TRUE(pclientA1->setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
-    waitonsyncs(4s, pclientA1.get(), &clientA2);
+    waitonsyncs(std::chrono::seconds(4), pclientA1.get(), &clientA2);
     pclientA1->logcb = clientA2.logcb = true;
 
     // check everything matches (model has expected state of remote and local)
@@ -2215,13 +2217,13 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterClashingLocalAddRemoteDelet
     ASSERT_TRUE(buildLocalFolders(sync1path / "f_1/f_1_2", "newlocal", 2, 2, 2));
 
     // get sync2 activity out of the way
-    waitonsyncs(4s, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA2);
 
     // resume A1 session (with sync), see if A2 nodes and localnodes get in sync again
     pclientA1.reset(new StandardClient(localtestroot, "clientA1"));
     ASSERT_TRUE(pclientA1->login_fetchnodes_resumesync(string((char*)session, sessionsize), sync1path.u8string(), "f", 1));
     ASSERT_EQ(pclientA1->basefolderhandle, clientA2.basefolderhandle);
-    waitonsyncs(4s, pclientA1.get(), &clientA2);
+    waitonsyncs(std::chrono::seconds(4), pclientA1.get(), &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     model.findnode("f/f_1/f_1_2")->addkid(model.buildModelSubdirs("newlocal", 2, 2, 2));
@@ -2306,7 +2308,7 @@ GTEST_TEST(Sync, BasicSync_SpecialCreateFile)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
 
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
@@ -2322,7 +2324,7 @@ GTEST_TEST(Sync, BasicSync_SpecialCreateFile)
     }
 
     // let them catch up
-    waitonsyncs(20s, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
@@ -2349,7 +2351,7 @@ GTEST_TEST(Sync, DISABLED_BasicSync_moveAndDeleteLocalFile)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
 
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
@@ -2363,7 +2365,7 @@ GTEST_TEST(Sync, DISABLED_BasicSync_moveAndDeleteLocalFile)
     fs::remove(clientA1.syncSet[1].localpath / "renamed");
 
     // let them catch up
-    waitonsyncs(20s, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(model.movetosynctrash("f/f_0", "f"));
@@ -2516,7 +2518,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndDeleteLink)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
 
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
@@ -2529,7 +2531,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndDeleteLink)
     ASSERT_TRUE(!linkage_error) << linkage_error;
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
@@ -2537,7 +2539,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndDeleteLink)
 
     fs::remove(clientA1.syncSet[1].localpath / "linked");
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
@@ -2561,7 +2563,7 @@ GTEST_TEST(Sync, BasicSync_CreateRenameAndDeleteLink)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
 
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
@@ -2574,7 +2576,7 @@ GTEST_TEST(Sync, BasicSync_CreateRenameAndDeleteLink)
     ASSERT_TRUE(!linkage_error) << linkage_error;
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
@@ -2582,7 +2584,7 @@ GTEST_TEST(Sync, BasicSync_CreateRenameAndDeleteLink)
     fs::rename(clientA1.syncSet[1].localpath / "linked", clientA1.syncSet[1].localpath / "linkrenamed", linkage_error);
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
@@ -2590,7 +2592,7 @@ GTEST_TEST(Sync, BasicSync_CreateRenameAndDeleteLink)
     fs::remove(clientA1.syncSet[1].localpath / "linkrenamed");
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
@@ -2614,7 +2616,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkLocally)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
 
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
@@ -2627,14 +2629,14 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkLocally)
     ASSERT_TRUE(!linkage_error) << linkage_error;
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
     fs::rename(clientA1.syncSet[1].localpath / "f_0", clientA1.syncSet[1].localpath / "linked", linkage_error);
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
@@ -2643,7 +2645,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkLocally)
     ASSERT_TRUE(createFile(clientA1.syncSet[1].localpath, "linked"));
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     model.findnode("f")->addkid(model.makeModelSubfile("linked"));
     model.ensureLocalDebrisTmpLock("f"); // since we downloaded files
@@ -2671,7 +2673,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkUponSyncDown)
     ASSERT_TRUE(clientA1.setupSync_mainthread("sync1", "f", 1));
     ASSERT_TRUE(clientA2.setupSync_mainthread("sync2", "f", 2));
 
-    waitonsyncs(4s, &clientA1, &clientA2);
+    waitonsyncs(std::chrono::seconds(4), &clientA1, &clientA2);
     clientA1.logcb = clientA2.logcb = true;
     // check everything matches (model has expected state of remote and local)
     ASSERT_TRUE(clientA1.confirmModel_mainthread(model.findnode("f"), 1));
@@ -2683,7 +2685,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkUponSyncDown)
     ASSERT_TRUE(!linkage_error) << linkage_error;
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     //check client 2 is unaffected
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
@@ -2691,7 +2693,7 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkUponSyncDown)
     ASSERT_TRUE(createFile(clientA2.syncSet[2].localpath, "linked"));
 
     // let them catch up
-    waitonsyncs(DEFAULWAIT, &clientA1, &clientA2);
+    waitonsyncs(DEFAULTWAIT, &clientA1, &clientA2);
 
     model.findnode("f")->addkid(model.makeModelSubfolder("linked")); //notice: the deleted here is folder because what's actually deleted is a symlink that points to a folder
                                                                      //ideally we could add full support for symlinks in this tests suite

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -13,7 +13,11 @@ namespace {
 class MegaLogger : public mega::Logger
 {
 public:
-    void log(const char* time, int loglevel, const char* source, const char* message)
+    void log(const char* time, int loglevel, const char* source, const char* message
+#ifdef ENABLE_LOG_PERFORMANCE
+          , const char **directMessages = nullptr, size_t *directMessagesSizes = nullptr, unsigned numberMessages = 0
+#endif
+    ) override
     {
         std::ostringstream os;
 
@@ -34,8 +38,19 @@ public:
             }
             os << ts;
         }
+#ifdef ENABLE_LOG_PERFORMANCE
+        os << "] " << mega::SimpleLogger::toStr(static_cast<mega::LogLevel>(loglevel)) << ": ";
+        if (message)
+        {
+            os << message;
+        }
+        else
+        {
+            for (unsigned i = 0; i < numberMessages; ++i) os.write(directMessages[i], directMessagesSizes[i]);
+        }
+#else
         os << "] " << mega::SimpleLogger::toStr(static_cast<mega::LogLevel>(loglevel)) << ": " << message;
-
+#endif
         if (source)
         {
             os << " (" << source << ")";

--- a/tests/unit/Logging_test.cpp
+++ b/tests/unit/Logging_test.cpp
@@ -19,6 +19,8 @@
 
 #include <mega/logging.h>
 
+#ifdef NOT_REALLY_NEEDED_BECAUSE_WE_EXERCISE_IT_ALL_THE_TIME_ANYWAY
+
 #ifdef ENABLE_LOG_PERFORMANCE
 namespace {
 
@@ -505,3 +507,5 @@ TEST(Logging, macroFatal)
         EXPECT_NE(logger.mMessage[0].find(msg), std::string::npos);
     }
 }
+
+#endif


### PR DESCRIPTION
… for Mac

Some types were mismatched and caused lots of signed/unsigned warnings (repeating since they were in the header)
Also found lots of areas where the ENABLE_LOG_PERFORMANCE was not checked, and various projects failed to build if that was turned on.
Removed Logging_test.cpp code since that was not building with that on, and we are using and checking logging all the time anyway.
Added some casts in net.cpp to ensure we use the size_t version of DirectMessage() constructor, and highlight that we are truncating the size argument at that point (for those targets that have 32 bit size_t).