### PR TITLE
#13885. Fix for crypto on threads in the Transfer destructor

### DIFF
--- a/include/mega/raid.h
+++ b/include/mega/raid.h
@@ -46,6 +46,9 @@ namespace mega {
             m_off_t pos;
             HttpReq::http_buf_t buf;  // owned here
             chunkmac_map chunkmacs;
+            
+            std::condition_variable finalizedCV;
+            bool finalized = false;
 
             FilePiece();
             FilePiece(m_off_t p, size_t len);    // makes a buffer of the specified size (with extra space for SymmCipher::ctr_crypt padding)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3881,7 +3881,7 @@ void MegaClient::logout()
 
 void MegaClient::locallogout(bool removecaches)
 {
-    mAsyncQueue.clearQueue();
+    mAsyncQueue.clearDiscardable();
 
     if (removecaches)
     {

--- a/src/raid.cpp
+++ b/src/raid.cpp
@@ -694,7 +694,8 @@ bool RaidBufferManager::FilePiece::finalize(bool parallel, m_off_t filesize, int
     }
 
     finalized = !queueParallel;
-    if (finalized) finalizedCV.notify_one();
+    if (finalized)
+        finalizedCV.notify_one();
 
     return queueParallel;
 }

--- a/src/raid.cpp
+++ b/src/raid.cpp
@@ -638,6 +638,7 @@ m_off_t TransferBufferManager::calcOutputChunkPos(m_off_t acquiredpos)
 // decrypt, mac downloaded chunk
 bool RaidBufferManager::FilePiece::finalize(bool parallel, m_off_t filesize, int64_t ctriv, SymmCipher *cipher, chunkmac_map* source_chunkmacs)
 {
+    assert(!finalized);
     bool queueParallel = false;
 
     byte *chunkstart = buf.datastart();
@@ -691,6 +692,10 @@ bool RaidBufferManager::FilePiece::finalize(bool parallel, m_off_t filesize, int
         endpos = ChunkedHash::chunkceil(startpos, finalpos);
         chunksize = static_cast<unsigned>(endpos - startpos);
     }
+
+    finalized = !queueParallel;
+    if (finalized) finalizedCV.notify_one();
+
     return queueParallel;
 }
 

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -184,6 +184,7 @@ TransferSlot::~TransferSlot()
                         LOG_verbose << "Async write failed";
                         transferbuf.bufferWriteCompleted(i, false);
                     }
+                    reqs[i]->status = REQ_READY;
                 }
                 delete asyncIO[i];
                 asyncIO[i] = NULL;
@@ -199,14 +200,30 @@ TransferSlot::~TransferSlot()
 
         for (int i = 0; i < connections; i++)
         {
-            HttpReqDL *downloadRequest = static_cast<HttpReqDL*>(reqs[i].get());
-            if (fa && downloadRequest && downloadRequest->status == REQ_INFLIGHT
-                    && downloadRequest->contentlength == downloadRequest->size   
-                    && downloadRequest->bufpos >= SymmCipher::BLOCKSIZE)
+            if (HttpReqDL *downloadRequest = static_cast<HttpReqDL*>(reqs[i].get()))
             {
-                HttpReq::http_buf_t* buf = downloadRequest->release_buf();
-                buf->end -= buf->datalen() % RAIDSECTOR;
-                transferbuf.submitBuffer(i, new TransferBufferManager::FilePiece(downloadRequest->dlpos, buf)); // resets size & bufpos of downloadrequest.
+                switch (downloadRequest->status)
+                {
+                    case REQ_INFLIGHT:
+                        if (fa && downloadRequest && downloadRequest->status == REQ_INFLIGHT
+                            && downloadRequest->contentlength == downloadRequest->size
+                            && downloadRequest->bufpos >= SymmCipher::BLOCKSIZE)
+                        {
+                            HttpReq::http_buf_t* buf = downloadRequest->release_buf();
+                            buf->end -= buf->datalen() % RAIDSECTOR;
+                            transferbuf.submitBuffer(i, new TransferBufferManager::FilePiece(downloadRequest->dlpos, buf)); // resets size & bufpos of downloadrequest.
+                        }
+                        break;
+
+                    case REQ_DECRYPTING:
+                        LOG_info << "Waiting for block decryption";
+                        std::mutex finalizedMutex; 
+                        std::unique_lock<std::mutex> guard(finalizedMutex);
+                        auto outputPiece = transferbuf.getAsyncOutputBufferPointer(i);
+                        outputPiece->finalizedCV.wait(guard, [&](){ return outputPiece->finalized; });
+                        downloadRequest->status = REQ_DECRYPTED;
+                        break;
+                }
             }
         }
 
