### PR TITLE
performance: no need to update the LocalNode tree sync status during …

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1582,6 +1582,9 @@ public:
     // -1: expired, 0: inactive (no business subscription), 1: active, 2: grace-period
     BizStatus mBizStatus;
 
+    // whether the destructor has started running yet
+    bool destructorRunning = false;
+
     // Keep track of high level operation counts and times, for performance analysis
     struct PerformanceStats
     {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1237,6 +1237,7 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
 
 MegaClient::~MegaClient()
 {
+    destructorRunning = true;
     locallogout(false);
 
     delete pendingcs;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1211,7 +1211,7 @@ void LocalNode::setnameparent(LocalNode* newparent, string* newlocalpath)
         }
     }
 
-    if (parent && parent != newparent)
+    if (parent && parent != newparent && !sync->client->destructorRunning)
     {
         treestate(TREESTATE_NONE);
     }


### PR DESCRIPTION
…MegaClient destruction.

Saves minutes during MEGAsync shutdown with a million node sync.