### PR TITLE
WIP: Changes to enable the UWP project to be built with vcpkg/cmake

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -557,6 +557,9 @@ if(WIN32)
     IF(USE_LIBUV)
         SET(Mega_PlatformSpecificLibs ${Mega_PlatformSpecificLibs} Kernel32.lib Iphlpapi.lib Userenv.lib Psapi.lib )
     ENDIF(USE_LIBUV)
+    IF(USE_CURL)
+        SET(Mega_PlatformSpecificLibs Kernel32.lib ) # c-ares needs LoadLibrary
+    ENDIF(USE_LIBUV)
 
     SET(Mega_PlatformSpecificFiles ${MegaDir}/src/win32/console.cpp
     ${MegaDir}/src/win32/consolewaiter.cpp 

--- a/contrib/cmake/build3rdparty.cmd
+++ b/contrib/cmake/build3rdparty.cmd
@@ -4,6 +4,7 @@ SETLOCAL EnableExtensions
 set DIR=%~dp0
 
 set PORTS_FILE="%DIR%preferred-ports.txt"
+set PORTS_FOLDER="%DIR%vcpkg_extra_ports"
 set DEPS_FILE="%DIR%3rdparty_deps.txt"
 set OVERLAYTRIPLETS=--overlay-triplets=%DIR%vcpkg_extra_triplets
 
@@ -11,13 +12,14 @@ set OVERLAYTRIPLETS=--overlay-triplets=%DIR%vcpkg_extra_triplets
  if /I "%1" == "-h" ( goto Help ) ^
  else (if /I "%1" == "-r" (set REMOVEBEFORE=true)^
  else (if /I "%1" == "-d" (set DEPS_FILE=%2 & shift )^
- else (if /I "%1" == "-p" (set PORTS_FILE=%2 & shift )^
+ else (if /I "%1" == "-p" (set PORTS_FILE=%2& shift )^
+ else (if /I "%1" == "-pf" (set PORTS_FOLDER=%2& shift )^
  else (if /I "%1" == "-t" (set OVERLAYTRIPLETS=--overlay-triplets=%2 & shift )^
  else (if /I "%1" == "-o" (set OVERRIDEVCPKGPORTS=true)^
  else (^
  echo "%1"|>nul findstr /rx \"-.*\" && goto Help REM if parameter starts width - and has not been recognized, go to Help
  if "%1" neq "" (if "%TRIPLET%" == "" (set TRIPLET=%1% ))^
- else (goto :START)))))))
+ else (goto :START))))))))
  
  shift
  goto GETOPTS
@@ -39,7 +41,7 @@ Setlocal
 
 Setlocal EnableDelayedExpansion
 for /f "eol=# tokens=* delims=," %%l in ('type %PORTS_FILE%') do ^
-set "OVERLAYPORTS=--overlay-ports=%DIR%vcpkg_extra_ports/%%l !OVERLAYPORTS!"
+set "OVERLAYPORTS=--overlay-ports=%PORTS_FOLDER%/%%l !OVERLAYPORTS!"
 
 WHERE vcpkg >nul || set VCPKG=./vcpkg.exe & 2>nul ren %%~dpi.\ports ports_moved
 
@@ -63,7 +65,7 @@ exit /b 0
 echo "Overriding VCPKG ports with those in: %PORTS_FILE%" 
 
 for /f %%i IN ('WHERE vcpkg') DO ( set vcpkgports=%%~dpi.\ports )
-for /f "eol=# tokens=* delims=," %%l in ('type %PORTS_FILE%') do ( CALL :copyPort "%DIR%vcpkg_extra_ports\%%l" %vcpkgports%)
+for /f "eol=# tokens=* delims=," %%l in ('type %PORTS_FILE%') do ( CALL :copyPort "%PORTS_FOLDER%\%%l" %vcpkgports%)
 goto doBuild
 
 

--- a/contrib/cmake/config.h.in
+++ b/contrib/cmake/config.h.in
@@ -142,7 +142,9 @@
 #define HAVE_TERMCAP_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
+#ifndef WIN32
 #define HAVE_UNISTD_H 1
+#endif
 
 /* Define to 1 if you have the <uv.h> header file. */
 /* #undef HAVE_UV_H */

--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -31,10 +31,13 @@
 #include <readline/history.h>
 #endif
 
-#if (__cplusplus >= 201700L)
+#ifdef WINDOWS_PHONE
+    #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#elif (__cplusplus >= 201700L)
     #include <filesystem>
     namespace fs = std::filesystem;
-    #define USE_FILESYSTEM
 #elif !defined(__MINGW32__) && !defined(__ANDROID__) && (!defined(__GNUC__) || (__GNUC__*100+__GNUC_MINOR__) >= 503)
 #define USE_FILESYSTEM
 #ifdef WIN32

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -30,7 +30,11 @@
 
 #define HAVE_FILESYSTEM
 
-#if (__cplusplus >= 201700L)
+#ifdef WINDOWS_PHONE
+    #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#elif (__cplusplus >= 201700L)
     #include <filesystem>
     namespace fs = std::filesystem;
 #else

--- a/src/win32/console.cpp
+++ b/src/win32/console.cpp
@@ -517,7 +517,9 @@ bool WinConsole::setShellConsole(UINT codepage, UINT failover_codepage)
     if (!ok)
     {
         codepage = CP_UTF8;
+#ifndef WINDOWS_PHONE
         failover_codepage = GetOEMCP();
+#endif
         SetConsoleCP(codepage);
         SetConsoleOutputCP(codepage);
     }


### PR DESCRIPTION
**NOTE**: this PR aims to update the project for UWP, but it's not ready and currently UWP app is not a priority. Keep this PR on hold, just in case we need to continue with the update in a near future.

UWP to supply its own vcpkg_extra_ports etc, customized for uwp