### PR TITLE
#16413. Fix upload nonresponseiveness due to checking filesystem typeComparator

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -373,7 +373,7 @@ AppFilePut::~AppFilePut()
 
 void AppFilePut::displayname(string* dname)
 {
-    *dname = localname.toName(*transfer->client->fsaccess, client->fsaccess->getFilesystemType(dname));
+    *dname = localname.toName(*transfer->client->fsaccess, client->fsaccess->getFilesystemType(localname));
 }
 
 // transfer progress callback
@@ -662,7 +662,7 @@ AppFileGet::AppFileGet(Node* n, handle ch, byte* cfilekey, m_off_t csize, m_time
         name = *cfilename;
     }
 
-    localname = LocalPath::fromName(name, *client->fsaccess, client->fsaccess->getFilesystemType(&name));
+    localname = LocalPath::fromName(name, *client->fsaccess, client->fsaccess->getFilesystemType(LocalPath::fromPath(name, *client->fsaccess)));
     if (!targetfolder.empty())
     {
         string s = targetfolder;
@@ -682,8 +682,7 @@ AppFilePut::AppFilePut(const LocalPath& clocalname, handle ch, const char* ctarg
     targetuser = ctargetuser;
 
     // erase path component
-    auto dummyName = clocalname.toPath(*client->fsaccess);
-    auto fileSystemType = client->fsaccess->getFilesystemType(&dummyName);
+    auto fileSystemType = client->fsaccess->getFilesystemType(clocalname);
 
     LocalPath p = clocalname;
     p.erase(0, p.lastpartlocal(*client->fsaccess));
@@ -2557,7 +2556,7 @@ bool recursiveCompare(Node* mn, fs::path p)
     }
 
     std::string path = p.u8string();
-    auto fileSystemType = client->fsaccess->getFilesystemType(&path);
+    auto fileSystemType = client->fsaccess->getFilesystemType(LocalPath::fromPath(path, *client->fsaccess));
     multimap<string, Node*> ms;
     multimap<string, fs::path> ps;
     for (auto& m : mn->children)
@@ -8090,7 +8089,7 @@ void exec_metamac(autocomplete::ACState& s)
 
     auto ifAccess = client->fsaccess->newfileaccess();
     {
-        auto localPath = LocalPath::fromName(s.words[1].s, *client->fsaccess, client->fsaccess->getFilesystemType(&s.words[1].s));
+        auto localPath = LocalPath::fromName(s.words[1].s, *client->fsaccess, client->fsaccess->getFilesystemType(LocalPath::fromPath(s.words[1].s, *client->fsaccess)));
         if (!ifAccess->fopen(localPath, 1, 0))
         {
             cerr << "Failed to open: " << s.words[1].s << endl;

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -161,6 +161,8 @@ public:
     bool findNextSeparator(size_t& separatorBytePos, const FileSystemAccess& fsaccess) const;
     bool findPrevSeparator(size_t& separatorBytePos, const FileSystemAccess& fsaccess) const;
     bool endsInSeparator(const FileSystemAccess& fsaccess) const;
+
+    // get the index of the leaf name.  A trailing / is considered part of the leaf.
     size_t getLeafnameByteIndex(const FileSystemAccess& fsaccess) const;
     bool backEqual(size_t bytePos, const LocalPath& compareTo) const;
     LocalPath subpathFrom(size_t bytePos) const;

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -160,10 +160,13 @@ public:
     void trimNonDriveTrailingSeparator(const FileSystemAccess& fsaccess);
     bool findNextSeparator(size_t& separatorBytePos, const FileSystemAccess& fsaccess) const;
     bool findPrevSeparator(size_t& separatorBytePos, const FileSystemAccess& fsaccess) const;
+    bool endsInSeparator(const FileSystemAccess& fsaccess) const;
     size_t getLeafnameByteIndex(const FileSystemAccess& fsaccess) const;
     bool backEqual(size_t bytePos, const LocalPath& compareTo) const;
     LocalPath subpathFrom(size_t bytePos) const;
     std::string substrTo(size_t bytePos) const;
+
+    void ensureWinExtendedPathLenPrefix();
 
     bool isContainingPathOf(const LocalPath& path, const FileSystemAccess& fsaccess);
 
@@ -440,12 +443,9 @@ struct MEGA_API FileSystemAccess : public EventTrigger
     bool islocalfscompatible(unsigned char, bool isEscape, FileSystemType = FS_UNKNOWN) const;
     void escapefsincompatible(string*, FileSystemType fileSystemType) const;
 
-    // Obtain a valid path by removing filename or debris directory from originalPath
-    // returns true if tempPath is modified, otherwise returns false
-    bool getValidPath(const string *originalPath, std::string &tempPath) const;
-    FileSystemType getFilesystemType(const string* dstPath) const;
+    FileSystemType getFilesystemType(const LocalPath& dstPath) const;
     const char *fstypetostring(FileSystemType type) const;
-    FileSystemType getlocalfstype(const std::string *dstPath) const;
+    FileSystemType getlocalfstype(const LocalPath& dstPath) const;
     void unescapefsincompatible(string*,FileSystemType) const;
 
     // convert MEGA path (UTF-8) to local format

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -162,7 +162,7 @@ public:
     bool findPrevSeparator(size_t& separatorBytePos, const FileSystemAccess& fsaccess) const;
     bool endsInSeparator(const FileSystemAccess& fsaccess) const;
 
-    // get the index of the leaf name.  A trailing / is considered part of the leaf.
+    // get the index of the leaf name.  A trailing separator is considered part of the leaf.
     size_t getLeafnameByteIndex(const FileSystemAccess& fsaccess) const;
     bool backEqual(size_t bytePos, const LocalPath& compareTo) const;
     LocalPath subpathFrom(size_t bytePos) const;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1843,7 +1843,7 @@ struct MegaFileGet : public MegaFile
     void progress() override;
     void completed(Transfer*, LocalNode*) override;
     void terminated() override;
-	MegaFileGet(MegaClient *client, Node* n, const LocalPath& dstPath, FileSystemType fsType);
+    MegaFileGet(MegaClient *client, Node* n, const LocalPath& dstPath, FileSystemType fsType);
     MegaFileGet(MegaClient *client, MegaNode* n, const LocalPath& dstPath);
     ~MegaFileGet() {}
 

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -394,7 +394,7 @@ public:
     void cancel() override;
 
 protected:
-    void downloadFolderNode(MegaNode *node, string *path);
+    void downloadFolderNode(MegaNode *node, LocalPath& path, FileSystemType fsType);
     void checkCompletion();
 
 public:
@@ -1843,8 +1843,8 @@ struct MegaFileGet : public MegaFile
     void progress() override;
     void completed(Transfer*, LocalNode*) override;
     void terminated() override;
-	MegaFileGet(MegaClient *client, Node* n, string dstPath);
-    MegaFileGet(MegaClient *client, MegaNode* n, string dstPath);
+	MegaFileGet(MegaClient *client, Node* n, const LocalPath& dstPath, FileSystemType fsType);
+    MegaFileGet(MegaClient *client, MegaNode* n, const LocalPath& dstPath);
     ~MegaFileGet() {}
 
     bool serialize(string*) override;
@@ -2239,12 +2239,12 @@ class MegaApiImpl : public MegaApp
         void startTimer( int64_t period, MegaRequestListener *listener=NULL);
 
         //Transfers
-        void startUpload(const char* localPath, MegaNode *parent, MegaTransferListener *listener=NULL);
-        void startUpload(const char* localPath, MegaNode *parent, int64_t mtime, MegaTransferListener *listener=NULL);
-        void startUpload(const char* localPath, MegaNode* parent, const char* fileName, MegaTransferListener *listener = NULL);
-        void startUpload(bool startFirst, const char* localPath, MegaNode* parent, const char* fileName, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, MegaTransferListener *listener);
-        void startUpload(bool startFirst, const char* localPath, MegaNode* parent, const char* fileName, const char* targetUser, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, MegaTransferListener *listener);
-        void startUploadForSupport(const char *localPath, bool isSourceTemporary = false, MegaTransferListener *listener=NULL);
+        void startUpload(const char* localPath, MegaNode *parent, FileSystemType fsType, MegaTransferListener *listener=NULL);
+        void startUpload(const char* localPath, MegaNode *parent, int64_t mtime, FileSystemType fsType, MegaTransferListener *listener=NULL);
+        void startUpload(const char* localPath, MegaNode* parent, const char* fileName, FileSystemType fsType, MegaTransferListener *listener = NULL);
+        void startUpload(bool startFirst, const char* localPath, MegaNode* parent, const char* fileName, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, FileSystemType fsType, MegaTransferListener *listener);
+        void startUpload(bool startFirst, const char* localPath, MegaNode* parent, const char* fileName, const char* targetUser, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, FileSystemType fsType, MegaTransferListener *listener);
+        void startUploadForSupport(const char *localPath, bool isSourceTemporary, FileSystemType fsType, MegaTransferListener *listener=NULL);
         void startDownload(MegaNode* node, const char* localPath, MegaTransferListener *listener = NULL);
         void startDownload(bool startFirst, MegaNode *node, const char* target, int folderTransferTag, const char *appData, MegaTransferListener *listener);
         void startStreaming(MegaNode* node, m_off_t startPos, m_off_t size, MegaTransferListener *listener);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -77,9 +77,9 @@ const char *FileSystemAccess::fstypetostring(FileSystemType type) const
     return "UNKNOWN FS";
 }
 
-FileSystemType FileSystemAccess::getlocalfstype(const string *dstPath) const
+FileSystemType FileSystemAccess::getlocalfstype(const LocalPath& dstPath) const
 {
-    if (!dstPath || dstPath->empty())
+    if (dstPath.empty())
     {
         return FS_UNKNOWN;
     }
@@ -87,7 +87,7 @@ FileSystemType FileSystemAccess::getlocalfstype(const string *dstPath) const
 #if defined (__linux__) && !defined (__ANDROID__)
     // Filesystem detection for Linux
     struct statfs fileStat;
-    if (!statfs(dstPath->c_str(), &fileStat))
+    if (!statfs(dstPath.editStringDirect()->c_str(), &fileStat))
     {
         switch (fileStat.f_type)
         {
@@ -106,7 +106,7 @@ FileSystemType FileSystemAccess::getlocalfstype(const string *dstPath) const
 #elif defined (__ANDROID__)
     // Filesystem detection for Android
     struct statfs fileStat;
-    if (!statfs(dstPath->c_str(), &fileStat))
+    if (!statfs(dstPath.editStringDirect()->c_str(), &fileStat))
     {
         switch (fileStat.f_type)
         {
@@ -132,7 +132,7 @@ FileSystemType FileSystemAccess::getlocalfstype(const string *dstPath) const
 #elif defined  (__APPLE__) || defined (USE_IOS)
     // Filesystem detection for Apple and iOS
     struct statfs fileStat;
-    if (!statfs(dstPath->c_str(), &fileStat))
+    if (!statfs(dstPath.editStringDirect()->c_str(), &fileStat))
     {
         if (!strcmp(fileStat.f_fstypename, "apfs"))
         {
@@ -154,13 +154,13 @@ FileSystemType FileSystemAccess::getlocalfstype(const string *dstPath) const
 #elif defined(_WIN32) || defined(WINDOWS_PHONE)
     // Filesystem detection for Windows
 
-    string utf8path = *dstPath;
-    string localpath;
-    path2local(&utf8path, &localpath);
+    auto tmpPath = dstPath;
+    tmpPath.editStringDirect()->append("", 1); // make sure of 2 byte terminator as LPCTWSTR (later we'll make it wstring for windows)
+
     std::wstring volMountPoint;
     volMountPoint.resize(MAX_PATH);
     DWORD mountLen = static_cast<DWORD>(volMountPoint.size());
-    if (!(GetVolumePathNameW((LPCWSTR)localpath.data(), &volMountPoint[0], mountLen)))
+    if (!(GetVolumePathNameW((LPCWSTR)tmpPath.editStringDirect()->data(), &volMountPoint[0], mountLen)))
     {
         return FS_UNKNOWN;
     }
@@ -241,35 +241,14 @@ bool FileSystemAccess::islocalfscompatible(unsigned char c, bool isEscape, FileS
     }
 }
 
-bool FileSystemAccess::getValidPath(const string *originalPath, string &tempPath) const
+FileSystemType FileSystemAccess::getFilesystemType(const LocalPath& dstPath) const
 {
-    if (!originalPath || originalPath->empty())
-    {
-        return false;
-    }
+    // first get "valid" path (no last leaf name, in case it is not in the FS?)
+    LocalPath validPath = dstPath;
 
-    string separator = getPathSeparator();
-    for (size_t i = 0; i < separator.size(); i++)
-    {
-        size_t pos = originalPath->rfind(separator[i]);
-        if (pos != std::string::npos && pos != originalPath->size() - 1)
-        {
-            tempPath = originalPath->substr(0, pos + 1);
-            return true;
-        }
-    }
-    return false;
-}
+    size_t leafIndex = validPath.getLeafnameByteIndex(*this);
+    if (leafIndex > 0) validPath.truncate(leafIndex);
 
-FileSystemType FileSystemAccess::getFilesystemType(const string* dstPath) const
-{
-    string tempPath;
-    const string *validPath = &tempPath;
-    if (!getValidPath(dstPath, tempPath) && dstPath)
-    {
-        // if getValidPath returns false and dstPath is not null, dstPath is valid
-        validPath = dstPath;
-    }
     return getlocalfstype(validPath);
 }
 
@@ -932,10 +911,7 @@ void LocalPath::prependWithSeparator(const LocalPath& additionalPath, const stri
 
 void LocalPath::trimNonDriveTrailingSeparator(const FileSystemAccess& fsaccess)
 {
-    if (localpath.size() >= fsaccess.localseparator.size()
-        && !memcmp(localpath.data() + (int(localpath.size()) & -int(fsaccess.localseparator.size())) - fsaccess.localseparator.size(),
-            fsaccess.localseparator.data(),
-            fsaccess.localseparator.size()))
+    if (endsInSeparator(fsaccess))
     {
         // ok so the last character is a directory separator.  But don't remove it for eg. F:\ on windows
         #ifdef WIN32
@@ -971,6 +947,14 @@ bool LocalPath::findPrevSeparator(size_t& separatorBytePos, const FileSystemAcce
     } 
 }
 
+bool LocalPath::endsInSeparator(const FileSystemAccess& fsaccess) const
+{
+    return localpath.size() >= fsaccess.localseparator.size()
+        && !memcmp(localpath.data() + (int(localpath.size()) & -int(fsaccess.localseparator.size())) - fsaccess.localseparator.size(),
+            fsaccess.localseparator.data(),
+            fsaccess.localseparator.size());
+}
+
 size_t LocalPath::getLeafnameByteIndex(const FileSystemAccess& fsaccess) const
 {
     // todo: take utf8 two byte characters into account
@@ -996,6 +980,17 @@ bool LocalPath::backEqual(size_t bytePos, const LocalPath& compareTo) const
 LocalPath LocalPath::subpathFrom(size_t bytePos) const
 {
     return LocalPath::fromLocalname(localpath.substr(bytePos));
+}
+
+
+void LocalPath::ensureWinExtendedPathLenPrefix()
+{
+#if defined(_WIN32) && !defined(WINDOWS_PHONE)
+    localpath.append("", 1);
+    if (!PathIsRelativeW((LPWSTR)localpath.c_str()) && ((localpath.size() < 4) || memcmp(localpath.data(), L"\\\\", 4)))
+        localpath.insert(0, (const char*)(const wchar_t*)L"\\\\?\\", 8);
+    localpath.resize(localpath.size() - 1);
+#endif
 }
 
 string LocalPath::substrTo(size_t bytePos) const

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -246,8 +246,11 @@ FileSystemType FileSystemAccess::getFilesystemType(const LocalPath& dstPath) con
     // first get "valid" path (no last leaf name, in case it is not in the FS?)
     LocalPath validPath = dstPath;
 
-    size_t leafIndex = validPath.getLeafnameByteIndex(*this);
-    if (leafIndex > 0) validPath.truncate(leafIndex);
+    if (!validPath.endsInSeparator(*this))
+    {
+        size_t leafIndex = validPath.getLeafnameByteIndex(*this);
+        if (leafIndex > 0) validPath.truncate(leafIndex);
+    }
 
     return getlocalfstype(validPath);
 }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -249,7 +249,8 @@ FileSystemType FileSystemAccess::getFilesystemType(const LocalPath& dstPath) con
     if (!validPath.endsInSeparator(*this))
     {
         size_t leafIndex = validPath.getLeafnameByteIndex(*this);
-        if (leafIndex > 0) validPath.truncate(leafIndex);
+        if (leafIndex > 0)
+            validPath.truncate(leafIndex);
     }
 
     return getlocalfstype(validPath);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -2965,12 +2965,12 @@ MegaTransferList *MegaApi::getChildTransfers(int transferTag)
 
 void MegaApi::startUpload(const char* localPath, MegaNode* parent, MegaTransferListener *listener)
 {
-    pImpl->startUpload(localPath, parent, listener);
+    pImpl->startUpload(localPath, parent, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUploadForSupport(const char* localPath, bool isSourceTemporary, MegaTransferListener *listener)
 {
-    pImpl->startUploadForSupport(localPath, isSourceTemporary, listener);
+    pImpl->startUploadForSupport(localPath, isSourceTemporary, FS_UNKNOWN, listener);
 }
 
 MegaStringList *MegaApi::getBackupFolders(int backuptag) const
@@ -3000,47 +3000,47 @@ void MegaApi::startTimer( int64_t period, MegaRequestListener *listener)
 
 void MegaApi::startUploadWithData(const char *localPath, MegaNode *parent, const char *appData, MegaTransferListener *listener)
 {
-    pImpl->startUpload(false, localPath, parent, (const char *)NULL, -1, 0, false, appData, false, false, listener);
+    pImpl->startUpload(false, localPath, parent, (const char *)NULL, -1, 0, false, appData, false, false, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUploadWithData(const char *localPath, MegaNode *parent, const char *appData, bool isSourceTemporary, MegaTransferListener *listener)
 {
-    pImpl->startUpload(false, localPath, parent, (const char *)NULL, -1, 0, false, appData, isSourceTemporary, false, listener);
+    pImpl->startUpload(false, localPath, parent, (const char *)NULL, -1, 0, false, appData, isSourceTemporary, false, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUploadWithTopPriority(const char *localPath, MegaNode *parent, const char *appData, bool isSourceTemporary, MegaTransferListener *listener)
 {
-    pImpl->startUpload(true, localPath, parent, (const char *)NULL, -1, 0, false, appData, isSourceTemporary, false, listener);
+    pImpl->startUpload(true, localPath, parent, (const char *)NULL, -1, 0, false, appData, isSourceTemporary, false, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUpload(const char *localPath, MegaNode *parent, int64_t mtime, MegaTransferListener *listener)
 {
-    pImpl->startUpload(localPath, parent, mtime, listener);
+    pImpl->startUpload(localPath, parent, mtime, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUpload(const char *localPath, MegaNode *parent, int64_t mtime, bool isSourceTemporary, MegaTransferListener *listener)
 {
-    pImpl->startUpload(false, localPath, parent, (const char *)NULL, mtime, 0, false, NULL, isSourceTemporary, false, listener);
+    pImpl->startUpload(false, localPath, parent, (const char *)NULL, mtime, 0, false, NULL, isSourceTemporary, false, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUpload(const char* localPath, MegaNode* parent, const char* fileName, MegaTransferListener *listener)
 {
-    pImpl->startUpload(localPath, parent, fileName, listener);
+    pImpl->startUpload(localPath, parent, fileName, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUpload(const char *localPath, MegaNode *parent, const char *fileName, int64_t mtime, MegaTransferListener *listener)
 {
-    pImpl->startUpload(false, localPath, parent, fileName, mtime, 0, false, NULL, false, false, listener);
+    pImpl->startUpload(false, localPath, parent, fileName, mtime, 0, false, NULL, false, false, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUpload(const char *localPath, MegaNode *parent, const char *appData, const char *fileName, int64_t mtime, MegaTransferListener *listener)
 {
-    pImpl->startUpload(false, localPath, parent, fileName, mtime, 0, false, appData, false, false, listener);
+    pImpl->startUpload(false, localPath, parent, fileName, mtime, 0, false, appData, false, false, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startUploadForChat(const char *localPath, MegaNode *parent, const char *appData, bool isSourceTemporary, MegaTransferListener *listener)
 {
-    pImpl->startUpload(false, localPath, parent, nullptr, -1, 0, false, appData, isSourceTemporary, true, listener);
+    pImpl->startUpload(false, localPath, parent, nullptr, -1, 0, false, appData, isSourceTemporary, true, FS_UNKNOWN, listener);
 }
 
 void MegaApi::startDownload(MegaNode *node, const char* localFolder, MegaTransferListener *listener)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4751,7 +4751,8 @@ MegaFileGet::MegaFileGet(MegaClient *client, Node *n, const LocalPath& dstPath, 
         }
         else finalPath = dstPath;
     }
-    else finalPath = lpName;
+    else
+        finalPath = lpName;
 
     size = n->size;
     mtime = n->mtime;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4733,23 +4733,25 @@ MegaFile *MegaFile::unserialize(string *d)
     return megaFile;
 }
 
-MegaFileGet::MegaFileGet(MegaClient *client, Node *n, string dstPath) : MegaFile()
+MegaFileGet::MegaFileGet(MegaClient *client, Node *n, const LocalPath& dstPath, FileSystemType fsType) : MegaFile()
 {
     h = n->nodehandle;
     *(FileFingerprint*)this = *n;
 
-    string securename = n->displayname();
-    client->fsaccess->name2local(&securename, client->fsaccess->getFilesystemType(&dstPath));
-    client->fsaccess->local2path(&securename, &name);
+    LocalPath lpName = LocalPath::fromName(n->displayname(), *client->fsaccess, fsType);
+    name = lpName.toPath(*client->fsaccess);
 
-    string finalPath;
-    if(dstPath.size())
+    LocalPath finalPath;
+    if(!dstPath.empty())
     {
-        char c = dstPath[dstPath.size()-1];
-        if((c == '\\') || (c == '/')) finalPath = dstPath+name;
+        if (dstPath.endsInSeparator(*client->fsaccess))
+        {
+            finalPath = dstPath;
+            finalPath.appendWithSeparator(lpName, true, client->fsaccess->localseparator);
+        }
         else finalPath = dstPath;
     }
-    else finalPath = name;
+    else finalPath = lpName;
 
     size = n->size;
     mtime = n->mtime;
@@ -4757,23 +4759,31 @@ MegaFileGet::MegaFileGet(MegaClient *client, Node *n, string dstPath) : MegaFile
     if(n->nodekey().size()>=sizeof(filekey))
         memcpy(filekey,n->nodekey().data(),sizeof filekey);
 
-    localname = LocalPath::fromPath(finalPath, *client->fsaccess);
+    localname = finalPath;
     hprivate = true;
     hforeign = false;
 }
 
-MegaFileGet::MegaFileGet(MegaClient *client, MegaNode *n, string dstPath) : MegaFile()
+MegaFileGet::MegaFileGet(MegaClient *client, MegaNode *n, const LocalPath& dstPath) : MegaFile()
 {
     h = n->getHandle();
-    name = n->getName();
-    string finalPath;
-    if(dstPath.size())
+
+    FileSystemType fsType = client->fsaccess->getFilesystemType(dstPath);
+
+    LocalPath lpName = LocalPath::fromName(n->getName(), *client->fsaccess, fsType);
+    name = lpName.toPath(*client->fsaccess);
+
+    LocalPath finalPath;
+    if(!dstPath.empty())
     {
-        char c = dstPath[dstPath.size()-1];
-        if((c == '\\') || (c == '/')) finalPath = dstPath+name;
+        if (dstPath.endsInSeparator(*client->fsaccess))
+        {
+            finalPath = dstPath;
+            finalPath.appendWithSeparator(lpName, true, client->fsaccess->localseparator);
+        }
         else finalPath = dstPath;
     }
-    else finalPath = name;
+    else finalPath = lpName;
 
     const char *fingerprint = n->getFingerprint();
     if (fingerprint)
@@ -4792,7 +4802,7 @@ MegaFileGet::MegaFileGet(MegaClient *client, MegaNode *n, string dstPath) : Mega
     if(n->getNodeKey()->size()>=sizeof(filekey))
         memcpy(filekey,n->getNodeKey()->data(),sizeof filekey);
 
-    localname = LocalPath::fromPath(finalPath, *client->fsaccess);
+    localname = finalPath;
     hprivate = !n->isPublic();
     hforeign = n->isForeign();
 
@@ -6316,12 +6326,9 @@ bool MegaApiImpl::createLocalFolder(const char *path)
 
     string sPath(path);
     
-#if defined(_WIN32) && !defined(WINDOWS_PHONE)
-    if(!PathIsRelativeA(sPath.c_str()) && ((sPath.size()<2) || sPath.compare(0, 2, "\\\\")))
-        sPath.insert(0, "\\\\?\\");
-#endif
-    
     auto localpath = LocalPath::fromPath(sPath, *client->fsaccess);
+
+    localpath.ensureWinExtendedPathLenPrefix();
 
     sdkMutex.lock();
     bool success = client->fsaccess->mkdirlocal(localpath);
@@ -8085,8 +8092,13 @@ void MegaApiImpl::startTimer( int64_t period, MegaRequestListener *listener)
     waiter->notify();
 }
 
-void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *parent, const char *fileName, const char *targetUser, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, MegaTransferListener *listener)
+void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *parent, const char *fileName, const char *targetUser, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, FileSystemType fsType, MegaTransferListener *listener)
 {
+    if (fsType == FS_UNKNOWN && localPath)
+    {
+        fsType = fsAccess->getFilesystemType(LocalPath::fromPath(localPath, *fsAccess));
+    }
+
     MegaTransferPrivate* transfer = new MegaTransferPrivate(MegaTransfer::TYPE_UPLOAD, listener);
     if(localPath)
     {
@@ -8125,7 +8137,7 @@ void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *
                ? localPath
                : "";
 
-       client->fsaccess->unescapefsincompatible(&auxName, client->fsaccess->getFilesystemType(&path));
+       client->fsaccess->unescapefsincompatible(&auxName, fsType);
        transfer->setFileName(auxName.c_str());
     }
 
@@ -8142,21 +8154,21 @@ void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *
     waiter->notify();
 }
 
-void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *parent, const char *fileName, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, MegaTransferListener *listener)
-{ return startUpload(startFirst, localPath, parent, fileName, nullptr, mtime, folderTransferTag, isBackup, appData, isSourceFileTemporary, forceNewUpload, listener); }
+void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *parent, const char *fileName, int64_t mtime, int folderTransferTag, bool isBackup, const char *appData, bool isSourceFileTemporary, bool forceNewUpload, FileSystemType fsType, MegaTransferListener *listener)
+{ return startUpload(startFirst, localPath, parent, fileName, nullptr, mtime, folderTransferTag, isBackup, appData, isSourceFileTemporary, forceNewUpload, fsType, listener); }
 
-void MegaApiImpl::startUpload(const char* localPath, MegaNode* parent, MegaTransferListener *listener)
-{ return startUpload(false, localPath, parent, (const char *)NULL, -1, 0, false, NULL, false, false, listener); }
+void MegaApiImpl::startUpload(const char* localPath, MegaNode* parent, FileSystemType fsType, MegaTransferListener *listener)
+{ return startUpload(false, localPath, parent, (const char *)NULL, -1, 0, false, NULL, false, false, fsType, listener); }
 
-void MegaApiImpl::startUpload(const char *localPath, MegaNode *parent, int64_t mtime, MegaTransferListener *listener)
-{ return startUpload(false, localPath, parent, (const char *)NULL, mtime, 0, false, NULL, false, false, listener); }
+void MegaApiImpl::startUpload(const char *localPath, MegaNode *parent, int64_t mtime,FileSystemType fsType, MegaTransferListener *listener)
+{ return startUpload(false, localPath, parent, (const char *)NULL, mtime, 0, false, NULL, false, false, fsType, listener); }
 
-void MegaApiImpl::startUpload(const char* localPath, MegaNode* parent, const char* fileName, MegaTransferListener *listener)
-{ return startUpload(false, localPath, parent, fileName, -1, 0, false, NULL, false, false, listener); }
+void MegaApiImpl::startUpload(const char* localPath, MegaNode* parent, const char* fileName, FileSystemType fsType, MegaTransferListener *listener)
+{ return startUpload(false, localPath, parent, fileName, -1, 0, false, NULL, false, false, fsType, listener); }
 
-void MegaApiImpl::startUploadForSupport(const char *localPath, bool isSourceTemporary, MegaTransferListener *listener)
+void MegaApiImpl::startUploadForSupport(const char *localPath, bool isSourceTemporary, FileSystemType fsType, MegaTransferListener *listener)
 {
-    return startUpload(true, localPath, nullptr, nullptr, "pGTOqu7_Fek", -1, 0, false, nullptr, isSourceTemporary, false, listener);
+    return startUpload(true, localPath, nullptr, nullptr, "pGTOqu7_Fek", -1, 0, false, nullptr, isSourceTemporary, false, fsType, listener);
 }
 
 void MegaApiImpl::startDownload(bool startFirst, MegaNode *node, const char* localPath, int folderTransferTag, const char *appData, MegaTransferListener *listener)
@@ -8286,7 +8298,7 @@ void MegaApiImpl::retryTransfer(MegaTransfer *transfer, MegaTransferListener *li
     {
         MegaNode *parent = getNodeByHandle(t->getParentHandle());
         startUpload(t->shouldStartFirst(), t->getPath(), parent, t->getFileName(), t->getTime(), 0,
-                          t->isBackupTransfer(), t->getAppData(), t->isSourceFileTemporary(), t->isStreamingTransfer(), listener);
+                          t->isBackupTransfer(), t->getAppData(), t->isSourceFileTemporary(), t->isStreamingTransfer(), client->fsaccess->getFilesystemType(LocalPath::fromLocalname(t->getPath())), listener);
         delete parent;
     }
 }
@@ -8843,7 +8855,7 @@ char *MegaApiImpl::escapeFsIncompatible(const char *filename, const char *dstPat
     }
     string name = filename;
     string path = dstPath ? dstPath : "";
-    client->fsaccess->escapefsincompatible(&name, client->fsaccess->getFilesystemType(&path));
+    client->fsaccess->escapefsincompatible(&name, client->fsaccess->getFilesystemType(LocalPath::fromPath(path, *client->fsaccess)));
     return MegaApi::strdup(name.c_str());
 }
 
@@ -8855,7 +8867,7 @@ char *MegaApiImpl::unescapeFsIncompatible(const char *name, const char *path)
     }
     string filename = name;
     string localpath = path ? path : "";
-    client->fsaccess->unescapefsincompatible(&filename, client->fsaccess->getFilesystemType(&localpath));
+    client->fsaccess->unescapefsincompatible(&filename, client->fsaccess->getFilesystemType(LocalPath::fromPath(localpath, *client->fsaccess)));
     return MegaApi::strdup(filename.c_str());
 }
 
@@ -18049,21 +18061,20 @@ unsigned MegaApiImpl::sendPendingTransfers()
                 // File download
                 if (!transfer->isStreamingTransfer())
                 {
-                    string name;
-                    string securename;
-                    string path;
+                    LocalPath name;
+                    LocalPath wLocalPath;
 
                     if (parentPath)
                     {
-                        path = parentPath;
+                        wLocalPath = LocalPath::fromPath(parentPath, *fsAccess);
                     }
                     else
                     {
-                        string separator;
-                        client->fsaccess->local2path(&client->fsaccess->localseparator, &separator);
-                        path = ".";
-                        path.append(separator);
+                        wLocalPath = LocalPath::fromPath(".", *fsAccess);
+                        wLocalPath.appendWithSeparator(LocalPath::fromPath("", *fsAccess), true, fsAccess->localseparator);
                     }
+
+                    FileSystemType fsType = fsAccess->getFilesystemType(wLocalPath);
 
                     MegaFileGet *f;
                     if (node)
@@ -18073,44 +18084,37 @@ unsigned MegaApiImpl::sendPendingTransfers()
                             attr_map::iterator ait = node->attrs.map.find('n');
                             if (ait == node->attrs.map.end())
                             {
-                                name = "CRYPTO_ERROR";
+                                name = LocalPath::fromPath("CRYPTO_ERROR", *fsAccess);
                             }
                             else if(!ait->second.size())
                             {
-                                name = "BLANK";
+                                name = LocalPath::fromPath("BLANK", *fsAccess);
                             }
                             else
                             {
-                                name = ait->second;
+                                name =  LocalPath::fromName(ait->second, *fsAccess, fsType);
                             }
                         }
                         else
                         {
-                            name = fileName;
+                            name = LocalPath::fromName(fileName, *fsAccess, fsType);
                         }
-                        client->fsaccess->name2local(&name, client->fsaccess->getFilesystemType(&path));
-                        client->fsaccess->local2path(&name, &securename);
-                        path += securename;
                     }
                     else
                     {
                         if (!transfer->getFileName())
                         {
-                            name = publicNode->getName();
+                            name = LocalPath::fromName(publicNode->getName(), *fsAccess, fsType);
                         }
                         else
                         {
-                            name = transfer->getFileName();
+                            name = LocalPath::fromName(transfer->getFileName(), *fsAccess, fsType);
                         }
-
-                        client->fsaccess->name2local(&name, client->fsaccess->getFilesystemType(&path));
-                        client->fsaccess->local2path(&name, &securename);
-                        path += securename;
                     }
+                    wLocalPath.appendWithSeparator(name, true, fsAccess->localseparator);
 
                     FileFingerprint *prevFp = NULL;
                     m_off_t size = 0;
-                    auto wLocalPath = LocalPath::fromPath(path, *fsAccess);
                     auto fa = fsAccess->newfileaccess();
                     if (fa->fopen(wLocalPath, true, false))
                     {
@@ -18148,7 +18152,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                             transfer->setTag(nextTag);
                             transfer->setTotalBytes(fa->size);
                             transfer->setTransferredBytes(0);
-                            transfer->setPath(path.c_str());
+                            transfer->setPath(wLocalPath.toPath(*fsAccess).c_str());
                             transfer->setStartTime(Waiter::ds);
                             transfer->setUpdateTime(Waiter::ds);
                             fireOnTransferStart(transfer);
@@ -18174,15 +18178,15 @@ unsigned MegaApiImpl::sendPendingTransfers()
                     currentTransfer = transfer;
                     if (node)
                     {
-                        f = new MegaFileGet(client, node, path);
+                        f = new MegaFileGet(client, node, wLocalPath, fsType);
                     }
                     else
                     {
                         delete prevFp;
-                        f = new MegaFileGet(client, publicNode, path);
+                        f = new MegaFileGet(client, publicNode, wLocalPath);
                     }
 
-                    transfer->setPath(path.c_str());
+                    transfer->setPath(wLocalPath.toPath(*fsAccess).c_str());
                     f->setTransfer(transfer);
                     bool ok = client->startxfer(GET, f, committer, true, startFirst);
                     if (!ok)
@@ -23984,6 +23988,8 @@ void MegaFolderUploadController::onFolderAvailable(MegaHandle handle)
     da = client->fsaccess->newdiraccess();
     if (da->dopen(&localPath, NULL, false))
     {
+        FileSystemType fsType = client->fsaccess->getFilesystemType(localPath);
+
         nodetype_t dirEntryType;
         while (da->dnext(localPath, localname, client->followsymlinks, &dirEntryType))
         {
@@ -23994,7 +24000,7 @@ void MegaFolderUploadController::onFolderAvailable(MegaHandle handle)
             if (dirEntryType == FILENODE)
             {
                 pendingTransfers++;
-                megaApi->startUpload(false, localPath.toPath(*client->fsaccess).c_str(), parent, (const char *)NULL, -1, tag, false, NULL, false, false, this);
+                megaApi->startUpload(false, localPath.toPath(*client->fsaccess).c_str(), parent, (const char *)NULL, -1, tag, false, NULL, false, false, fsType, this);
             }
             else if (dirEntryType == FOLDERNODE)
             {
@@ -24774,6 +24780,8 @@ void MegaBackupController::onFolderAvailable(MegaHandle handle)
         da = client->fsaccess->newdiraccess();
         if (da->dopen(&localPath, NULL, false))
         {
+            FileSystemType fsType = client->fsaccess->getFilesystemType(localPath);
+
             while (da->dnext(localPath, localname, client->followsymlinks))
             {
                 ScopedLengthRestore restoreLen(localPath);
@@ -24790,7 +24798,7 @@ void MegaBackupController::onFolderAvailable(MegaHandle handle)
                         pendingTransfers++;
 
                         totalFiles++;
-                        megaApi->startUpload(false, localPath.toPath(*client->fsaccess).c_str(), parent, (const char *)NULL, -1, folderTransferTag, true, NULL, false, false, this);
+                        megaApi->startUpload(false, localPath.toPath(*client->fsaccess).c_str(), parent, (const char *)NULL, -1, folderTransferTag, true, NULL, false, false, fsType, this);
                     }
                     else
                     {
@@ -25242,42 +25250,36 @@ void MegaFolderDownloadController::start(MegaNode *node)
         deleteNode = true;
     }
 
-    string name;
-    string securename;
-    string path;
+    LocalPath name;
+    LocalPath path;
 
     if (parentPath)
     {
-        path = parentPath;
+        path = LocalPath::fromPath(parentPath, *client->fsaccess);
     }
     else
     {
-        string separator;
-        client->fsaccess->local2path(&client->fsaccess->localseparator, &separator);
-        path = ".";
-        path.append(separator);
+        path = LocalPath::fromPath(".", *client->fsaccess);
+        path.appendWithSeparator(LocalPath::fromPath("", *client->fsaccess), true, client->fsaccess->localseparator);
     }
+
+    FileSystemType fsType = client->fsaccess->getFilesystemType(path);
 
     if (!fileName)
     {
-        name = node->getName();
+        name = LocalPath::fromName(node->getName(), *client->fsaccess, fsType);
     }
     else
     {
-        name = fileName;
+        name = LocalPath::fromName(fileName, *client->fsaccess, fsType);
     }
+    
+    path.appendWithSeparator(name, true, client->fsaccess->localseparator);
 
-    client->fsaccess->name2local(&name, client->fsaccess->getFilesystemType(&path));
-    client->fsaccess->local2path(&name, &securename);
-    path += securename;
+    path.ensureWinExtendedPathLenPrefix();
 
-#if defined(_WIN32) && !defined(WINDOWS_PHONE)
-    if (!PathIsRelativeA(path.c_str()) && ((path.size()<2) || path.compare(0, 2, "\\\\")))
-        path.insert(0, "\\\\?\\");
-#endif
-
-    transfer->setPath(path.c_str());
-    downloadFolderNode(node, &path);
+    transfer->setPath(path.toPath(*client->fsaccess).c_str());
+    downloadFolderNode(node, path, fsType);
 
     if (deleteNode)
     {
@@ -25371,18 +25373,17 @@ void MegaFolderDownloadController::cancel()
 }
 
 
-void MegaFolderDownloadController::downloadFolderNode(MegaNode *node, string *path)
+void MegaFolderDownloadController::downloadFolderNode(MegaNode *node, LocalPath& localpath, FileSystemType fsType)
 {
     recursive++;
 
-    auto localpath = LocalPath::fromPath(*path, *client->fsaccess);
     auto da = client->fsaccess->newfileaccess();
     if (!da->fopen(localpath, true, false))
     {
         if (!client->fsaccess->mkdirlocal(localpath))
         {
             da.reset();
-            LOG_err << "Unable to create folder: " << *path;
+            LOG_err << "Unable to create folder: " << localpath.toPath(*client->fsaccess);
 
             recursive--;
             mLastError = API_EWRITE;
@@ -25393,12 +25394,12 @@ void MegaFolderDownloadController::downloadFolderNode(MegaNode *node, string *pa
     }
     else if (da->type != FILENODE)
     {
-        LOG_debug << "Already existing folder detected: " << *path;
+        LOG_debug << "Already existing folder detected: " << localpath.toPath(*client->fsaccess);
     }
     else
     {
         da.reset();
-        LOG_err << "Local file detected where there should be a folder: " << *path;
+        LOG_err << "Local file detected where there should be a folder: " << localpath.toPath(*client->fsaccess);
 
         recursive--;
         mLastError = API_EEXIST;
@@ -25422,7 +25423,7 @@ void MegaFolderDownloadController::downloadFolderNode(MegaNode *node, string *pa
 
     if (!children)
     {
-        LOG_err << "Child nodes not found: " << *path;
+        LOG_err << "Child nodes not found: " << localpath.toPath(*client->fsaccess);
         recursive--;
         mLastError = API_ENOENT;
         mIncompleteTransfers++;
@@ -25435,7 +25436,7 @@ void MegaFolderDownloadController::downloadFolderNode(MegaNode *node, string *pa
         MegaNode *child = children->get(i);
         
         ScopedLengthRestore restoreLen(localpath);
-        localpath.appendWithSeparator(LocalPath::fromName(child->getName(), *client->fsaccess, client->fsaccess->getFilesystemType(path)), true, client->fsaccess->localseparator);
+        localpath.appendWithSeparator(LocalPath::fromName(child->getName(), *client->fsaccess, fsType), true, client->fsaccess->localseparator);
 
         string utf8path = localpath.toPath(*client->fsaccess);
 
@@ -25446,7 +25447,7 @@ void MegaFolderDownloadController::downloadFolderNode(MegaNode *node, string *pa
         }
         else
         {
-            downloadFolderNode(child, &utf8path);
+            downloadFolderNode(child, localpath, fsType);
         }
     }
 
@@ -28075,7 +28076,9 @@ int MegaHTTPServer::onMessageComplete(http_parser *parser)
                 }
             }
 
-            httpctx->megaApi->startUpload(httpctx->tmpFileName.c_str(), newParentNode, newname.c_str(), httpctx);
+            FileSystemType fsType = httpctx->server->fsAccess->getFilesystemType(LocalPath::fromPath(httpctx->tmpFileName, *httpctx->server->fsAccess));
+
+            httpctx->megaApi->startUpload(httpctx->tmpFileName.c_str(), newParentNode, newname.c_str(), fsType, httpctx);
 
             delete node;
             delete baseNode;
@@ -30810,7 +30813,10 @@ void MegaFTPDataServer::processReceivedData(MegaTCPContext *tcpctx, ssize_t nrea
             {
                 LOG_debug << "Starting upload of file " << fds->newNameToUpload;
                 fds->controlftpctx->tmpFileName = ftpdatactx->tmpFileName;
-                ftpdatactx->megaApi->startUpload(ftpdatactx->tmpFileName.c_str(), newParentNode, fds->newNameToUpload.c_str(), fds->controlftpctx);
+
+                FileSystemType fsType = fds->fsAccess->getFilesystemType(LocalPath::fromPath(ftpdatactx->tmpFileName, *fds->fsAccess));
+
+                ftpdatactx->megaApi->startUpload(ftpdatactx->tmpFileName.c_str(), newParentNode, fds->newNameToUpload.c_str(), fsType, fds->controlftpctx);
                 ftpdatactx->controlRespondedElsewhere = true;
             }
             else

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -692,7 +692,7 @@ Sync::Sync(MegaClient* cclient, SyncConfig config, const char* cdebris,
     fsstableids = dirnotify->fsstableids();
     LOG_info << "Filesystem IDs are stable: " << fsstableids;
 
-    mFilesystemType = client->fsaccess->getFilesystemType(&mLocalPath);
+    mFilesystemType = client->fsaccess->getFilesystemType(crootpath);
 
     localroot->init(this, FOLDERNODE, NULL, crootpath, nullptr);  // the root node must have the absolute path.  We don't store shortname, to avoid accidentally using relative paths.
     localroot->setnode(remotenode);

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -4391,9 +4391,11 @@ TEST_F(SdkTest, invalidFileNames)
 {
     LOG_info << "___TEST invalidFileNames___";
 
+    FSACCESS_CLASS fsa;
+    auto aux = LocalPath::fromPath(fs::current_path().u8string(), fsa);
+
 #if defined (__linux__) || defined (__ANDROID__)
-    std::string aux = fs::current_path().string();
-    if (fileSystemAccess.getlocalfstype(&aux) == FS_EXT)
+    if (fileSystemAccess.getlocalfstype(aux) == FS_EXT)
     {
         // Escape set of characters and check if it's the expected one
         const char *name = megaApi[0]->escapeFsIncompatible("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~", fs::current_path().c_str());
@@ -4413,9 +4415,8 @@ TEST_F(SdkTest, invalidFileNames)
         delete [] name;
     }
 #elif defined  (__APPLE__) || defined (USE_IOS)
-    std::string aux = fs::current_path().string();
-    if (fileSystemAccess.getlocalfstype(&aux) == FS_APFS
-            || fileSystemAccess.getlocalfstype(&aux) == FS_HFS)
+    if (fileSystemAccess.getlocalfstype(aux) == FS_APFS
+            || fileSystemAccess.getlocalfstype(aux) == FS_HFS)
     {
         // Escape set of characters and check if it's the expected one
         const char *name = megaApi[0]->escapeFsIncompatible("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~", fs::current_path().c_str());
@@ -4435,8 +4436,6 @@ TEST_F(SdkTest, invalidFileNames)
         delete [] name;
     }
 #elif defined(_WIN32) || defined(_WIN64) || defined(WINDOWS_PHONE)
-    FSACCESS_CLASS fsa;
-    auto aux = LocalPath::fromPath(fs::current_path().u8string(), fsa);
     if (fileSystemAccess.getlocalfstype(aux) == FS_NTFS)
     {
         // Escape set of characters and check if it's the expected one

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -4435,8 +4435,9 @@ TEST_F(SdkTest, invalidFileNames)
         delete [] name;
     }
 #elif defined(_WIN32) || defined(_WIN64) || defined(WINDOWS_PHONE)
-    std::string aux = fs::current_path().string();
-    if (fileSystemAccess.getlocalfstype(&aux) == FS_NTFS)
+    FSACCESS_CLASS fsa;
+    auto aux = LocalPath::fromPath(fs::current_path().u8string(), fsa);
+    if (fileSystemAccess.getlocalfstype(aux) == FS_NTFS)
     {
         // Escape set of characters and check if it's the expected one
         const char *name = megaApi[0]->escapeFsIncompatible("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~", fs::current_path().u8string().c_str());
@@ -4564,11 +4565,11 @@ TEST_F(SdkTest, invalidFileNames)
 
 #ifdef WIN32
     // double check a few well known paths
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(::mega::make_unique<string>("c:").get()), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(::mega::make_unique<string>("c:\\").get()), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(::mega::make_unique<string>("C:\\").get()), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(::mega::make_unique<string>("C:\\Program Files").get()), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(::mega::make_unique<string>("c:\\Program Files\\Windows NT").get()), FS_NTFS);
+    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("c:", fsa)), FS_NTFS);
+    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("c:\\", fsa)), FS_NTFS);
+    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("C:\\", fsa)), FS_NTFS);
+    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("C:\\Program Files", fsa)), FS_NTFS);
+    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("c:\\Program Files\\Windows NT", fsa)), FS_NTFS);
 #endif
 
 }


### PR DESCRIPTION
For a large folder upload, minimize checking of which filesystem we are working in.  Just once per folder.
Took advantage of the new LocalPath to simplify whether the path we are checking is utf8 or utf16 (for windows)
getlocalfstype and getFilesystemType work on LocalPath now, which means fewer switches between utf8/utf16
that means we can use LocalPath functions and don't need getValidPath anymore
Upload functions in megaApi_impl take a FS parameter, for cases where we already know.  If it is unknown then the FS is looked up.