@@ -221,6 +238,11 @@ TransferSlot::~TransferSlot()
                 auto outputPiece = transferbuf.getAsyncOutputBufferPointer(i);
                 if (outputPiece)
                 {
+                    if (!outputPiece->finalized)
+                    {
+                        transfer->client->tmptransfercipher.setkey(transfer->transferkey.data());
+                        outputPiece->finalize(true, transfer->size, transfer->ctriv, &transfer->client->tmptransfercipher, &transfer->chunkmacs);
+                    }
                     anyData = true;
                     if (fa && fa->fwrite(outputPiece->buf.datastart(), static_cast<unsigned>(outputPiece->buf.datalen()), outputPiece->pos))
                     {
@@ -639,7 +661,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                                         sc.setkey(transferkey.data());
                                         outputPiece->finalize(true, filesize, ctriv, &sc, nullptr);
                                         req->status = REQ_DECRYPTED;
-                                    });
+                                    }, false);  // not discardable:  if we downloaded the data, don't waste it - decrypt and write as much as we can to file
                                 }
                                 else
                                 {
@@ -766,7 +788,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                                         sc.setkey(transferkey.data());
                                         req->prepare(finaltempurl.c_str(), &sc, ctriv, pos, npos); 
                                         req->status = REQ_PREPARED;
-                                    });
+                                    }, true);   // discardable - if the transfer or client are being destroyed, we won't be sending that data.
                             }
                             else
                             {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2348,7 +2348,7 @@ std::pair<bool, int64_t> generateMetaMac(SymmCipher &cipher, InputStreamAccess &
     return std::make_pair(true, chunkMacs.macsmac(&cipher));
 }
 
-void MegaClientAsyncQueue::push(std::function<void(SymmCipher&)> f)
+void MegaClientAsyncQueue::push(std::function<void(SymmCipher&)> f, bool discardable)
 {
     if (mThreads.empty())
     {
@@ -2361,7 +2361,7 @@ void MegaClientAsyncQueue::push(std::function<void(SymmCipher&)> f)
     {
         {
             std::lock_guard<std::mutex> g(mMutex);
-            mQueue.emplace_back(std::move(f));
+            mQueue.emplace_back(discardable, std::move(f));
         }
         mConditionVariable.notify_one();
     }
@@ -2390,19 +2390,22 @@ MegaClientAsyncQueue::MegaClientAsyncQueue(Waiter& w, unsigned threadCount)
 
 MegaClientAsyncQueue::~MegaClientAsyncQueue()
 {
-    clearQueue();
-    push(nullptr);
+    clearDiscardable();
+    push(nullptr, false);
     mConditionVariable.notify_all();
+    LOG_warn << "~MegaClientAsyncQueue() joining threads";
     for (auto& t : mThreads)
     {
         t.join();
     }
+    LOG_warn << "~MegaClientAsyncQueue() ends";
 }
 
-void MegaClientAsyncQueue::clearQueue()
+void MegaClientAsyncQueue::clearDiscardable()
 {
     std::lock_guard<std::mutex> g(mMutex);
-    mQueue.clear();
+    auto newEnd = std::remove_if(mQueue.begin(), mQueue.end(), [](Entry& entry){ return entry.discardable; });
+    mQueue.erase(newEnd, mQueue.end());
 }
 
 void MegaClientAsyncQueue::asyncThreadLoop()
@@ -2414,7 +2417,7 @@ void MegaClientAsyncQueue::asyncThreadLoop()
         {
             std::unique_lock<std::mutex> g(mMutex);
             mConditionVariable.wait(g, [this]() { return !mQueue.empty(); });
-            f = std::move(mQueue.front());
+            f = std::move(mQueue.front().f);
             if (!f) return;   // nullptr is not popped, and causes all the threads to exit
             mQueue.pop_front();
         }

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -3736,7 +3736,6 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
             {
                 t.reset();
                 lastOnTranferFinishedCount = onTranferFinishedCount;
-                cout << "new download" << endl;
                 deleteFile(filename.c_str());
                 onTransferUpdate_progress = 0;
                 onTransferUpdate_filesize = 0;

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -152,6 +152,7 @@ public:
 
     m_off_t onTransferUpdate_progress;
     m_off_t onTransferUpdate_filesize;
+    unsigned onTranferFinishedCount = 0;
 
     std::mutex lastEventMutex;
     std::unique_ptr<MegaEvent> lastEvent;

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1702,7 +1702,7 @@ public:
     {
         std::vector<uint8_t> data(length);
 
-        std::generate_n(data.begin(), data.size(), std::rand);
+        std::generate_n(data.begin(), data.size(), [](){ return (uint8_t)std::rand(); });
 
         return data;
     }


### PR DESCRIPTION
When a Transfer is destroyed, we should process and write any data already downloaded so as to not waste the user's bandwidth.
Also those downloaded chunks must wait for decryption to finish if it is in progress, and decrypt any chunks downloaded but not yet decrypted.

Also the AsyncQueue is adjusted to have a flag as to whether operations can be discarded on MegaClient destruction (which is one case for transfer deletion)
Decryption of downloads are not discardable, but encrypt for uploads are.
If the MegaClient is destroyed, we let the decryptions run, but discard the encryptions.

The threading issue is addressed because we no longer try to merge the mac map of a still-decrypting chunk.