### PR TITLE
#15582: do remove transfer and files on tranfer failed.

### DIFF
--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -710,6 +710,8 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                     break;
 
                 case REQ_ASYNCIO:
+                    assert(asyncIO);
+                    assert(asyncIO[i]);
                     if (asyncIO[i]->finished)
                     {
                         LOG_verbose << "Processing finished async fs operation";


### PR DESCRIPTION
To prevent "Async operation failed" triggering a deletion a fail that didn't cause a deletion and an ulterior crash.
This reverts to the unconditional deletion of the failed transfer before  https://github.com/meganz/sdk/pull/1844: https://github.com/meganz/sdk/pull/1844/files#diff-7dfecf951cd004ec60662f276863edcdL529 
(now the only case when that transfer doesn't get to deletion is if it as a file being upload to a foreign account, which was the original intent in 1844)