### PR TITLE
#15355. More fingerprint accuracy when deciding to copy rather than upload a file

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -7978,13 +7978,12 @@ void exec_metamac(autocomplete::ACState& s)
         return;
     }
 
-    auto ifaccess = client->fsaccess->newfileaccess();
+    auto ifAccess = client->fsaccess->newfileaccess();
     {
-        std::string local_path;
+        std::string localPath;
+        client->fsaccess->path2local(&s.words[1].s, &localPath);
 
-        client->fsaccess->path2local(&s.words[1].s, &local_path);
-
-        if (!ifaccess->fopen(&local_path, 1, 0))
+        if (!ifAccess->fopen(&localPath, 1, 0))
         {
             cerr << "Failed to open: " << s.words[1].s << endl;
             return;
@@ -7992,19 +7991,19 @@ void exec_metamac(autocomplete::ACState& s)
     }
 
     SymmCipher cipher;
-    int64_t remote_iv;
-    int64_t remote_mm;
+    int64_t remoteIv;
+    int64_t remoteMac;
 
     {
-        std::string remote_key = node->nodekey();
-        const char *iva = &remote_key[SymmCipher::KEYLENGTH];
+        std::string remoteKey = node->nodekey();
+        const char *iva = &remoteKey[SymmCipher::KEYLENGTH];
 
-        cipher.setkey((byte*)&remote_key[0], node->type);
-        remote_iv = MemAccess::get<int64_t>(iva);
-        remote_mm = MemAccess::get<int64_t>(iva + sizeof(int64_t));
+        cipher.setkey((byte*)&remoteKey[0], node->type);
+        remoteIv = MemAccess::get<int64_t>(iva);
+        remoteMac = MemAccess::get<int64_t>(iva + sizeof(int64_t));
     }
 
-    auto result = generate_metamac(cipher, *ifaccess, remote_iv);
+    auto result = generateMetaMac(cipher, *ifAccess, remoteIv);
     if (!result.first)
     {
         cerr << "Failed to generate metamac for: "
@@ -8016,12 +8015,12 @@ void exec_metamac(autocomplete::ACState& s)
         const std::ios::fmtflags flags = cout.flags();
 
         cout << s.words[2].s
-             << ": "
+             << " (remote): "
              << std::hex
-             << (uint64_t)remote_mm
+             << (uint64_t)remoteMac
              << "\n"
              << s.words[1].s
-             << ": "
+             << " (local): "
              << (uint64_t)result.second
              << endl;
 

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -2898,7 +2898,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_cp, sequence(text("cp"), remoteFSPath(client, &cwd, "src"), either(remoteFSPath(client, &cwd, "dst"), param("dstemail"))));
     p->Add(exec_du, sequence(text("du"), remoteFSPath(client, &cwd)));
 #ifdef ENABLE_SYNC
-    p->Add(exec_sync, sequence(text("sync"), opt(sequence(localFSPath(), either(remoteFSPath(client, &cwd, "dst"), param("cancelslot"))))));
+    p->Add(exec_sync, sequence(text("sync"), opt(either(sequence(localFSPath(), remoteFSPath(client, &cwd, "dst")), param("cancelslot")))));
     p->Add(exec_syncconfig, sequence(text("syncconfig"), opt(sequence(param("type (TWOWAY/UP/DOWN)"), opt(sequence(param("syncDeletions (ON/OFF)"), param("forceOverwrite (ON/OFF)")))))));
 #endif
     p->Add(exec_export, sequence(text("export"), remoteFSPath(client, &cwd), opt(either(param("expiretime"), text("del")))));

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -376,3 +376,5 @@ void exec_find(autocomplete::ACState& s);
 void exec_treecompare(autocomplete::ACState& s);
 void exec_querytransferquota(autocomplete::ACState& s);
 #endif
+void exec_metamac(autocomplete::ACState& s);
+

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -172,6 +172,18 @@ struct MEGA_API InputStreamAccess
     virtual ~InputStreamAccess() { }
 };
 
