### PR TITLE
Use thread local for logger buffer to avoid crashes

### DIFF
--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -200,7 +200,7 @@ class SimpleLogger
     static OutputMap outputs;
     static OutputStreams getOutput(enum LogLevel ll);
 #else
-    std::array<char, LOGGER_CHUNKS_SIZE> mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
+    static __thread std::array<char, LOGGER_CHUNKS_SIZE> mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
     std::array<char, LOGGER_CHUNKS_SIZE>::iterator mBufferIt;
 
     using DiffType = std::array<char, LOGGER_CHUNKS_SIZE>::difference_type;

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -200,7 +200,12 @@ class SimpleLogger
     static OutputMap outputs;
     static OutputStreams getOutput(enum LogLevel ll);
 #else
-    static __thread std::array<char, LOGGER_CHUNKS_SIZE> mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
+
+#ifdef WIN32
+    static thread_local std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
+#else
+    static __thread std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
+#endif
     std::array<char, LOGGER_CHUNKS_SIZE>::iterator mBufferIt;
 
     using DiffType = std::array<char, LOGGER_CHUNKS_SIZE>::difference_type;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -42,9 +42,15 @@ Logger *SimpleLogger::logger = nullptr;
 enum LogLevel SimpleLogger::logCurrentLevel = logInfo;
 long long SimpleLogger::maxPayloadLogSize  = 10240;
 
-__thread std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
+#ifdef ENABLE_LOG_PERFORMANCE
 
-#ifndef ENABLE_LOG_PERFORMANCE
+#ifdef WIN32
+thread_local std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; 
+#else
+__thread std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; 
+#endif
+
+#else
 // static member initialization
 std::mutex SimpleLogger::outputs_mutex;
 OutputMap SimpleLogger::outputs;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -42,6 +42,8 @@ Logger *SimpleLogger::logger = nullptr;
 enum LogLevel SimpleLogger::logCurrentLevel = logInfo;
 long long SimpleLogger::maxPayloadLogSize  = 10240;
 
+__thread std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; // will be stack-allocated since SimpleLogger is stack-allocated
+
 #ifndef ENABLE_LOG_PERFORMANCE
 // static member initialization
 std::mutex SimpleLogger::outputs_mutex;


### PR DESCRIPTION
Avoid stack overflow when folders go very deep and most of the stack frame is taken by logging objects. Use thread_local for better management of stack memory