### PR TITLE
Add libwebsockets to the scripts to build 3rd party dependencies

### DIFF
--- a/contrib/cmake/3rdparty_deps.txt
+++ b/contrib/cmake/3rdparty_deps.txt
@@ -68,6 +68,9 @@ libwebsockets
 # - If using the latest Pdfium, use at least VS2017 and skip the branch checkout above, and substitute the pdfium-masterbranch-CMakeLists.txt in vcpkg/ports/pdfium and make this one small patch (other changes may be needed if the master branch has changed):
 #      in pdfium\core\fxcrt\fx_memory_wrappers.h(26)   comment out the static_assert (uint8_t counts as an arithmentic type)
 
-
 pdfium
 pdfium-freetype
+
+# If building for use with MEGAChat messaging then libwebsocket is needed (but voice/video calling needs WebRTC which changes the dependencies a lot, openssl in particular)
+libwebsockets
+

--- a/contrib/cmake/vcpkg_extra_ports/libwebsockets/2.4.2/find_library_libuv.patch
+++ b/contrib/cmake/vcpkg_extra_ports/libwebsockets/2.4.2/find_library_libuv.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c62d7f9..8049686 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1098,7 +1098,7 @@ endif(LWS_WITH_LIBEV)
+ if (LWS_WITH_LIBUV)
+ 	if (NOT LIBUV_FOUND)
+ 		find_path(LIBUV_INCLUDE_DIRS NAMES uv.h)
+-		find_library(LIBUV_LIBRARIES NAMES uv)
++		find_library(LIBUV_LIBRARIES NAMES libuv)
+ 		if(LIBUV_INCLUDE_DIRS AND LIBUV_LIBRARIES)
+ 			set(LIBUV_FOUND 1)
+ 		endif()

--- a/contrib/cmake/vcpkg_extra_ports/libwebsockets/2.4.2/portfile.cmake
+++ b/contrib/cmake/vcpkg_extra_ports/libwebsockets/2.4.2/portfile.cmake
@@ -5,7 +5,9 @@ vcpkg_from_github(
     REPO warmcat/libwebsockets
     REF v2.4.2
     SHA512 7bee49f6763ff3ab7861fcda25af8d80f6757c56e197ea42be53e0b2480969eee73de3aee5198f5ff06fd1cb8ab2be4c6495243e83cd0acc235b0da83b2353d1
-    HEAD_REF master
+    HEAD_REF v2.4-stable
+    PATCHES
+	    find_library_libuv.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LWS_WITH_STATIC)
@@ -13,7 +15,6 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LWS_WITH_SHARED)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DLWS_WITH_STATIC=${LWS_WITH_STATIC}
         -DLWS_WITH_SHARED=${LWS_WITH_SHARED}
@@ -21,19 +22,14 @@ vcpkg_configure_cmake(
         -DLWS_WITHOUT_TESTAPPS=ON
         -DLWS_IPV6=OFF
         -DLWS_HTTP2=ON
-		-DLWS_WITH_LIBUV=ON
-        -DLIBUV_LIBRARIES="C:/dev/3rdParty-fullstatic-uncheckediterators/vcpkg/installed/x64-windows-mega/lib/libuv.lib"		
+        -DLWS_WITH_LIBUV=ON
     # OPTIONS_RELEASE -DOPTIMIZE=1
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 vcpkg_install_cmake()
 
-if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "windows" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
-else()
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libwebsockets)
-endif()
+vcpkg_fixup_cmake_targets(CONFIG_PATH "cmake")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
@@ -50,9 +46,7 @@ file(WRITE ${CURRENT_PACKAGES_DIR}/share/libwebsockets/LibwebsocketsTargets-rele
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libwebsockets)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libwebsockets/LICENSE ${CURRENT_PACKAGES_DIR}/share/libwebsockets/copyright)
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "windows" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/websockets_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/websockets.lib)
-        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/websockets_static.lib ${CURRENT_PACKAGES_DIR}/lib/websockets.lib)
-    endif()
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/websockets_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/websockets.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/websockets_static.lib ${CURRENT_PACKAGES_DIR}/lib/websockets.lib)
 endif ()
 vcpkg_copy_pdbs()


### PR DESCRIPTION
Libwebsockets is needed if using Karere for chat messages.