### PR TITLE
#16115. This test was using type NONE, which is out of bounds for the transfe…

### DIFF
--- a/include/mega/transfer.h
+++ b/include/mega/transfer.h
@@ -213,7 +213,7 @@ public:
     std::array<vector<Transfer*>, 6> nexttransfers(std::function<bool(Transfer*)>& continuefunction);
     Transfer *transferat(direction_t direction, unsigned int position);
 
-    transfer_list transfers[2];
+    std::array<transfer_list, 2> transfers;
     MegaClient *client;
     uint64_t currentpriority;
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -384,6 +384,7 @@ public:
 
     size_t size()                                        { applyErase(); return mDeque.size(); }
     size_t empty()                                       { applyErase(); return mDeque.empty(); }
+    void clear()                                         { mDeque.clear(); }
     iterator begin(bool canHandleErasedElements = false) { if (!canHandleErasedElements) applyErase(); return mDeque.begin(); }
     iterator end(bool canHandleErasedElements = false)   { if (!canHandleErasedElements) applyErase(); return mDeque.end(); }
     void push_front(T t)                                 { applyErase(); mDeque.push_front(E(t)); }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -214,6 +214,7 @@ bool FileSystemAccess::islocalfscompatible(unsigned char c, bool isEscape, FileS
         case FS_FUSE:
         case FS_SDCARDFS:
         case FS_UNKNOWN:
+        default:
             // FUSE and SDCARDFS are Android filesystem wrappers used to mount traditional filesystems
             // as ext4, Fat32, extFAT...
             // So we will consider that restricted characters for these wrappers are the same

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3777,6 +3777,8 @@ void MegaClient::freeq(direction_t d)
         delete transferPtr.second;
     }
     transfers[d].clear();
