### PR TITLE
Issue15846- Add public link creation time to node (iOS bindings)

### DIFF
--- a/bindings/ios/MEGANode.h
+++ b/bindings/ios/MEGANode.h
@@ -175,6 +175,14 @@ typedef NS_ENUM(NSUInteger, MEGANodeChangeType) {
 @property (readonly, nonatomic) NSDate *modificationTime;
 
 /**
+ * @brief Public link creation time of the file to MEGA (in seconds since the epoch).
+ *
+ * The value is only valid for nodes of type MEGANodeTypeFile.
+ *
+ */
+@property (readonly, nonatomic) NSDate *publicLinkCreationTime;
+
+/**
  * @brief Handle to identify this MEGANode.
  *
  * You can use [MEGASdk nodeForHandle:] to recover the node later.

--- a/bindings/ios/MEGANode.h
+++ b/bindings/ios/MEGANode.h
@@ -180,7 +180,7 @@ typedef NS_ENUM(NSUInteger, MEGANodeChangeType) {
  * The value is only valid for nodes of type MEGANodeTypeFile.
  *
  */
-@property (readonly, nonatomic) NSDate *publicLinkCreationTime;
+@property (readonly, nonatomic, nullable) NSDate *publicLinkCreationTime;
 
 /**
  * @brief Handle to identify this MEGANode.

--- a/bindings/ios/MEGANode.mm
+++ b/bindings/ios/MEGANode.mm
@@ -129,6 +129,10 @@ using namespace mega;
     return self.megaNode ? [[NSDate alloc] initWithTimeIntervalSince1970:self.megaNode->getModificationTime()] : nil;
 }
 
+- (NSDate *)publicLinkCreationTime {
+    return self.megaNode ? [[NSDate alloc] initWithTimeIntervalSince1970:self.megaNode->getPublicLinkCreationTime()] : nil;
+}
+
 - (uint64_t)handle {
     return self.megaNode ? self.megaNode->getHandle() : ::mega::INVALID_HANDLE;
 }


### PR DESCRIPTION
What did I do for this PR?
Add `publicLinkCreationTime` to SDK bindings that help to identify a shared link creation time for MEGA shared link, and expose this data to the iOS application.

Does this PR fix any problem?
https://issues.developers.mega.co.nz/issues/15846
It is originally from issue15846, with follow on discussion, we need to update the date of shared link with `PublicLinkCreationTime`