### PR TITLE
#15016. Add 32/64 bit architecture of App and OS to UserAgent

### DIFF
--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -339,7 +339,7 @@ struct MEGA_API FileSystemAccess : public EventTrigger
     bool target_exists;
 
     // append local operating system version information to string
-    virtual void osversion(string*) const { }
+    virtual void osversion(string*, bool includeArchitecture) const { }
 
     // append id for stats
     virtual void statsid(string*) const { }

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -338,8 +338,9 @@ struct MEGA_API FileSystemAccess : public EventTrigger
     // set whenever an operation fails because the target already exists
     bool target_exists;
 
-    // append local operating system version information to string
-    virtual void osversion(string*, bool includeArchitecture) const { }
+    // append local operating system version information to string.
+    // Set includeArchExtraInfo to know if the app is 32 bit running on 64 bit (on windows, that is via the WOW subsystem)
+    virtual void osversion(string*, bool includeArchExtraInfo) const { }
 
     // append id for stats
     virtual void statsid(string*) const { }

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -106,7 +106,7 @@ public:
     void addevents(Waiter*, int) override;
     int checkevents(Waiter*) override;
 
-    void osversion(string*) const override;
+    void osversion(string*, bool includeArchitecture) const override;
     void statsid(string*) const override;
 
     static void emptydirlocal(string*, dev_t = 0);

--- a/include/mega/win32/megafs.h
+++ b/include/mega/win32/megafs.h
@@ -75,7 +75,7 @@ public:
     static bool istransient(DWORD);
     bool istransientorexists(DWORD);
 
-    void osversion(string*, bool includeArchitecture) const override;
+    void osversion(string*, bool includeArchExtraInfo) const override;
     void statsid(string*) const override;
 
     static void emptydirlocal(string*, dev_t = 0);

--- a/include/mega/win32/megafs.h
+++ b/include/mega/win32/megafs.h
@@ -75,7 +75,7 @@ public:
     static bool istransient(DWORD);
     bool istransientorexists(DWORD);
 
-    void osversion(string*) const override;
+    void osversion(string*, bool includeArchitecture) const override;
     void statsid(string*) const override;
 
     static void emptydirlocal(string*, dev_t = 0);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -10760,7 +10760,7 @@ const char *MegaApiImpl::getVersion()
 char *MegaApiImpl::getOperatingSystemVersion()
 {
     string version;
-    fsAccess->osversion(&version);
+    fsAccess->osversion(&version, false);
     return MegaApi::strdup(version.c_str());
 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1221,11 +1221,12 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
     useragent = u;
 
     useragent.append(" (");
-    fsaccess->osversion(&useragent);
+    fsaccess->osversion(&useragent, true);
 
     useragent.append(") MegaClient/" TOSTRING(MEGA_MAJOR_VERSION)
                      "." TOSTRING(MEGA_MINOR_VERSION)
                      "." TOSTRING(MEGA_MICRO_VERSION));
+    useragent += sizeof(char*) == 8 ? "/64" : (sizeof(char*) == 4 ? "/32" : "");
 
     LOG_debug << "User-Agent: " << useragent;
     LOG_debug << "Cryptopp version: " << CRYPTOPP_VERSION;

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -1547,7 +1547,7 @@ string getDistroVersion()
 }
 #endif
 
-void PosixFileSystemAccess::osversion(string* u, bool /*includeArchitecture*/) const
+void PosixFileSystemAccess::osversion(string* u, bool /*includeArchExtraInfo*/) const
 {
 #ifdef __linux__
     string distro = getDistro();

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -1547,7 +1547,7 @@ string getDistroVersion()
 }
 #endif
 
-void PosixFileSystemAccess::osversion(string* u) const
+void PosixFileSystemAccess::osversion(string* u, bool /*includeArchitecture*/) const
 {
 #ifdef __linux__
     string distro = getDistro();

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "mega.h"
+#include <wow64apiset.h>
 
 namespace mega {
 WinFileAccess::WinFileAccess(Waiter *w) : FileAccess(w)
@@ -1172,7 +1173,7 @@ bool WinFileSystemAccess::expanselocalpath(string *path, string *absolutepath)
 #endif
 }
 
-void WinFileSystemAccess::osversion(string* u) const
+void WinFileSystemAccess::osversion(string* u, bool includeArchitecture) const
 {
     char buf[128];
 
@@ -1201,6 +1202,16 @@ void WinFileSystemAccess::osversion(string* u) const
         }
     }
     snprintf(buf, sizeof(buf), "Windows %d.%d.%d", version.dwMajorVersion, version.dwMinorVersion, version.dwBuildNumber);
+
+    if (includeArchitecture)
+    {
+        BOOL isWOW = FALSE;
+        BOOL callSucceeded = IsWow64Process(GetCurrentProcess(), &isWOW);
+        if (callSucceeded && isWOW)
+        {
+            strcat(buf, "/64");  // if the app 32/64 bit matches the OS, then no need to specify the OS separately, so we only need to cover the WOW 32 bit on 64 bit case.
+        }
+    }
 #endif
 
     u->append(buf);

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -1173,7 +1173,7 @@ bool WinFileSystemAccess::expanselocalpath(string *path, string *absolutepath)
 #endif
 }
 
-void WinFileSystemAccess::osversion(string* u, bool includeArchitecture) const
+void WinFileSystemAccess::osversion(string* u, bool includeArchExtraInfo) const
 {
     char buf[128];
 
@@ -1203,7 +1203,7 @@ void WinFileSystemAccess::osversion(string* u, bool includeArchitecture) const
     }
     snprintf(buf, sizeof(buf), "Windows %d.%d.%d", version.dwMajorVersion, version.dwMinorVersion, version.dwBuildNumber);
 
-    if (includeArchitecture)
+    if (includeArchExtraInfo)
     {
         BOOL isWOW = FALSE;
         BOOL callSucceeded = IsWow64Process(GetCurrentProcess(), &isWOW);


### PR DESCRIPTION
eg. "MEGAsync/4.3.1.0 (Windows 10.0.18362/64) MegaClient/3.6.9/32".
/64 and /32 are the additions to the existing format.
/32 on the end denotes whether the app is 32 bit or 64 bit (so could also be /64 (or empty currently, for any other architecture))
And the /64 inside the brackets would only be present when the OS architecture differs from the app (so for windows, only when the app is 32 bit on 64 bit, under the WOW system)