### PR TITLE
#15355 - Fingerprint Accuracy Fixes

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1181,7 +1181,9 @@ public:
 
     Node* nodebyhandle(handle);
     Node* nodebyfingerprint(FileFingerprint*);
+#ifdef ENABLE_SYNC
     Node* nodebyfingerprint(LocalNode*);
+#endif /* ENABLE_SYNC */
 
     node_vector *nodesbyfingerprint(FileFingerprint* fingerprint);
     void nodesbyoriginalfingerprint(const char* fingerprint, Node* parent, node_vector *nv);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -14034,6 +14034,7 @@ Node* MegaClient::nodebyfingerprint(FileFingerprint* fingerprint)
     return mFingerprints.nodebyfingerprint(fingerprint);
 }
 
+#ifdef ENABLE_SYNC
 Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
 {
     std::unique_ptr<const node_vector>
@@ -14089,6 +14090,7 @@ Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
 
     return *remoteNode;
 }
+#endif /* ENABLE_SYNC */
 
 node_vector *MegaClient::nodesbyfingerprint(FileFingerprint* fingerprint)
 {

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1558,6 +1558,20 @@ bool createFile(const fs::path &p, const string &filename)
     return createFile(p / fs::u8path(filename), filename.data(), filename.size());
 }
 
+bool createFileWithTimestamp(const fs::path &path,
+                             const std::vector<uint8_t> &data,
+                             const fs::file_time_type &timestamp)
+{
+    const bool result = createFile(path, data);
+
+    if (result)
+    {
+        fs::last_write_time(path, timestamp);
+    }
+
+    return result;
+}
+
 bool buildLocalFolders(fs::path targetfolder, const string& prefix, int n, int recurselevel, int filesperfolder)
 {
     if (suppressfiles) filesperfolder = 0;
@@ -1724,15 +1738,14 @@ TEST_F(SyncFingerprintCollision, DifferentMacSameName)
     auto result0 =
       client0->thread_do([&](StandardClient &sc, std::promise<bool> &p)
                          {
-                             ASSERT_TRUE(createFile(path1, data1));
-
-                             fs::last_write_time(
-                                path1, fs::last_write_time(path0));
-
-                             p.set_value(true);
+                             p.set_value(
+                               createFileWithTimestamp(
+                                 path1,
+                                 data1,
+                                 fs::last_write_time(path0)));
                          });
 
-    waitonresults(&result0);
+    ASSERT_TRUE(waitonresults(&result0));
     waitOnSyncs();
 
     addModelFile(model0, "d/d_0", "a", data0);
@@ -1759,15 +1772,14 @@ TEST_F(SyncFingerprintCollision, DifferentMacDifferentName)
     auto result0 =
       client0->thread_do([&](StandardClient &sc, std::promise<bool> &p)
                          {
-                             ASSERT_TRUE(createFile(path1, data1));
-
-                             fs::last_write_time(
-                                path1, fs::last_write_time(path0));
-
-                             p.set_value(true);
+                             p.set_value(
+                               createFileWithTimestamp(
+                                 path1,
+                                 data1,
+                                 fs::last_write_time(path0)));
                          });
 
-    waitonresults(&result0);
+    ASSERT_TRUE(waitonresults(&result0));
     waitOnSyncs();
 
     addModelFile(model0, "d/d_0", "a", data0);
@@ -1791,15 +1803,14 @@ TEST_F(SyncFingerprintCollision, SameMacDifferentName)
     auto result0 =
       client0->thread_do([&](StandardClient &sc, std::promise<bool> &p)
                          {
-                             ASSERT_TRUE(createFile(path1, data0));
-
-                             fs::last_write_time(
-                                path1, fs::last_write_time(path0));
-
-                             p.set_value(true);
+                             p.set_value(
+                               createFileWithTimestamp(
+                                 path1,
+                                 data0,
+                                 fs::last_write_time(path0)));
                          });
 
-    waitonresults(&result0);
+    ASSERT_TRUE(waitonresults(&result0));
     waitOnSyncs();
 
     addModelFile(model0, "d/d_0", "a", data0);


### PR DESCRIPTION
Unfortunately, merge of prior PR introduced several problems.

First, it broke the build for those building without ENABLE_SYNC defined.
This has been corrected by adding the necessary #ifdef / #endif blocks.

Secondly, unit tests were hanging on Jenkins.
It seems to have hung because an assertion triggered while computing the value of a promise.
That is, the software was waiting for a result which it never received.
