### PR TITLE
With thread_local in use, the text appearing in MEGAsync on windows X…

### DIFF
--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -201,10 +201,11 @@ class SimpleLogger
     static OutputStreams getOutput(enum LogLevel ll);
 #else
 
-#ifdef WIN32
-    //static thread_local 
+#ifdef WIN64
+    static thread_local std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
+#elif WIN32
     // Keep this as a normal class member on WIN32 until we abandon XP (Qt fonts appear with strikethrough on XP otherwise)
-    std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
+    /*static thread_local*/ std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
 #else
     static __thread std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
 #endif

--- a/include/mega/logging.h
+++ b/include/mega/logging.h
@@ -202,7 +202,9 @@ class SimpleLogger
 #else
 
 #ifdef WIN32
-    static thread_local std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
+    //static thread_local 
+    // Keep this as a normal class member on WIN32 until we abandon XP (Qt fonts appear with strikethrough on XP otherwise)
+    std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
 #else
     static __thread std::array<char, LOGGER_CHUNKS_SIZE> mBuffer;
 #endif

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -45,7 +45,7 @@ long long SimpleLogger::maxPayloadLogSize  = 10240;
 #ifdef ENABLE_LOG_PERFORMANCE
 
 #ifdef WIN32
-thread_local std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; 
+//thread_local std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; 
 #else
 __thread std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; 
 #endif

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -44,7 +44,9 @@ long long SimpleLogger::maxPayloadLogSize  = 10240;
 
 #ifdef ENABLE_LOG_PERFORMANCE
 
-#ifdef WIN32
+#ifdef WIN64
+thread_local std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer;
+#elif WIN32
 //thread_local std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; 
 #else
 __thread std::array<char, LOGGER_CHUNKS_SIZE> SimpleLogger::mBuffer; 


### PR DESCRIPTION
…P was italic with strikethrough.