### PR TITLE
#15752. Performance optimizations for working with large numbers of transfers

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1112,6 +1112,9 @@ public:
     // FileFingerprint to node mapping
     Fingerprints mFingerprints;
 
+    // flag to skip removing nodes from mFingerprints when all nodes get deleted
+    bool mOptimizePurgeNodes = false;
+
     // send updates to app when the storage size changes
     int64_t mNotifiedSumSize = 0;
 

--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -161,6 +161,26 @@ struct MEGA_API Transfer : public FileFingerprint
 
     // examine a file on disk for video/audio attributes to attach to the file, on upload/download
     void addAnyMissingMediaFileAttributes(Node* node, std::string& localpath);
+
+    // whether the Transfer needs to remove itself from the list it's in (for quick shutdown we can skip)
+    bool mOptimizedDelete = false;
+};
+
+
+struct LazyEraseTransferPtr
+{
+    // This class enables us to relatively quickly and efficiently delete many items from the middle of std::deque
+    // By being the class actualy stored in a mega::deque_with_lazy_bulk_erase.
+    // Such builk deletion is done by marking the ones to delete, and finally performing those as a single remove_if.
+    Transfer* transfer;
+    uint64_t preErasurePriority = 0;
+    bool erased = false;
+
+    explicit LazyEraseTransferPtr(Transfer* t) : transfer(t) {}
+    operator Transfer*&() { return transfer; }
+    void erase() { preErasurePriority = transfer->priority; transfer = nullptr; erased = true; }
+    bool isErased() const { return erased; }
+    bool operator==(const LazyEraseTransferPtr& e) { return transfer && transfer == e.transfer; }
 };
 
 class MEGA_API TransferList
@@ -168,6 +188,8 @@ class MEGA_API TransferList
 public:
     static const uint64_t PRIORITY_START = 0x0000800000000000ull;
     static const uint64_t PRIORITY_STEP  = 0x0000000000010000ull;
+
+    typedef deque_with_lazy_bulk_erase<Transfer*, LazyEraseTransferPtr> transfer_list;
 
     TransferList();
     void addtransfer(Transfer* transfer, DBTableTransactionCommitter&, bool startFirst = false);
@@ -187,7 +209,7 @@ public:
     error pause(Transfer *transfer, bool enable, DBTableTransactionCommitter& committer);
     transfer_list::iterator begin(direction_t direction);
     transfer_list::iterator end(direction_t direction);
-    transfer_list::iterator iterator(Transfer *transfer);
+    bool getIterator(Transfer *transfer, transfer_list::iterator&, bool canHandleErasedElements = false);
     std::array<vector<Transfer*>, 6> nexttransfers(std::function<bool(Transfer*)>& continuefunction);
     Transfer *transferat(direction_t direction, unsigned int position);
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -314,9 +314,14 @@ typedef map<FileFingerprint*, Transfer*, FileFingerprintCmp> transfer_map;
 template <class T, class E>
 class deque_with_lazy_bulk_erase
 {
+    // This is a wrapper class for deque.  Erasing an element from the middle of a deque is not cheap since all the subsequent elements need to be shuffled back.
+    // This wrapper intercepts the erase() calls for single items, and instead marks each one as 'erased'.  
+    // The supplied template class E contains the normal deque entry T, plus a flag or similar to mark an entry erased.
+    // Any other operation on the deque performs all the gathered erases in a single std::remove_if for efficiency.
+    // This makes an enormous difference when cancelling 100k transfers in MEGAsync's transfers window for example.
     deque<E> mDeque;
+    bool mErasing = false;
 
-    bool erasing = false;
 public:
 
     typedef typename deque<E>::iterator iterator;
@@ -325,26 +330,26 @@ public:
     {
         assert(i != mDeque.end());
         i->erase();
-        erasing = true;
+        mErasing = true;
     }
 
     void applyErase()
     {
-        if (erasing)
+        if (mErasing)
         {
             auto newEnd = std::remove_if(mDeque.begin(), mDeque.end(), [](const E& e) { return e.isErased(); } );
             mDeque.erase(newEnd, mDeque.end());
-            erasing = false;
+            mErasing = false;
         }
     }
 
-    size_t size() { applyErase(); return mDeque.size(); }
+    size_t size()                                        { applyErase(); return mDeque.size(); }
     iterator begin(bool canHandleErasedElements = false) { if (!canHandleErasedElements) applyErase(); return mDeque.begin(); }
-    iterator end(bool canHandleErasedElements = false) { if (!canHandleErasedElements) applyErase(); return mDeque.end(); }
-    void push_front(T t) { applyErase(); mDeque.push_front(E(t)); }
-    void push_back(T t) { applyErase(); mDeque.push_back(E(t)); }
-    void insert(iterator i, T t) { applyErase(); mDeque.insert(i, E(t)); }
-    T& operator[](size_t n) { applyErase(); return mDeque[n]; }
+    iterator end(bool canHandleErasedElements = false)   { if (!canHandleErasedElements) applyErase(); return mDeque.end(); }
+    void push_front(T t)                                 { applyErase(); mDeque.push_front(E(t)); }
+    void push_back(T t)                                  { applyErase(); mDeque.push_back(E(t)); }
+    void insert(iterator i, T t)                         { applyErase(); mDeque.insert(i, E(t)); }
+    T& operator[](size_t n)                              { applyErase(); return mDeque[n]; }
 
 };
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -344,6 +344,7 @@ public:
     }
 
     size_t size()                                        { applyErase(); return mDeque.size(); }