+    transferlist.transfers[GET].clear();
+    transferlist.transfers[PUT].clear();
 }
 
 bool MegaClient::isFetchingNodesPendingCS()

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3345,6 +3345,7 @@ void MegaClient::dispatchTransfers()
     // We prepare data for put/get in index 0..1, and the put/get/big/small combinations in index 2..5
     for (TransferSlot* ts : tslots)
     {
+        assert(ts->transfer->type == PUT || ts->transfer->type == GET);
         TransferCategory tc(ts->transfer);
         counters[tc.index()].addexisting(ts->transfer->size, ts->progressreported);
         counters[tc.directionIndex()].addexisting(ts->transfer->size,  ts->progressreported);

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -222,6 +222,13 @@ Transfer *Transfer::unserialize(MegaClient *client, string *d, transfer_map* tra
     type = MemAccess::get<direction_t>(ptr);
     ptr += sizeof(direction_t);
 
+    if (type != GET && type != PUT)
+    {
+        assert(false);
+        LOG_err << "Transfer unserialization failed - neither get nor put";
+        return NULL;
+    }
+
     ll = MemAccess::get<unsigned short>(ptr);
     ptr += sizeof(ll);
 
@@ -1611,6 +1618,8 @@ void TransferList::addtransfer(Transfer *transfer, DBTableTransactionCommitter& 
         transfer->state = TRANSFERSTATE_QUEUED;
     }
 
+    assert(transfer->type == PUT || transfer->type == GET);
+
     if (!transfer->priority)
     {
         if (startFirst && transfers[transfer->type].size())
@@ -1699,6 +1708,7 @@ void TransferList::movetransfer(transfer_list::iterator it, transfer_list::itera
     }
 
     Transfer *transfer = (*it);
+    assert(transfer->type == PUT || transfer->type == GET);
     if (dstit == transfers[transfer->type].end())
     {
         LOG_debug << "Moving transfer to the last position";
@@ -1908,9 +1918,17 @@ auto TransferList::end(direction_t direction) -> transfer_list::iterator
 
 bool TransferList::getIterator(Transfer *transfer, transfer_list::iterator& it, bool canHandleErasedElements) 
 {
+    assert(transfer);
     if (!transfer)
     {
         LOG_err << "Getting iterator of a NULL transfer";
+        return false;
+    }
+
+    assert(transfer->type == GET || transfer->type == PUT);
+    if (transfer->type != GET && transfer->type != PUT)
+    {
+        LOG_err << "Getting iterator of wrong transfer type " << transfer->type;
         return false;
     }
 
@@ -1979,6 +1997,7 @@ Transfer *TransferList::transferat(direction_t direction, unsigned int position)
 
 void TransferList::prepareIncreasePriority(Transfer *transfer, transfer_list::iterator /*srcit*/, transfer_list::iterator dstit, DBTableTransactionCommitter& committer)
 {
+    assert(transfer->type == PUT || transfer->type == GET);
     if (dstit == transfers[transfer->type].end())
     {
         return;
@@ -2016,6 +2035,7 @@ void TransferList::prepareIncreasePriority(Transfer *transfer, transfer_list::it
 
 void TransferList::prepareDecreasePriority(Transfer *transfer, transfer_list::iterator it, transfer_list::iterator dstit)
 {
+    assert(transfer->type == PUT || transfer->type == GET);
     if (transfer->slot && transfer->state == TRANSFERSTATE_ACTIVE)
     {
         transfer_list::iterator cit = it + 1;

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -441,12 +441,12 @@ struct StandardClient : public MegaApp
 
     
     std::atomic<unsigned> transfersAdded{0}, transfersRemoved{0}, transfersPrepared{0}, transfersFailed{0}, transfersUpdated{0}, transfersComplete{0};
-    void transfer_added(Transfer*) { ++transfersAdded; }
-    void transfer_removed(Transfer*) { ++transfersRemoved; }
-    void transfer_prepare(Transfer*) { ++transfersPrepared; }
-    void transfer_failed(Transfer*, error, dstime = 0) { ++transfersFailed; }
-    void transfer_update(Transfer*) { ++transfersUpdated; }
-    void transfer_complete(Transfer*) { ++transfersComplete; }
+    void transfer_added(Transfer*) override { ++transfersAdded; }
+    void transfer_removed(Transfer*) override { ++transfersRemoved; }
+    void transfer_prepare(Transfer*) override { ++transfersPrepared; }
+    void transfer_failed(Transfer*,  const Error&, dstime = 0) override { ++transfersFailed; }
+    void transfer_update(Transfer*) override { ++transfersUpdated; }
+    void transfer_complete(Transfer*) override { ++transfersComplete; }
 
 
     void threadloop()

--- a/tests/unit/File_test.cpp
+++ b/tests/unit/File_test.cpp
@@ -75,7 +75,7 @@ TEST(File, serialize_unserialize)
     file.chatauth = new char[4]{'b', 'a', 'r', '\0'}; // owned by file
     std::fill(file.filekey, file.filekey + mega::FILENODEKEYLENGTH, 'X');
     file.targetuser = "targetuser";
-    file.transfer = new mega::Transfer{client.get(), mega::NONE}; // owned by client
+    file.transfer = new mega::Transfer{client.get(), mega::GET}; // owned by client
     file.transfer->files.push_back(&file);
     file.file_it = file.transfer->files.begin();
 
@@ -104,7 +104,7 @@ TEST(File, unserialize_32bit)
     file.chatauth = new char[4]{'b', 'a', 'r', '\0'}; // owned by file
     std::fill(file.filekey, file.filekey + mega::FILENODEKEYLENGTH, 'X');
     file.targetuser = "targetuser";
-    file.transfer = new mega::Transfer{client.get(), mega::NONE}; // owned by client
+    file.transfer = new mega::Transfer{client.get(), mega::GET}; // owned by client
     file.transfer->files.push_back(&file);
     file.file_it = file.transfer->files.begin();
 


### PR DESCRIPTION
…rs array.

Also use std::array for some compiler/library support for deteting out of bounds
Also add some asserts so we catch similar errors.
Also avoid loading any cached transfers with an invalid type.