+class MEGA_API FileInputStream : public InputStreamAccess
+{
+    FileAccess *fileAccess;
+    m_off_t offset;
+
+public:
+    FileInputStream(FileAccess *fileAccess);
+
+    m_off_t size() override;
+    bool read(byte *buffer, unsigned size) override;
+};
+
 // generic host directory enumeration
 struct MEGA_API DirAccess
 {

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1181,6 +1181,8 @@ public:
 
     Node* nodebyhandle(handle);
     Node* nodebyfingerprint(FileFingerprint*);
+    Node* nodebyfingerprint(LocalNode*);
+
     node_vector *nodesbyfingerprint(FileFingerprint* fingerprint);
     void nodesbyoriginalfingerprint(const char* fingerprint, Node* parent, node_vector *nv);
 

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -491,8 +491,8 @@ void hashCombine(T& seed, const U& v)
     seed ^= std::hash<U>{}(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
 }
 
-class FileAccess;
-class InputStreamAccess;
+struct FileAccess;
+struct InputStreamAccess;
 class SymmCipher;
 
 std::pair<bool, int64_t> generate_metamac(SymmCipher &cipher, FileAccess &ifaccess, const int64_t iv);

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -495,9 +495,9 @@ struct FileAccess;
 struct InputStreamAccess;
 class SymmCipher;
 
-std::pair<bool, int64_t> generate_metamac(SymmCipher &cipher, FileAccess &ifaccess, const int64_t iv);
+std::pair<bool, int64_t> generateMetaMac(SymmCipher &cipher, FileAccess &ifAccess, const int64_t iv);
 
-std::pair<bool, int64_t> generate_metamac(SymmCipher &cipher, InputStreamAccess &isaccess, const int64_t iv);
+std::pair<bool, int64_t> generateMetaMac(SymmCipher &cipher, InputStreamAccess &isAccess, const int64_t iv);
 
 } // namespace
 

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -491,6 +491,14 @@ void hashCombine(T& seed, const U& v)
     seed ^= std::hash<U>{}(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
 }
 
+class FileAccess;
+class InputStreamAccess;
+class SymmCipher;
+
+std::pair<bool, int64_t> generate_metamac(SymmCipher &cipher, FileAccess &ifaccess, const int64_t iv);
+
+std::pair<bool, int64_t> generate_metamac(SymmCipher &cipher, InputStreamAccess &isaccess, const int64_t iv);
+
 } // namespace
 
 #endif

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -3049,18 +3049,6 @@ public:
     virtual bool read(byte *buffer, unsigned size);
 };
 
-class FileInputStream : public InputStreamAccess
-{
-    FileAccess *fileAccess;
-    m_off_t offset;
-
-public:
-    FileInputStream(FileAccess *fileAccess);
-    virtual m_off_t size();
-    virtual bool read(byte *buffer, unsigned size);
-    virtual ~FileInputStream();
-};
-
 #ifdef HAVE_LIBUV
 class StreamingBuffer
 {

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -614,4 +614,39 @@ void AsyncIOContext::finish()
     }
 }
 
+FileInputStream::FileInputStream(FileAccess *fileAccess)
+{
+    this->fileAccess = fileAccess;
+    this->offset = 0;
+}
+
+m_off_t FileInputStream::size()
+{
+    return fileAccess->size;
+}
+
+bool FileInputStream::read(byte *buffer, unsigned size)
+{
+    if (!buffer)
+    {
+        if ((offset + size) <= fileAccess->size)
+        {
+            offset += size;
+            return true;
+        }
+
+        LOG_warn << "Invalid seek on FileInputStream";
+        return false;
+    }
+
+    if (fileAccess->frawread(buffer, size, offset, true))
+    {
+        offset += size;
+        return true;
+    }
+
+    LOG_warn << "Invalid read on FileInputStream";
+    return false;
+}
+
 } // namespace

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -23368,46 +23368,6 @@ bool ExternalInputStream::read(byte *buffer, unsigned size)
 }
 
 
