### PR TITLE
Fix build on hi3535.

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22277,7 +22277,7 @@ std::vector<MegaTransferPrivate *> TransferQueue::popUpTo(int lastQueuedTransfer
 {
     std::lock_guard<std::mutex> g(mutex);
     std::vector<MegaTransferPrivate*> toret;
-    for (auto it = transfers.cbegin(); it != transfers.cend();)
+    for (auto it = transfers.begin(); it != transfers.end();)
     {
         MegaTransferPrivate *transfer = *it;
         if (transfer->getPlaceInQueue() > lastQueuedTransfer)


### PR DESCRIPTION
It seems that Synology's hi3535 toolchain doesn't fully implement C++11.

Specifically, it does not provide the deque::erase(const_iterator) specialization.