### PR TITLE
fix compilation issues in windows

### DIFF
--- a/bindings/qt/sdk.pri
+++ b/bindings/qt/sdk.pri
@@ -235,7 +235,8 @@ CONFIG(USE_PDFIUM) {
     vcpkg:LIBS += -lpdfium -lfreetype$$DEBUG_SUFFIX -ljpeg$$DEBUG_SUFFIX_WO -lopenjp2  -llcms$$DEBUG_SUFFIX 
 
     #make sure we get the vcpkg built icu libraries and not a system one with the same name
-    vcpkg:LIBS += -l$$THIRDPARTY_VCPKG_PATH/lib/icuuc$$DEBUG_SUFFIX_WO.lib -l$$THIRDPARTY_VCPKG_PATH/lib/icuio$$DEBUG_SUFFIX_WO.lib
+    debug:vcpkg:LIBS += -l$$THIRDPARTY_VCPKG_PATH/debug/lib/icuucd -l$$THIRDPARTY_VCPKG_PATH/debug/lib/icuiod
+    !debug:vcpkg:LIBS += -l$$THIRDPARTY_VCPKG_PATH/lib/icuuc$$DEBUG_SUFFIX_WO.lib -l$$THIRDPARTY_VCPKG_PATH/lib/icuio$$DEBUG_SUFFIX_WO.lib
     #vcpkg:QMAKE_LFLAGS_WINDOWS += /VERBOSE
 
     vcpkg:unix:!macx:LIBS += -lpng -lharfbuzz #freetype dependencies. ideally we could use pkg-config to get these

--- a/contrib/cmake/config.h.in
+++ b/contrib/cmake/config.h.in
@@ -142,7 +142,9 @@
 #define HAVE_TERMCAP_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
+#ifndef _WIN32
 #define HAVE_UNISTD_H 1
+#endif
 
 /* Define to 1 if you have the <uv.h> header file. */
 /* #undef HAVE_UV_H */

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -32,6 +32,7 @@
 #include <sys/mount.h>
 #include <sys/param.h>
 #elif defined(_WIN32) || defined(_WIN64) || defined(WINDOWS_PHONE)
+#include <winsock2.h>
 #include <Windows.h>
 #endif
 


### PR DESCRIPTION
- use the proper debug libicu library from vcpkg
- do not define HAVE_UNISTD_H in config.h.in for windows
- include winsock2.h before windows.h to avoid compilation issues