+    size_t empty()                                        { applyErase(); return mDeque.empty(); }
     iterator begin(bool canHandleErasedElements = false) { if (!canHandleErasedElements) applyErase(); return mDeque.begin(); }
     iterator end(bool canHandleErasedElements = false)   { if (!canHandleErasedElements) applyErase(); return mDeque.end(); }
     void push_front(T t)                                 { applyErase(); mDeque.push_front(E(t)); }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -12971,18 +12971,6 @@ class MegaApi
         bool hasChildren(MegaNode *parent);
 
         /**
-         * @brief Get the current index of the node in the parent folder for a specific sorting order
-         *
-         * If the node doesn't exist or it doesn't have a parent node (because it's a root node)
-         * this function returns -1
-         *
-         * @param node Node to check
-         * @param order Sorting order to use
-         * @return Index of the node in its parent folder
-         */
-        int getIndex(MegaNode* node, int order = 1);
-
-        /**
          * @brief Get the child node with the provided name
          *
          * If the node doesn't exist, this function returns NULL

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1594,15 +1594,14 @@ class MegaChildrenListsPrivate : public MegaChildrenLists
     public:
         MegaChildrenListsPrivate();
         MegaChildrenListsPrivate(MegaChildrenLists*);
-        MegaChildrenListsPrivate(MegaNodeListPrivate *folderList, MegaNodeListPrivate *fileList);
-        virtual ~MegaChildrenListsPrivate();
+        MegaChildrenListsPrivate(unique_ptr<MegaNodeListPrivate> folderList, unique_ptr<MegaNodeListPrivate> fileList);
         virtual MegaChildrenLists *copy();
         virtual MegaNodeList* getFolderList();
         virtual MegaNodeList* getFileList();
 
     protected:
-        MegaNodeList *folders;
-        MegaNodeList *files;
+        unique_ptr<MegaNodeList> folders;
+        unique_ptr<MegaNodeList> files;
 };
 
 class MegaUserListPrivate : public MegaUserList
@@ -2283,14 +2282,13 @@ class MegaApiImpl : public MegaApp
 		int getNumChildren(MegaNode* parent);
 		int getNumChildFiles(MegaNode* parent);
 		int getNumChildFolders(MegaNode* parent);
-        MegaNodeList* getChildren(MegaNode *parent, int order=1);
+        MegaNodeList* getChildren(MegaNode *parent, int order);
         MegaNodeList* getVersions(MegaNode *node);
         int getNumVersions(MegaNode *node);
         bool hasVersions(MegaNode *node);
         void getFolderInfo(MegaNode *node, MegaRequestListener *listener);
         MegaChildrenLists* getFileFolderChildren(MegaNode *parent, int order=1);
         bool hasChildren(MegaNode *parent);
-        int getIndex(MegaNode* node, int order=1);
         MegaNode *getChildNode(MegaNode *parent, const char* name);
         MegaNode *getParentNode(MegaNode *node);
         char *getNodePath(MegaNode *node);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3890,11 +3890,6 @@ bool MegaApi::hasChildren(MegaNode *parent)
     return pImpl->hasChildren(parent);
 }
 
-int MegaApi::getIndex(MegaNode *node, int order)
-{
-    return pImpl->getIndex(node, order);
-}
-
 MegaNode *MegaApi::getChildNode(MegaNode *parent, const char* name)
 {
     return pImpl->getChildNode(parent, name);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -16955,7 +16955,7 @@ MegaNodeList *MegaApiImpl::getChildren(MegaNode* p, int order)
             std::sort(childrenNodes.begin(), childrenNodes.end(), comparatorFunction);
         }
     }
-    return new MegaNodeListPrivate(childrenNodes.data(), int(childrenNodes.size()));;
+    return new MegaNodeListPrivate(childrenNodes.data(), int(childrenNodes.size()));
 }
 
 MegaNodeList *MegaApiImpl::getVersions(MegaNode *node)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1080,6 +1080,7 @@ void MegaClient::init()
     notifyStorageChangeOnStateCurrent = false;
     mNotifiedSumSize = 0;
     mNodeCounters = NodeCounterMap();
+    mOptimizePurgeNodes = false;
 }
 
 MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, DbAccess* d, GfxProc* g, const char* k, const char* u, unsigned workerThreadCount)
@@ -3735,10 +3736,12 @@ void MegaClient::checkfacompletion(handle th, Transfer* t)
 void MegaClient::freeq(direction_t d)
 {
     DBTableTransactionCommitter committer(tctable);
-    for (transfer_map::iterator it = transfers[d].begin(); it != transfers[d].end(); )
+    for (auto transferPtr : transfers[d])
     {
-        delete it++->second;
+        transferPtr.second->mOptimizedDelete = true;  // so it doesn't remove itself from this list while deleting
+        delete transferPtr.second;
     }
+    transfers[d].clear();
 }
 
 bool MegaClient::isFetchingNodesPendingCS()
@@ -11809,12 +11812,14 @@ void MegaClient::purgenodesusersabortsc(bool keepOwnUser)
     syncs.clear();
 #endif
 
+    mOptimizePurgeNodes = true;
+    mFingerprints.clear();
     for (node_map::iterator it = nodes.begin(); it != nodes.end(); it++)
     {
         delete it->second;
     }
-
     nodes.clear();
+    mOptimizePurgeNodes = false;
 
 #ifdef ENABLE_SYNC
     todebris.clear();

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -11814,6 +11814,7 @@ void MegaClient::purgenodesusersabortsc(bool keepOwnUser)
 
     mOptimizePurgeNodes = true;
     mFingerprints.clear();
+    mNodeCounters.clear();
     for (node_map::iterator it = nodes.begin(); it != nodes.end(); it++)
     {
         delete it->second;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -114,7 +114,10 @@ Node::~Node()
     client->preadabort(this);
 
     // remove node's fingerprint from hash
-    client->mFingerprints.remove(this);
+    if (!client->mOptimizePurgeNodes)
+    {
+        client->mFingerprints.remove(this);
+    }
 
 #ifdef ENABLE_SYNC
     // remove from todebris node_set
@@ -151,29 +154,32 @@ Node::~Node()
     }
 
 
-    // remove from parent's children
-    if (parent)
+    if (!client->mOptimizePurgeNodes)
     {
-        parent->children.erase(child_it);
-    }
+        // remove from parent's children
+        if (parent)
+        {
+            parent->children.erase(child_it);
+        }
 
-    Node* fa = firstancestor();
-    handle ancestor = fa->nodehandle;
-    if (ancestor == client->rootnodes[0] || ancestor == client->rootnodes[1] || ancestor == client->rootnodes[2] || fa->inshare)
-    {
-        client->mNodeCounters[firstancestor()->nodehandle] -= subnodeCounts();
-    }
+        Node* fa = firstancestor();
+        handle ancestor = fa->nodehandle;
+        if (ancestor == client->rootnodes[0] || ancestor == client->rootnodes[1] || ancestor == client->rootnodes[2] || fa->inshare)
+        {
+            client->mNodeCounters[firstancestor()->nodehandle] -= subnodeCounts();
+        }
 
-    if (inshare)
-    {
-        client->mNodeCounters.erase(nodehandle);
-    }
+        if (inshare)
+        {
+            client->mNodeCounters.erase(nodehandle);
+        }
 
-    // delete child-parent associations (normally not used, as nodes are
-    // deleted bottom-up)
-    for (node_list::iterator it = children.begin(); it != children.end(); it++)
-    {
-        (*it)->parent = NULL;
+        // delete child-parent associations (normally not used, as nodes are
+        // deleted bottom-up)
+        for (node_list::iterator it = children.begin(); it != children.end(); it++)
+        {
+            (*it)->parent = NULL;
+        }
     }
 
     delete plink;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -852,10 +852,14 @@ void Sync::addstatecachechildren(uint32_t parent_dbid, idlocalnode_map* tmap, st
         l->init(this, l->type, p, path, std::move(shortname));
 
 #ifdef DEBUG
-        auto sn = client->fsaccess->fsShortname(*path);
-        assert(!l->localname.empty() && 
+        auto fa = client->fsaccess->newfileaccess(false);
+        if (fa->fopen(path))  // exists, is file
+        {
+            auto sn = client->fsaccess->fsShortname(*path);
+            assert(!l->localname.empty() && 
                 (!l->slocalname && (!sn || l->localname == *sn) ||
                 (l->slocalname && sn && !l->slocalname->empty() && *l->slocalname != l->localname && *l->slocalname == *sn)));
+        }
 #endif
 
         l->parent_dbid = parent_dbid;

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -1633,7 +1633,7 @@ void TransferList::addtransfer(Transfer *transfer, DBTableTransactionCommitter& 
     else
     {
         transfer_list::iterator it = std::lower_bound(transfers[transfer->type].begin(), transfers[transfer->type].end(), LazyEraseTransferPtr(transfer), priority_comparator);
-        assert(it == transfers[transfer->type].end() || (*it)->priority != transfer->priority);
+        assert(it == transfers[transfer->type].end() || it->transfer->priority != transfer->priority);
         transfers[transfer->type].insert(it, transfer);
     }
 }
@@ -1765,7 +1765,7 @@ void TransferList::movetransfer(transfer_list::iterator it, transfer_list::itera
 
     transfers[transfer->type].erase(it);
     transfer_list::iterator fit = transfers[transfer->type].begin() + dstindex;
-    assert(fit == transfers[transfer->type].end() || (*fit)->priority != transfer->priority);
+    assert(fit == transfers[transfer->type].end() || fit->transfer->priority != transfer->priority);
     transfers[transfer->type].insert(fit, transfer);
     client->transfercacheadd(transfer, &committer);
     client->app->transfer_update(transfer);


### PR DESCRIPTION
Cancelling transfers in particular, and shutdown were very slow with > 100k transfers
This PR addresses some N^2 behaviour
 - When deleting all nodes, no need for every node to remove itself from the Fingerprints map, just clear() it.  (optimize purge nodes flag)
 - When destroying all transfers with freeq(), no need for the transfers to remove themselves from the list, just clear() it.  (optimize delete flag)
 - When removing transfers from the std::deque due to transfer completion, the removal requires moving all the remaining items back one place.
   If we are removing many items (such as "cancel all" with 100k transfers queued, doing all that shuffling per transfer is ridiculously slow.
   A deque wrapper class is introduced that intercepts erase() and marks the entry erased instead (with its Transfer* set to null as the transfer has now been deleted).
   All other function calls on the deque are also intercepted, and first actually erase those elements (performing the shuffling once only) and then perform that function as usual.
   There was some complication with the 'priority' value which is still needed to be able to find other elements to erase, so LazyEraseTransferPtr was introduced to keep that value even when the entry is marked erased.
 - More efficient getChildren function that just uses sort() instead of manually building up a sorted vector with lower_bound.
 - Avoid sorting getChildren anyway in MegaFolderDownloadController::downloadFolderNode, as that takes significant time for very large folders.