### PR TITLE
#15763: start gfx processor thread (missing in Sync_test)

### DIFF
--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -376,6 +376,9 @@ struct StandardClient : public MegaApp
         , clientthread([this]() { threadloop(); })
     {
         client.clientname = clientname + " ";
+#ifdef GFX_CLASS
+        gfx.startProcessingThread();
+#endif
     }
 
     ~StandardClient()


### PR DESCRIPTION
fix required after https://github.com/meganz/sdk/pull/1894