### PR TITLE
Don't generate neither thumbnails nor previews for Files.app extension

### DIFF
--- a/src/gfx/GfxProcCG.mm
+++ b/src/gfx/GfxProcCG.mm
@@ -59,6 +59,9 @@ GfxProcCG::~GfxProcCG() {
 }
 
 const char* GfxProcCG::supportedformats() {
+    if ([[NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleExecutable"] isEqualToString:@"MEGAFiles"]) {
+        return "";
+    }
     return ".bmp.cr2.crw.cur.dng.gif.heic.ico.j2c.jp2.jpf.jpeg.jpg.nef.orf.pbm.pdf.pgm.png.pnm.ppm.psd.raf.rw2.rwl.tga.tif.tiff.3g2.3gp.avi.m4v.mov.mp4.mqv.qt.";
 }
 


### PR DESCRIPTION
- There is not enough RAM for accomplish this task for the moment. This can change in the future with lighter methods to handle the MEGA account.