### PR TITLE
Fix for SdkTestFolderIteration when it can't remove the old test fold…

### DIFF
--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -1951,7 +1951,7 @@ bool PosixDirAccess::dnext(string* path, string* name, bool followsymlinks, node
             path->append(d->d_name);
 
             bool statOk = !lstat(path->c_str(), &statbuf);
-            if (statOk && S_ISLNK(statbuf.st_mode) && followsymlinks)
+            if (followsymlinks && statOk && S_ISLNK(statbuf.st_mode))
             {
                 currentItemFollowedSymlink = true;
                 statOk = !stat(path->c_str(), &statbuf);

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -2372,8 +2372,11 @@ TEST_F(SdkTest, SdkTestFolderIteration)
         bool openWithNameOrUseFileAccess = testcombination == 0;
 
         error_code ec;
-        fs::remove_all("test_SdkTestFolderIteration", ec);
-        ASSERT_TRUE(!ec) << "could not remove old test folder";
+        if (fs::exists("test_SdkTestFolderIteration")) 
+        {
+            fs::remove_all("test_SdkTestFolderIteration", ec);
+            ASSERT_TRUE(!ec) << "could not remove old test folder";
+        }
 
         fs::create_directory("test_SdkTestFolderIteration", ec);
         ASSERT_TRUE(!ec) << "could not create test folder";


### PR DESCRIPTION
…er because it doesn't exist

Also a slight performance improvement from review for PR 1907, which is already merged