### PR TITLE
#16244. Adjust iOS code to LocalPath

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -132,7 +132,7 @@ IF(WIN32)
 ELSE(WIN32)
     set(MegaDir "${CMAKE_CURRENT_LIST_DIR}/../..")
     if ("${Mega3rdPartyDir}" STREQUAL "")
-        set (Mega3rdPartyDir "${MegaDir}/../3rdParty/")
+        set (Mega3rdPartyDir "${MegaDir}/../3rdParty/" CACHE STRING "")
     endif()
 ENDIF(WIN32)
 

--- a/include/mega/osx/osxutils.h
+++ b/include/mega/osx/osxutils.h
@@ -3,7 +3,7 @@
 
 #include "mega/proxy.h"
 
-void path2localMac(std::string* path, std::string* local);
+void path2localMac(const std::string* path, std::string* local);
 
 #if defined(__APPLE__) && !(TARGET_OS_IPHONE)
 void getOSXproxy(mega::Proxy* proxy);

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -77,9 +77,6 @@ public:
 
 #ifdef USE_IOS
     static char *appbasepath;
-    const string iosAdjust(const LocalPath&);
-#else
-    const string& iosAdjust(const LocalPath&);
 #endif
 
     bool notifyerr;

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -77,6 +77,9 @@ public:
 
 #ifdef USE_IOS
     static char *appbasepath;
+    const string iosAdjust(const LocalPath&);
+#else
+    const string& iosAdjust(const LocalPath&);
 #endif
 
     bool notifyerr;

--- a/src/osx/osxutils.mm
+++ b/src/osx/osxutils.mm
@@ -13,7 +13,7 @@ using namespace std;
 
 enum { HTTP_PROXY = 0, HTTPS_PROXY };
 
