### PR TITLE
#16219 Fix time for backups in 32bits systems.

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -24911,7 +24911,7 @@ void MegaBackupController::setPeriod(const int64_t &value)
     period = value;
     if (value != -1)
     {
-        this->offsetds=std::time(NULL)*10 - Waiter::ds;
+        this->offsetds=m_time(NULL)*10 - Waiter::ds;
         this->startTime = lastbackuptime?(lastbackuptime+period-offsetds):Waiter::ds;
         if (this->startTime < Waiter::ds)
             this->startTime = Waiter::ds;
@@ -24934,7 +24934,7 @@ void MegaBackupController::setPeriodstring(const string &value)
             return;
         }
 
-        this->offsetds=std::time(NULL)*10 - Waiter::ds;
+        this->offsetds=m_time(NULL)*10 - Waiter::ds;
 
         if (!lastbackuptime)
         {


### PR DESCRIPTION
Use m_time to ensure that all dates are 64bits, solving a rollover problem in the dates shown in the backup.
