### PR TITLE
#14903. Shortname is actually a 'local' name, with wchar_t stored in std::string (on windows)

### DIFF
--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -437,7 +437,8 @@ struct CacheableWriter
     string& dest;
 
     void serializebinary(byte* data, size_t len);
-    void serializecstr(const char* field, bool storeNull);  // may store the '\0' also for backward compatibility
+    void serializecstr(const char* field, bool storeNull);  // may store the '\0' also for backward compatibility. Only use for utf8!  (std::string storing double byte chars will only store 1 byte)
+    void serializepstr(const string* field);  // uses string size() not strlen
     void serializestring(const string& field);
     void serializecompressed64(int64_t field);
     void serializei64(int64_t field);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -12495,6 +12495,7 @@ bool MegaClient::syncdown(LocalNode* l, string* localpath, bool rubbish)
 
                 if (l->sync->movetolocaldebris(localpath) || !fsaccess->transient_error)
                 {
+                    DBTableTransactionCommitter committer(tctable);
                     delete lit++->second;
                 }
                 else

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1756,7 +1756,7 @@ bool LocalNode::serialize(string* d)
     }
     w.serializebyte(mSyncable);
     w.serializeexpansionflags(1);  // first flag indicates we are storing slocalname.  Storing it is much, much faster than looking it up on startup.
-    w.serializecstr(slocalname ? slocalname->c_str() : nullptr, false);
+    w.serializepstr(slocalname.get());
     return true;
 }
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -851,9 +851,12 @@ void Sync::addstatecachechildren(uint32_t parent_dbid, idlocalnode_map* tmap, st
 
         l->init(this, l->type, p, path, std::move(shortname));
 
+#ifdef DEBUG
+        auto sn = client->fsaccess->fsShortname(*path);
         assert(!l->localname.empty() && 
-                (!l->slocalname && l->localname == *client->fsaccess->fsShortname(*path) ||
-                (l->slocalname && !l->slocalname->empty() && *l->slocalname != l->localname)));
+                (!l->slocalname && (!sn || l->localname == *sn) ||
+                (l->slocalname && sn && !l->slocalname->empty() && *l->slocalname != l->localname && *l->slocalname == *sn)));
+#endif
 
         l->parent_dbid = parent_dbid;
         l->size = size;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -73,6 +73,13 @@ void CacheableWriter::serializecstr(const char* field, bool storeNull)
     dest.append(field, ll);
 }
 
+void CacheableWriter::serializepstr(const string* field)
+{
+    unsigned short ll = (unsigned short)(field ? field->size() : 0);
+    dest.append((char*)&ll, sizeof(ll));
+    if (field) dest.append(field->data(), ll);
+}
+
 void CacheableWriter::serializestring(const string& field)
 {
     unsigned short ll = (unsigned short)field.size();


### PR DESCRIPTION
So we must use size() when serializing, strlen gets the wrong answer (just 1 character long).
Also taking into account possible nullptr cases for mac/linux or when the shortname matches the local name.