### PR TITLE
#16424. Testing for *scsn could send uninitialized data, fixed now

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -206,6 +206,8 @@ public:
     const char* text() const;
     handle getHandle() const;
 
+    friend std::ostream& operator<<(std::ostream& os, const SCSN& scsn);
+
     SCSN();
     void clear();
 };

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -180,10 +180,15 @@ public:
     dstime timeToTransfersResumed;
 };
 
-// A helper class that keeps the SN (sequence number) members in sync and well initialized.
+/**
+ * @brief A helper class that keeps the SN (sequence number) members in sync and well initialized.
+ *  The server-client sequence number is updated along with every batch of actionpackets received from API
+ *  It is used to commit the open transaction in DB, so the account's local state is persisted. Upon resumption,
+ *  the scsn is sent to API, which provides the possible updates missing while the client was not running
+ */
 class SCSN
 {
-    // scsn that we are sending in sc requests (ie, where we are up to with the in-memory node data)
+    // scsn that we are sending in sc requests (ie, where we are up to with the persisted node data)
     char scsn[12];
 
     // sc inconsistency: stop querying for action packets
@@ -192,13 +197,14 @@ class SCSN
 public: 
 
     bool setScsn(JSON*);
-    void set(handle);
+    void setScsn(handle);
     void stopScsn();
 
-    bool ready();
-    bool stopped();
+    bool ready() const;
+    bool stopped() const;
 
-    const char* text();
+    const char* text() const;
+    handle getHandle() const;
 
     SCSN();
     void clear();

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -180,6 +180,29 @@ public:
     dstime timeToTransfersResumed;
 };
 
+// A helper class that keeps the SN (sequence number) members in sync and well initialized.
+class SCSN
+{
+    // scsn that we are sending in sc requests (ie, where we are up to with the in-memory node data)
+    char scsn[12];
+
+    // sc inconsistency: stop querying for action packets
+    bool stopsc = false;
+
+public: 
+
+    bool setScsn(JSON*);
+    void set(handle);
+    void stopScsn();
+
+    bool ready();
+    bool stopped();
+
+    const char* text();
+
+    SCSN();
+    void clear();
+};
 
 class MEGA_API MegaClient
 {
@@ -821,9 +844,6 @@ private:
     std::unique_ptr<HttpReq> pendingscUserAlerts;
     BackoffTimer btsc;
 
-    // sc inconsistence: stop querying for action packets
-    bool stopsc = false;
-
     // account is blocked: stops querying for action packets, pauses transfer & removes transfer slot availability
     bool mBlocked = false;
 
@@ -1161,9 +1181,7 @@ public:
     long long mAppliedKeyNodeCount = 0;
 
     // server-client request sequence number
-    char scsn[12];
-
-    bool setscsn(JSON*);
+    SCSN scsn;
 
     void purgenodes(node_vector* = NULL);
     void purgeusers(user_vector* = NULL);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -5375,7 +5375,7 @@ void CommandFetchNodes::procresult()
 
             case MAKENAMEID2('s', 'n'):
                 // sequence number
-                if (!client->setscsn(&client->json))
+                if (!client->scsn.setScsn(&client->json))
                 {
                     client->fetchingnodes = false;
                     return client->app->fetchnodes_result(API_EINTERNAL);
@@ -5411,7 +5411,7 @@ void CommandFetchNodes::procresult()
 #endif
             case EOO:
             {
-                if (!*client->scsn)
+                if (!client->scsn.ready())
                 {
                     client->fetchingnodes = false;
                     return client->app->fetchnodes_result(API_EINTERNAL);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -5936,7 +5936,7 @@ char *MegaApiImpl::getSequenceNumber()
 {
     sdkMutex.lock();
 
-    char *scsn = MegaApi::strdup(client->scsn);
+    char *scsn = MegaApi::strdup(client->scsn.text());
 
     sdkMutex.unlock();
 
@@ -13907,7 +13907,7 @@ void MegaApiImpl::notify_retry(dstime dsdelta, retryreason_t reason)
 void MegaApiImpl::notify_dbcommit()
 {
     MegaEventPrivate *event = new MegaEventPrivate(MegaEvent::EVENT_COMMIT_DB);
-    event->setText(client->scsn);
+    event->setText(client->scsn.text());
     fireOnEvent(event);
 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -641,6 +641,12 @@ handle SCSN::getHandle() const
     return t;
 }
 
+std::ostream& operator<<(std::ostream &os, const SCSN &scsn)
+{
+    os << scsn.text();
+    return os;
+}
+
 
 int MegaClient::nextreqtag()
 {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1278,7 +1278,7 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
     badhostcs = NULL;
 
     scsn.clear();
-	cachedscsn = UNDEF;
+    cachedscsn = UNDEF;
 
     snprintf(appkey, sizeof appkey, "&ak=%s", k);
 
@@ -4793,7 +4793,7 @@ void MegaClient::initsc()
         LOG_debug << "Saving SCSN " << scsn << " with " << nodes.size() << " nodes, " << users.size() << " users, " << pcrindex.size() << " pcrs and " << chats.size() << " chats to local cache (" << complete << ")";
 #else
 
-        LOG_debug << "Saving SCSN " << scsn.text() << " with " << nodes.size() << " nodes and " << users.size() << " users and " << pcrindex.size() << " pcrs to local cache (" << complete << ")";
+        LOG_debug << "Saving SCSN " << scsn << " with " << nodes.size() << " nodes and " << users.size() << " users and " << pcrindex.size() << " pcrs to local cache (" << complete << ")";
  #endif
         finalizesc(complete);
     }

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -2681,7 +2681,7 @@ int CurlHttpIO::cert_verify_callback(X509_STORE_CTX* ctx, void* req)
     HttpReq *request = (HttpReq *)req;
     CurlHttpIO *httpio = (CurlHttpIO *)request->httpio;
     unsigned char buf[sizeof(APISSLMODULUS1) - 1];
-    EVP_PKEY* evp;
+    EVP_PKEY* evp = nullptr;
     int ok = 0;
 
     if (MegaClient::disablepkp)


### PR DESCRIPTION
The main fix is for scsn to be fully 0'd on MegaClient construction.
Also the setting of *scsn=0 and stopsc=true were pretty much the same condition.
Wrapped up the scsn and its validity in a small helper class which can also validate its state when used.
In future perhaps btsc could also be added to that class as it is also highly interdependent with it.
One small compiler warning fixed in net.cpp