-FileInputStream::FileInputStream(FileAccess *fileAccess)
-{
-    this->fileAccess = fileAccess;
-    this->offset = 0;
-}
-
-m_off_t FileInputStream::size()
-{
-    return fileAccess->size;
-}
-
-bool FileInputStream::read(byte *buffer, unsigned size)
-{
-    if (!buffer)
-    {
-        if ((offset + size) <= fileAccess->size)
-        {
-            offset += size;
-            return true;
-        }
-
-        LOG_warn << "Invalid seek on FileInputStream";
-        return false;
-    }
-
-    if (fileAccess->frawread(buffer, size, offset, true))
-    {
-        offset += size;
-        return true;
-    }
-
-    LOG_warn << "Invalid read on FileInputStream";
-    return false;
-}
-
-FileInputStream::~FileInputStream()
-{
-
-}
-
 MegaTreeProcCopy::MegaTreeProcCopy(MegaClient *client)
 {
     nn = NULL;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -14051,18 +14051,13 @@ Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
                    remoteNodes->end(),
                    [&](const Node *remoteNode) -> bool
                    {
-                       return localNode->type == remoteNode->type
-                              && localName == remoteNode->displayname();
+                       return localName == remoteNode->displayname();
                    });
 
     if (remoteNode != remoteNodes->end())
         return *remoteNode;
 
     remoteNode = remoteNodes->begin();
-
-    // Metamac only has meaning for files.
-    if ((*remoteNode)->type != FILENODE)
-        return *remoteNode;
 
     // Compare the local file's metamac against a random candidate.
     // 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -14036,8 +14036,8 @@ Node* MegaClient::nodebyfingerprint(FileFingerprint* fingerprint)
 
 Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
 {
-    const node_vector *remoteNodes =
-      mFingerprints.nodesbyfingerprint(localNode);
+    std::unique_ptr<const node_vector>
+      remoteNodes(mFingerprints.nodesbyfingerprint(localNode));
 
     if (remoteNodes->empty())
         return nullptr;

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -317,25 +317,6 @@ void TransferSlot::disconnect()
     }
 }
 
-// coalesce block macs into file mac
-int64_t chunkmac_map::macsmac(SymmCipher *cipher)
-{
-    byte mac[SymmCipher::BLOCKSIZE] = { 0 };
-
-    for (chunkmac_map::iterator it = begin(); it != end(); it++)
-    {
-        SymmCipher::xorblock(it->second.mac, mac);
-        cipher->ecb_encrypt(mac);
-    }
-
-    uint32_t* m = (uint32_t*)mac;
-
-    m[0] ^= m[1];
-    m[1] = m[2] ^ m[3];
-
-    return MemAccess::get<int64_t>((const char*)mac);
-}
-
 int64_t TransferSlot::macsmac(chunkmac_map* m)
 {
     return m->macsmac(transfer->transfercipher());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2298,49 +2298,49 @@ bool operator==(const SyncConfig& lhs, const SyncConfig& rhs)
     return lhs.tie() == rhs.tie();
 }
 
-std::pair<bool, int64_t> generate_metamac(SymmCipher &cipher, FileAccess &ifaccess, const int64_t iv)
+std::pair<bool, int64_t> generateMetaMac(SymmCipher &cipher, FileAccess &ifAccess, const int64_t iv)
 {
-    FileInputStream isaccess(&ifaccess);
+    FileInputStream isAccess(&ifAccess);
 
-    return generate_metamac(cipher, isaccess, iv);
+    return generateMetaMac(cipher, isAccess, iv);
 }
 
