### PR TITLE
#15027. Fix/useralerts on their own sc channel

### DIFF
--- a/include/mega/http.h
+++ b/include/mega/http.h
@@ -211,7 +211,7 @@ struct MEGA_API HttpReq
 
     string posturl;
 
-    bool protect;
+    bool protect; // check pinned public key
     bool minspeed;
 
     bool sslcheckfailed;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -802,7 +802,8 @@ private:
     vector<TimerWithBackoff *> bttimers;
 
     // server-client command trigger connection
-    HttpReq* pendingsc;
+    std::unique_ptr<HttpReq> pendingsc;
+    std::unique_ptr<HttpReq> pendingsc50;
     BackoffTimer btsc;
     bool stopsc = false;
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -806,6 +806,8 @@ private:
     std::unique_ptr<HttpReq> pendingscUserAlerts;
     BackoffTimer btsc;
     bool stopsc = false;
+    bool pendingscTimedOut = false;
+
 
     // badhost report
     HttpReq* badhostcs;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -803,7 +803,7 @@ private:
 
     // server-client command trigger connection
     std::unique_ptr<HttpReq> pendingsc;
-    std::unique_ptr<HttpReq> pendingsc50;
+    std::unique_ptr<HttpReq> pendingscUserAlerts;
     BackoffTimer btsc;
     bool stopsc = false;
 


### PR DESCRIPTION
The c=50 useralert request occured on the `wsc` channel but should be on its own `sc` channel without any timeout (and the `wsc` system must wait for it before continuing)
Added a pendingsc50 channel to match the pendingsc channel and moved the relevant logic there.
Using unique_ptr to ensure ownership issues are addressed, so there are some small changes to pendingsc.
Also found a case where btcs should have been btsc.
