### PR TITLE
Revert "small fix for transfer tag, make it always 'long long', never 'int'"

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -3357,7 +3357,7 @@ class MegaRequest
          *
          * @return Tag of a transfer related to the request
          */
-        virtual long long getTransferTag() const;
+        virtual int getTransferTag() const;
 
         /**
          * @brief Returns the number of details related to this request

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1106,7 +1106,7 @@ class MegaRequestPrivate : public MegaRequest
         void setText(const char* text);
         void setNumber(long long number);
         void setFlag(bool flag);
-        void setTransferTag(long long transfer);
+        void setTransferTag(int transfer);
         void setListener(MegaRequestListener *listener);
         void setTotalBytes(long long totalBytes);
         void setTransferredBytes(long long transferredBytes);
@@ -1144,7 +1144,7 @@ class MegaRequestPrivate : public MegaRequest
         long long getTotalBytes() const override;
         MegaRequestListener *getListener() const override;
         MegaAccountDetails *getMegaAccountDetails() const override;
-        long long getTransferTag() const override;
+        int getTransferTag() const override;
         int getNumDetails() const override;
         int getTag() const override;
         MegaPricing *getPricing() const override;
@@ -1212,7 +1212,7 @@ protected:
 #endif
         MegaBackupListener *backupListener;
 
-        long long transferTag = 0;
+        int transfer;
         int numDetails;
         MegaNode* publicNode;
         int numRetry;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -972,7 +972,7 @@ MegaTimeZoneDetails *MegaRequest::getMegaTimeZoneDetails() const
     return NULL;
 }
 
-long long MegaRequest::getTransferTag() const
+int MegaRequest::getTransferTag() const
 {
 	return 0;
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -3066,6 +3066,7 @@ MegaRequestPrivate::MegaRequestPrivate(int type, MegaRequestListener *listener)
 {
     this->type = type;
     this->tag = 0;
+    this->transfer = 0;
     this->listener = listener;
 #ifdef ENABLE_SYNC
     this->syncListener = NULL;
@@ -3672,9 +3673,9 @@ void MegaRequestPrivate::setFlag(bool flag)
     this->flag = flag;
 }
 
-void MegaRequestPrivate::setTransferTag(long long transfer)
+void MegaRequestPrivate::setTransferTag(int transfer)
 {
-    transferTag = transfer;
+    this->transfer = transfer;
 }
 
 void MegaRequestPrivate::setListener(MegaRequestListener *listener)
@@ -3886,9 +3887,9 @@ MegaRequestListener *MegaRequestPrivate::getListener() const
     return listener;
 }
 
-long long MegaRequestPrivate::getTransferTag() const
+int MegaRequestPrivate::getTransferTag() const
 {
-    return transferTag;
+    return transfer;
 }
 
 const char *MegaRequestPrivate::toString() const


### PR DESCRIPTION
Reverts meganz/sdk#2119

The original PR will be re-created too, but requires further changes in order to not break Android bindings, and perhaps other adjustments