### PR TITLE
#16503. Fix processing of `mfag` response

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -3037,7 +3037,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_handles, sequence(text("handles"), opt(either(text("on"), text("off")))));
     p->Add(exec_httpsonly, sequence(text("httpsonly"), opt(either(text("on"), text("off")))));
 
-    p->Add(exec_mfac, sequence(text("mfac")));
+    p->Add(exec_mfac, sequence(text("mfac"), param("email")));
     p->Add(exec_mfae, sequence(text("mfae")));
     p->Add(exec_mfad, sequence(text("mfad"), param("pin")));
 
@@ -4406,7 +4406,17 @@ void exec_mfad(autocomplete::ACState& s)
 
 void exec_mfac(autocomplete::ACState& s)
 {
-    client->multifactorauthcheck(login.email.c_str());
+    string email;
+    if (s.words.size() == 2)
+    {
+        email = s.words[1].s;
+    }
+    else
+    {
+        email = login.email;
+    }
+
+    client->multifactorauthcheck(email.c_str());
 }
 
 void exec_mfae(autocomplete::ACState& s)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -7772,19 +7772,24 @@ CommandMultiFactorAuthCheck::CommandMultiFactorAuthCheck(MegaClient *client, con
 void CommandMultiFactorAuthCheck::procresult()
 {
     Error e;
-    if (!checkError(e, client->json))
+    if (checkError(e, client->json))
     {
-        if (client->json.isnumeric())
-        {
-            e = static_cast<error>(client->json.getint());
-        }
-        else
-        {
-            client->json.storeobject();
-            e = API_EINTERNAL;
-        }
+        client->app->multifactorauthcheck_result(e);
+        return;
     }
-    client->app->multifactorauthcheck_result(e);
+
+    int enabled;
+    if (client->json.isnumeric())
+    {
+        enabled = static_cast<int>(client->json.getint());
+    }
+    else
+    {
+        client->json.storeobject();
+        enabled = API_EINTERNAL;
+    }
+
+    client->app->multifactorauthcheck_result(enabled);
 }
 
 CommandMultiFactorAuthDisable::CommandMultiFactorAuthDisable(MegaClient *client, const char *pin)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -7772,15 +7772,19 @@ CommandMultiFactorAuthCheck::CommandMultiFactorAuthCheck(MegaClient *client, con
 void CommandMultiFactorAuthCheck::procresult()
 {
     Error e;
-    if (checkError(e, client->json))
+    if (!checkError(e, client->json))
     {
-        client->app->multifactorauthcheck_result(e);
+        if (client->json.isnumeric())
+        {
+            e = static_cast<error>(client->json.getint());
+        }
+        else
+        {
+            client->json.storeobject();
+            e = API_EINTERNAL;
+        }
     }
-    else    // error
-    {
-        client->json.storeobject();
-        client->app->multifactorauthcheck_result(API_EINTERNAL);
-    }
+    client->app->multifactorauthcheck_result(e);
 }
 
 CommandMultiFactorAuthDisable::CommandMultiFactorAuthDisable(MegaClient *client, const char *pin)


### PR DESCRIPTION
In case it returns `[1]`, it used to be taken as an error, but it means that 2FA is enabled, indeed.