-void path2localMac(string* path, string* local)
+void path2localMac(const string* path, string* local)
 {
     if (!path->size())
     {

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -426,22 +426,22 @@ bool PosixFileAccess::fopen(LocalPath& f, bool read, bool write, DirAccess* iter
     if (!write)
     {
         char resolved_path[PATH_MAX];
-        if (memcmp(f->c_str(), ".", 2) && memcmp(f->c_str(), "..", 3)
-                && (statok || !lstat(f->c_str(), &statbuf) )
+        if (memcmp(f.editStringDirect()->c_str(), ".", 2) && memcmp(f.editStringDirect()->c_str(), "..", 3)
+                && (statok || !lstat(f.editStringDirect()->c_str(), &statbuf) )
                 && !S_ISLNK(statbuf.st_mode)
-                && realpath(f->c_str(), resolved_path) == resolved_path)
+                && realpath(f.editStringDirect()->c_str(), resolved_path) == resolved_path)
         {
             const char *fname;
             size_t fnamesize;
-            if ((fname = strrchr(f->c_str(), '/')))
+            if ((fname = strrchr(f.editStringDirect()->c_str(), '/')))
             {
                 fname++;
-                fnamesize = f->size() - (fname - f->c_str());
+                fnamesize = f.editStringDirect()->size() - (fname - f.editStringDirect()->c_str());
             }
             else
             {
-                fname =  f->c_str();
-                fnamesize = f->size();
+                fname =  f.editStringDirect()->c_str();
+                fnamesize = f.editStringDirect()->size();
             }
             fnamesize++;
 
@@ -459,7 +459,7 @@ bool PosixFileAccess::fopen(LocalPath& f, bool read, bool write, DirAccess* iter
 
             if (rnamesize == fnamesize && memcmp(fname, rname, fnamesize))
             {
-                LOG_warn << "fopen failed due to invalid case: " << f->c_str();
+                LOG_warn << "fopen failed due to invalid case: " << f.editStringDirect()->c_str();
                 return false;
             }
         }

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -50,11 +50,11 @@ static string iosAdjust(const LocalPath& name)
 {
     // return a temporary variable that the caller can optionally use c_str on (in that expression)
     string absolutename;
-    if (PosixFileAccess::appbasepath)
+    if (PosixFileSystemAccess::appbasepath)
     {
         if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
-            absolutename = PosixFileAccess::appbasepath;
+            absolutename = PosixFileSystemAccess::appbasepath;
             absolutename.append(*name.editStringDirect());
             return absolutename;
         }

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -110,12 +110,12 @@ bool PosixFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
     retry = false;
 
 #ifdef USE_IOS
-    string nonblocking_localname = this->nonblocking_localname;
+    LocalPath nonblocking_localname(this->nonblocking_localname);
     if (PosixFileSystemAccess::appbasepath)
     {
-        if (nonblocking_localname.size() && nonblocking_localname.at(0) != '/')
+        if (!nonblocking_localname.empty() && nonblocking_localname.editStringDirect()->at(0) != '/')
         {
-            nonblocking_localname.insert(0, PosixFileSystemAccess::appbasepath);
+            nonblocking_localname.editStringDirect()->insert(0, PosixFileSystemAccess::appbasepath);
         }
     }
 #endif
@@ -155,12 +155,12 @@ bool PosixFileAccess::sysstat(m_time_t* mtime, m_off_t* size)
 bool PosixFileAccess::sysopen(bool)
 {
 #ifdef USE_IOS
-    string nonblocking_localname = this->nonblocking_localname;
+    LocalPath nonblocking_localname(this->nonblocking_localname);
     if (PosixFileSystemAccess::appbasepath)
     {
-        if (nonblocking_localname.size() && nonblocking_localname.at(0) != '/')
+        if (!nonblocking_localname.empty() && nonblocking_localname.editStringDirect()->at(0) != '/')
         {
-            nonblocking_localname.insert(0, PosixFileSystemAccess::appbasepath);
+            nonblocking_localname.editStringDirect()->insert(0, PosixFileSystemAccess::appbasepath);
         }
     }
 #endif
@@ -402,11 +402,11 @@ bool PosixFileAccess::fopen(LocalPath& f, bool read, bool write, DirAccess* iter
     string absolutef;
     if (PosixFileSystemAccess::appbasepath)
     {
-        if (f->size() && f->at(0) != '/')
+        if (!f.empty() && f.editStringDirect()->at(0) != '/')
         {
             absolutef = PosixFileSystemAccess::appbasepath;
-            absolutef.append(*f);
-            f = &absolutef;
+            absolutef.append(f.editStringDirect()->c_str());
+            f.editStringDirect()->assign(absolutef);
         }
     }
 #endif
@@ -1026,18 +1026,18 @@ bool PosixFileSystemAccess::renamelocal(LocalPath& oldname, LocalPath& newname, 
     string absolutenewname;
     if (appbasepath)
     {
-        if (oldname->size() && oldname->at(0) != '/')
+        if (!oldname.empty() && oldname.editStringDirect()->at(0) != '/')
         {
             absoluteoldname = appbasepath;
-            absoluteoldname.append(*oldname);
-            oldname = &absoluteoldname;
+            absoluteoldname.append(oldname.editStringDirect()->c_str());
+            oldname.editStringDirect()->assign(absoluteoldname);
         }
 
-        if (newname->size() && newname->at(0) != '/')
+        if (!newname.empty() && newname.editStringDirect()->at(0) != '/')
         {
             absolutenewname = appbasepath;
-            absolutenewname.append(*newname);
-            newname = &absolutenewname;
+            absolutenewname.append(newname.editStringDirect()->c_str());
+            newname.editStringDirect()->assign(absolutenewname);
         }
     }
 #endif
@@ -1069,18 +1069,18 @@ bool PosixFileSystemAccess::copylocal(LocalPath& oldname, LocalPath& newname, m_
     string absolutenewname;
     if (appbasepath)
     {
-        if (oldname->size() && oldname->at(0) != '/')
+        if (!oldname.empty() && oldname.editStringDirect()->at(0) != '/')
         {
             absoluteoldname = appbasepath;
-            absoluteoldname.append(*oldname);
-            oldname = &absoluteoldname;
+            absoluteoldname.append(oldname.editStringDirect()->c_str());
+            oldname.editStringDirect()->assign(absoluteoldname);
         }
 
-        if (newname->size() && newname->at(0) != '/')
+        if (!newname.empty() && newname.editStringDirect()->at(0) != '/')
         {
             absolutenewname = appbasepath;
-            absolutenewname.append(*newname);
-            newname = &absolutenewname;
+            absolutenewname.append(newname.editStringDirect()->c_str());
+            newname.editStringDirect()->assign(absolutenewname);
         }
     }
 #endif
@@ -1149,11 +1149,11 @@ bool PosixFileSystemAccess::unlinklocal(LocalPath& name)
     string absolutename;
     if (appbasepath)
     {
-        if (name->size() && name->at(0) != '/')
+        if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
             absolutename = appbasepath;
-            absolutename.append(*name);
-            name = &absolutename;
+            absolutename.append(name.editStringDirect()->c_str());
+            name.editStringDirect()->assign(absolutename);
         }
     }
 #endif
@@ -1176,11 +1176,11 @@ void PosixFileSystemAccess::emptydirlocal(LocalPath& name, dev_t basedev)
     string absolutename;
     if (appbasepath)
     {
-        if (name->size() && name->at(0) != '/')
+        if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
             absolutename = appbasepath;
-            absolutename.append(*name);
-            name = &absolutename;
+            absolutename.append(name.editStringDirect()->c_str());
+            name.editStringDirect()->assign(absolutename);
         }
     }
 #endif
@@ -1273,11 +1273,11 @@ bool PosixFileSystemAccess::rmdirlocal(LocalPath& name)
     string absolutename;
     if (appbasepath)
     {
-        if (name->size() && name->at(0) != '/')
+        if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
             absolutename = appbasepath;
-            absolutename.append(*name);
-            name = &absolutename;
+            absolutename.append(name.editStringDirect()->c_str());
+            name.editStringDirect()->assign(absolutename);
         }
     }
 #endif
@@ -1300,11 +1300,11 @@ bool PosixFileSystemAccess::mkdirlocal(LocalPath& name, bool)
     string absolutename;
     if (appbasepath)
     {
-        if (name->size() && name->at(0) != '/')
+        if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
             absolutename = appbasepath;
-            absolutename.append(*name);
-            name = &absolutename;
+            absolutename.append(name.editStringDirect()->c_str());
+            name.editStringDirect()->assign(absolutename);
         }
     }
 #endif
@@ -1336,11 +1336,11 @@ bool PosixFileSystemAccess::setmtimelocal(LocalPath& name, m_time_t mtime)
     string absolutename;
     if (appbasepath)
     {
-        if (name->size() && name->at(0) != '/')
+        if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
             absolutename = appbasepath;
-            absolutename.append(*name);
-            name = &absolutename;
+            absolutename.append(name.editStringDirect()->c_str());
+            name.editStringDirect()->assign(absolutename);
         }
     }
 #endif
@@ -1363,11 +1363,11 @@ bool PosixFileSystemAccess::chdirlocal(LocalPath& name) const
     string absolutename;
     if (appbasepath)
     {
-        if (name->size() && name->at(0) != '/')
+        if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
             absolutename = appbasepath;
-            absolutename.append(*name);
-            name = &absolutename;
+            absolutename.append(name.editStringDirect()->c_str());
+            name.editStringDirect()->assign(absolutename);
         }
     }
 #endif
@@ -1877,11 +1877,11 @@ bool PosixDirAccess::dopen(LocalPath* path, FileAccess* f, bool doglob)
     string absolutepath;
     if (PosixFileSystemAccess::appbasepath)
     {
-        if (path->size() && path->at(0) != '/')
+        if (!path->empty() && path->editStringDirect()->at(0) != '/')
         {
             absolutepath = PosixFileSystemAccess::appbasepath;
-            absolutepath.append(*path);
-            path = &absolutepath;
+            absolutepath.append(path->editStringDirect()->c_str());
+            path->editStringDirect()->assign(absolutepath);
         }
     }
 #endif
@@ -1922,11 +1922,11 @@ bool PosixDirAccess::dnext(LocalPath& path, LocalPath& name, bool followsymlinks
     string absolutepath;
     if (PosixFileSystemAccess::appbasepath)
     {
-        if (path->size() && path->at(0) != '/')
+        if (!path.empty() && path.editStringDirect()->at(0) != '/')
         {
             absolutepath = PosixFileSystemAccess::appbasepath;
-            absolutepath.append(*path);
-            path = &absolutepath;
+            absolutepath.append(path.editStringDirect()->c_str());
+            path.editStringDirect()->assign(absolutepath);
         }
     }
 #endif

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -50,11 +50,11 @@ static string iosAdjust(const LocalPath& name)
 {
     // return a temporary variable that the caller can optionally use c_str on (in that expression)
     string absolutename;
-    if (appbasepath)
+    if (PosixFileAccess::appbasepath)
     {
         if (!name.empty() && name.editStringDirect()->at(0) != '/')
         {
-            absolutename = appbasepath;
+            absolutename = PosixFileAccess::appbasepath;
             absolutename.append(*name.editStringDirect());
             return absolutename;
         }
@@ -1135,7 +1135,6 @@ void PosixFileSystemAccess::emptydirlocal(LocalPath& name, dev_t basedev)
     dirent* d;
     int removed;
     struct stat statbuf;
-    size_t t;
     PosixFileSystemAccess pfsa;
 #ifdef USE_IOS
     const string namestr = iosAdjust(name);

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -544,7 +544,7 @@ bool PosixFileAccess::fopen(LocalPath& f, bool read, bool write, DirAccess* iter
                 //If creation time equal to kMagicBusyCreationDate
                 if(statbuf.st_birthtimespec.tv_sec == -2082844800)
                 {
-                    LOG_debug << "File is busy: " << f->c_str();
+                    LOG_debug << "File is busy: " << f.editStringDirect()->c_str();
                     retry = true;
                     return false;
                 }


### PR DESCRIPTION
Latest commit (`0d487488e70899ea14d0178ae6ed0f05854965b1`) on `develop` branch doesn’t compile on iOS:
```
SDK/src/posix/fs.cpp:113:12: No viable conversion from 'mega::LocalPath' to 'std::__1::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >')
SDK/src/posix/fs.cpp:158:12: No viable conversion from 'mega::LocalPath' to 'std::__1::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >')
SDK/src/posix/fs.cpp:405:14: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'
SDK/src/posix/fs.cpp:405:16: No member named 'size' in 'mega::LocalPath'
SDK/src/posix/fs.cpp:405:27: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'?
SDK/src/posix/fs.cpp:405:29: No member named 'at' in 'mega::LocalPath'
SDK/src/posix/fs.cpp:408:30: Indirection requires pointer operand ('mega::LocalPath' invalid)
SDK/src/posix/fs.cpp:409:15: No viable overloaded '='
SDK/src/posix/fs.cpp:429:21: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'?
SDK/src/posix/fs.cpp:429:23: No member named 'c_str' in 'mega::LocalPath'
SDK/src/posix/fs.cpp:429:51: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'?
SDK/src/posix/fs.cpp:429:53: No member named 'c_str' in 'mega::LocalPath'
SDK/src/posix/fs.cpp:430:39: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'?
SDK/src/posix/fs.cpp:430:41: No member named 'c_str' in 'mega::LocalPath'
SDK/src/posix/fs.cpp:432:30: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'?
SDK/src/posix/fs.cpp:432:32: No member named 'c_str' in 'mega::LocalPath'
SDK/src/posix/fs.cpp:436:35: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'?
SDK/src/posix/fs.cpp:436:37: No member named 'c_str' in 'mega::LocalPath'
SDK/src/posix/fs.cpp:439:30: Member reference type 'mega::LocalPath' is not a pointer; did you mean to use '.'?
Too many errors emitted, stopping now
```
Probably, the error was introduced in the PR: https://github.com/meganz/sdk/pull/2088