-std::pair<bool, int64_t> generate_metamac(SymmCipher &cipher, InputStreamAccess &isaccess, const int64_t iv)
+std::pair<bool, int64_t> generateMetaMac(SymmCipher &cipher, InputStreamAccess &isAccess, const int64_t iv)
 {
     static const m_off_t SZ_1024K = 1l << 20;
     static const m_off_t SZ_128K  = 128l << 10;
 
     std::vector<byte> buffer;
-    chunkmac_map chunk_macs;
-    m_off_t chunk_length = 0;
+    chunkmac_map chunkMacs;
+    m_off_t chunkLength = 0;
     m_off_t current = 0;
-    m_off_t remaining = isaccess.size();
+    m_off_t remaining = isAccess.size();
 
     buffer.reserve(SZ_1024K + SymmCipher::BLOCKSIZE);
 
     while (remaining > 0)
     {
-        chunk_length =
-          std::min(chunk_length + SZ_128K,
+        chunkLength =
+          std::min(chunkLength + SZ_128K,
                    std::min(remaining, SZ_1024K));
 
-        if (!isaccess.read(&buffer[0], (unsigned int)chunk_length))
+        if (!isAccess.read(&buffer[0], (unsigned int)chunkLength))
             return std::make_pair(false, 0l);
 
-        memset(&buffer[chunk_length], 0, SymmCipher::BLOCKSIZE);
+        memset(&buffer[chunkLength], 0, SymmCipher::BLOCKSIZE);
 
         cipher.ctr_crypt(&buffer[0],
-                         (unsigned int)chunk_length,
+                         (unsigned int)chunkLength,
                          current,
                          iv,
-                         chunk_macs[current].mac,
+                         chunkMacs[current].mac,
                          1);
 
-        current += chunk_length;
-        remaining -= chunk_length;
+        current += chunkLength;
+        remaining -= chunkLength;
     }
 
-    return std::make_pair(true, chunk_macs.macsmac(&cipher));
+    return std::make_pair(true, chunkMacs.macsmac(&cipher));
 }
 
 } // namespace

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1731,13 +1731,8 @@ TEST_F(SyncFingerprintCollision, DifferentMacSameName)
 
                              p.set_value(true);
                          });
-    auto result1 =
-      client0->thread_do([&](StandardClient &sc, std::promise<bool> &p)
-                         {
-                             p.set_value(result0.get());
-                         });
 
-    waitonresults(&result1);
+    waitonresults(&result0);
     waitOnSyncs();
 
     addModelFile(model0, "d/d_0", "a", data0);
@@ -1771,13 +1766,8 @@ TEST_F(SyncFingerprintCollision, DifferentMacDifferentName)
 
                              p.set_value(true);
                          });
-    auto result1 =
-      client0->thread_do([&](StandardClient &sc, std::promise<bool> &p)
-                         {
-                             p.set_value(result0.get());
-                         });
 
-    waitonresults(&result1);
+    waitonresults(&result0);
     waitOnSyncs();
 
     addModelFile(model0, "d/d_0", "a", data0);
@@ -1808,13 +1798,8 @@ TEST_F(SyncFingerprintCollision, SameMacDifferentName)
 
                              p.set_value(true);
                          });
-    auto result1 =
-      client0->thread_do([&](StandardClient &sc, std::promise<bool> &p)
-                         {
-                             p.set_value(result0.get());
-                         });
 
-    waitonresults(&result1);
+    waitonresults(&result0);
     waitOnSyncs();
 
     addModelFile(model0, "d/d_0", "a", data0);


### PR DESCRIPTION
The result of this change-set is to perform a more detailed comparison of two files that have matching fingerprints. This is necessary as file content is sparsely hashed and so two differing files can sometimes yield the same fingerprint.

When a remote node is found with a filename and fingerprint matching a local file, we compare the two by computing the metamac of the local file using the remote node's key. If the metamac matches, we know the two are identical and as such, can avoid uploading the local file and create a copy in the cloud.

If we are unable to compute the metamac or if the metamac ~matches~ does not match, we consider the files distinct. This may result in some files being uploaded needlessly but it will ensure file integrity.

An appropriate unit test is included that exercises these changes.

Note that file corruption can still occur as the metamac comparison is only performed when the local and remote nodes have the same filename. That is, if we upload a file A that fingerprints to X and proceed to sync a different file B that also fingerprints to X, B will not be uploaded and a copy of A will be made in the cloud.