### PR TITLE
Fix for local renaming.

### DIFF
--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -161,7 +161,6 @@ public:
     bool findNextSeparator(size_t& separatorBytePos, const FileSystemAccess& fsaccess) const;
     bool findPrevSeparator(size_t& separatorBytePos, const FileSystemAccess& fsaccess) const;
     size_t getLeafnameByteIndex(const FileSystemAccess& fsaccess) const;
-    bool backEqual(size_t bytePos, const std::string& compareTo) const;
     bool backEqual(size_t bytePos, const LocalPath& compareTo) const;
     LocalPath subpathFrom(size_t bytePos) const;
     std::string substrTo(size_t bytePos) const;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -971,12 +971,6 @@ size_t LocalPath::getLeafnameByteIndex(const FileSystemAccess& fsaccess) const
     return p;
 }
 
-bool LocalPath::backEqual(size_t bytePos, const string& compareTo) const
-{
-    auto n = compareTo.size();
-    return bytePos + n == localpath.size() && memcmp(compareTo.data(), localpath.data() + bytePos, n);
-}
-
 bool LocalPath::backEqual(size_t bytePos, const LocalPath& compareTo) const
 {
     auto n = compareTo.localpath.size();

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -980,7 +980,7 @@ bool LocalPath::backEqual(size_t bytePos, const string& compareTo) const
 bool LocalPath::backEqual(size_t bytePos, const LocalPath& compareTo) const
 {
     auto n = compareTo.localpath.size();
-    return bytePos + n == localpath.size() && memcmp(compareTo.localpath.data(), localpath.data() + bytePos, n);
+    return bytePos + n == localpath.size() && !memcmp(compareTo.localpath.data(), localpath.data() + bytePos, n);
 }
 
 LocalPath LocalPath::subpathFrom(size_t bytePos) const

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -136,11 +136,15 @@ struct Model
         return makeModelSubfile(u8name, data.data(), data.size());
     }
 
+    unique_ptr<ModelNode> makeModelSubfile(const string& u8name, const string& data)
+    {
+        return makeModelSubfile(u8name, data.data(), data.size());
+    }
+
     unique_ptr<ModelNode> makeModelSubfile(const string& u8name)
     {
         return makeModelSubfile(u8name, u8name.data(), u8name.size());
     }
-
 
     unique_ptr<ModelNode> buildModelSubdirs(const string& prefix, int n, int recurselevel, int filesperdir)
     {
@@ -2041,7 +2045,61 @@ GTEST_TEST(Sync, BasicSync_MoveLocalFolderBetweenSyncs)
     ASSERT_TRUE(clientA3.confirmModel_mainthread(model.findnode("f"), 31));
 }
 
+GTEST_TEST(Sync, BasicSync_RenameLocalFile)
+{
+    static auto TIMEOUT = std::chrono::seconds(4);
 
+    const fs::path root = makeNewTestRoot(LOCAL_TEST_FOLDER);
+
+    // Primary client.
+    StandardClient client0(root, "c0");
+    // Observer.
+    StandardClient client1(root, "c1");
+
+    // Log callbacks.
+    client0.logcb = true;
+    client1.logcb = true;
+
+    // Log clients in.
+    ASSERT_TRUE(client0.login_reset_makeremotenodes("MEGA_EMAIL", "MEGA_PWD", "x", 0, 0));
+    ASSERT_TRUE(client1.login_fetchnodes("MEGA_EMAIL", "MEGA_PWD"));
+    ASSERT_EQ(client0.basefolderhandle, client1.basefolderhandle);
+
+    // Set up syncs.
+    ASSERT_TRUE(client0.setupSync_mainthread("s0", "x", 0));
+    ASSERT_TRUE(client1.setupSync_mainthread("s1", "x", 1));
+
+    // Wait for initial sync to complete.
+    waitonsyncs(TIMEOUT, &client0, &client1);
+
+    // Add x/f.
+    ASSERT_TRUE(createFile(client0.syncSet[0].localpath, "f"));
+
+    // Wait for sync to complete.
+    waitonsyncs(TIMEOUT, &client0, &client1);
+
+    // Confirm model.
+    Model model;
+
+    model.root->addkid(model.makeModelSubfolder("x"));
+    model.findnode("x")->addkid(model.makeModelSubfile("f"));
+
+    ASSERT_TRUE(client0.confirmModel_mainthread(model.findnode("x"), 0));
+    ASSERT_TRUE(client1.confirmModel_mainthread(model.findnode("x"), 1, true));
+
+    // Rename x/f to x/g.
+    fs::rename(client0.syncSet[0].localpath / "f",
+               client0.syncSet[0].localpath / "g");
+
+    // Wait for sync to complete.
+    waitonsyncs(TIMEOUT, &client0, &client1);
+
+    // Update and confirm model.
+    model.findnode("x/f")->name = "g";
+
+    ASSERT_TRUE(client0.confirmModel_mainthread(model.findnode("x"), 0));
+    ASSERT_TRUE(client1.confirmModel_mainthread(model.findnode("x"), 1, true));
+}
 
 GTEST_TEST(Sync, BasicSync_AddLocalFolder)
 {


### PR DESCRIPTION
LocalPath::backEqual(...) had the wrong sense when checking memcmp(...)'s return value.

The result of this was that the SDK would not correctly detect renames.
This was not caught by the integration tests as the there were no tests checking basic rename functionality.

This PR corrects the sense of backEqual(...) and adds a suitable test case to check for similar failures in the future.