### PR TITLE
#15383. Achievements disabled for business accounts

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -5247,7 +5247,7 @@ MegaUser *MegaApiImpl::getMyUser()
 
 bool MegaApiImpl::isAchievementsEnabled()
 {
-    return client->achievements_enabled;
+    return client->achievements_enabled && !isBusinessAccount();
 }
 
 bool MegaApiImpl::isBusinessAccount()

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -5247,7 +5247,8 @@ MegaUser *MegaApiImpl::getMyUser()
 
 bool MegaApiImpl::isAchievementsEnabled()
 {
-    return client->achievements_enabled && !isBusinessAccount();
+    assert(!isBusinessAccount() || !client->achievements_enabled);
+    return client->achievements_enabled;
 }
 
 bool MegaApiImpl::isBusinessAccount()

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6552,6 +6552,7 @@ void MegaClient::sc_ub()
                 if (prevBizStatus == BIZ_STATUS_INACTIVE)
                 {
                     app->account_updated();
+                    getuserdata();  // update account flags
                 }
 
                 return;
@@ -7967,7 +7968,9 @@ error MegaClient::readmiscflags(JSON *json)
         switch (json->getnameid())
         {
         // mcs:1 --> MegaChat enabled
-        // ach:1 --> Mega Achievements enabled
+        case MAKENAMEID3('a', 'c', 'h'):
+            achievements_enabled = bool(json->getint());    //  Mega Achievements enabled
+            break;
         case MAKENAMEID4('m', 'f', 'a', 'e'):   // multi-factor authentication enabled
             gmfa_enabled = bool(json->getint());
             break;


### PR DESCRIPTION
When a free account becomes business account at runtime, the SDK is already logged in as `achievements_enabled`, but business accounts do not allow achievements. Better to start returning the account has achievements disabled.