### PR TITLE
Avoid one extra fopen() per Sync::scan() when not initializing

### DIFF
--- a/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
+++ b/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		940BEFBB19ED92C2007E7FA2 /* commands.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 940BEF9C19ED92C2007E7FA2 /* commands.cpp */; };
 		940BEFBC19ED92C2007E7FA2 /* db.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 940BEF9D19ED92C2007E7FA2 /* db.cpp */; };
 		940BEFBD19ED92C2007E7FA2 /* file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 940BEF9E19ED92C2007E7FA2 /* file.cpp */; };
+		BECAAD977F5F4092A01CCE5D /* filter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6D278C4CACCF44D99ACFC056 /* filter.cpp */; };
 		940BEFBE19ED92C2007E7FA2 /* fileattributefetch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 940BEF9F19ED92C2007E7FA2 /* fileattributefetch.cpp */; };
 		940BEFBF19ED92C2007E7FA2 /* filefingerprint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 940BEFA019ED92C2007E7FA2 /* filefingerprint.cpp */; };
 		940BEFC019ED92C2007E7FA2 /* filesystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 940BEFA119ED92C2007E7FA2 /* filesystem.cpp */; };
@@ -160,6 +161,7 @@
 		940BEF9C19ED92C2007E7FA2 /* commands.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = commands.cpp; path = ../../src/commands.cpp; sourceTree = "<group>"; };
 		940BEF9D19ED92C2007E7FA2 /* db.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = db.cpp; path = ../../src/db.cpp; sourceTree = "<group>"; };
 		940BEF9E19ED92C2007E7FA2 /* file.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = file.cpp; path = ../../src/file.cpp; sourceTree = "<group>"; };
+		6D278C4CACCF44D99ACFC056 /* filter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = filter.cpp; path = ../../src/filter.cpp; sourceTree = "<group>"; };
 		940BEF9F19ED92C2007E7FA2 /* fileattributefetch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fileattributefetch.cpp; path = ../../src/fileattributefetch.cpp; sourceTree = "<group>"; };
 		940BEFA019ED92C2007E7FA2 /* filefingerprint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = filefingerprint.cpp; path = ../../src/filefingerprint.cpp; sourceTree = "<group>"; };
 		940BEFA119ED92C2007E7FA2 /* filesystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = filesystem.cpp; path = ../../src/filesystem.cpp; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 		940BF04A19EDBCAD007E7FA2 /* sqlite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sqlite.h; sourceTree = "<group>"; };
 		940BF04B19EDBCAD007E7FA2 /* db.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = db.h; sourceTree = "<group>"; };
 		940BF04C19EDBCAD007E7FA2 /* file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file.h; sourceTree = "<group>"; };
+		3B45B5D817D0481A848902A4 /* filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter.h; sourceTree = "<group>"; };
 		940BF04D19EDBCAD007E7FA2 /* fileattributefetch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fileattributefetch.h; sourceTree = "<group>"; };
 		940BF04E19EDBCAD007E7FA2 /* filefingerprint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filefingerprint.h; sourceTree = "<group>"; };
 		940BF04F19EDBCAD007E7FA2 /* filesystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filesystem.h; sourceTree = "<group>"; };
@@ -356,6 +359,7 @@
 				940BEF9C19ED92C2007E7FA2 /* commands.cpp */,
 				940BEF9D19ED92C2007E7FA2 /* db.cpp */,
 				940BEF9E19ED92C2007E7FA2 /* file.cpp */,
+				6D278C4CACCF44D99ACFC056 /* filter.cpp */,
 				940BEF9F19ED92C2007E7FA2 /* fileattributefetch.cpp */,
 				940BEFA019ED92C2007E7FA2 /* filefingerprint.cpp */,
 				940BEFA119ED92C2007E7FA2 /* filesystem.cpp */,
@@ -541,6 +545,7 @@
 				940BF04819EDBCAD007E7FA2 /* db */,
 				940BF04B19EDBCAD007E7FA2 /* db.h */,
 				940BF04C19EDBCAD007E7FA2 /* file.h */,
+				3B45B5D817D0481A848902A4 /* filter.h */,
 				940BF04D19EDBCAD007E7FA2 /* fileattributefetch.h */,
 				940BF04E19EDBCAD007E7FA2 /* filefingerprint.h */,
 				940BF04F19EDBCAD007E7FA2 /* filesystem.h */,
@@ -800,6 +805,7 @@
 				41B2AED91A0A859C006C40FB /* DelegateMEGAGlobalListener.mm in Sources */,
 				940BF01019ED97B9007E7FA2 /* MEGAError.mm in Sources */,
 				940BEFBD19ED92C2007E7FA2 /* file.cpp in Sources */,
+				BECAAD977F5F4092A01CCE5D /* filter.cpp in Sources */,
 				940BF00E19ED97B9007E7FA2 /* MEGAAccountDetails.mm in Sources */,
 				940BEFF119ED9351007E7FA2 /* console.cpp in Sources */,
 				940BF01719ED97B9007E7FA2 /* MEGATransferList.mm in Sources */,

--- a/bindings/java/contrib/vs2015/MEGAdll.vcxproj
+++ b/bindings/java/contrib/vs2015/MEGAdll.vcxproj
@@ -32,6 +32,7 @@
     <ClInclude Include="..\..\..\..\include\mega\crypto\sodium.h" />
     <ClInclude Include="..\..\..\..\include\mega\db.h" />
     <ClInclude Include="..\..\..\..\include\mega\file.h" />
+    <ClInclude Include="..\..\..\..\include\mega\filter.h" />
     <ClInclude Include="..\..\..\..\include\mega\fileattributefetch.h" />
     <ClInclude Include="..\..\..\..\include\mega\filefingerprint.h" />
     <ClInclude Include="..\..\..\..\include\mega\filesystem.h" />
@@ -83,6 +84,7 @@
     <ClCompile Include="..\..\..\..\src\db.cpp" />
     <ClCompile Include="..\..\..\..\src\db\sqlite.cpp" />
     <ClCompile Include="..\..\..\..\src\file.cpp" />
+    <ClCompile Include="..\..\..\..\src\filter.cpp" />
     <ClCompile Include="..\..\..\..\src\fileattributefetch.cpp" />
     <ClCompile Include="..\..\..\..\src\filefingerprint.cpp" />
     <ClCompile Include="..\..\..\..\src\filesystem.cpp" />

--- a/bindings/java/contrib/vs2015/MEGAdll.vcxproj.filters
+++ b/bindings/java/contrib/vs2015/MEGAdll.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClInclude Include="..\..\..\..\include\mega\file.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\include\mega\filter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\..\include\mega\fileattributefetch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -192,6 +195,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\file.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\filter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\fileattributefetch.cpp">

--- a/bindings/qt/QTMegaEvent.cpp
+++ b/bindings/qt/QTMegaEvent.cpp
@@ -113,6 +113,16 @@ void QTMegaEvent::setEvent(MegaEvent* event)
 }
 
 #ifdef ENABLE_SYNC
+MegaSyncEvent *QTMegaEvent::getSyncEvent()
+{
+    return reinterpret_cast<MegaSyncEvent*>(event);
+}
+
+void QTMegaEvent::setSyncEvent(MegaSyncEvent* event)
+{
+    this->event = reinterpret_cast<MegaEvent*>(event);
+}
+
 MegaSync *QTMegaEvent::getSync()
 {
     return sync;

--- a/bindings/qt/QTMegaEvent.h
+++ b/bindings/qt/QTMegaEvent.h
@@ -28,6 +28,7 @@ public:
 #if ENABLE_SYNC
         ,
         OnSyncStateChanged,
+        OnSyncEvent,
         OnFileSyncStateChanged,
         OnGlobalSyncStateChanged
 #endif
@@ -54,10 +55,15 @@ public:
     void setEvent(MegaEvent *event);
 
 #ifdef ENABLE_SYNC
+    MegaSyncEvent *getSyncEvent();
+    void setSyncEvent(MegaSyncEvent *event);
+
     MegaSync *getSync();
     void setSync(MegaSync *sync);
+
     std::string *getLocalPath();
     void setLocalPath(std::string *localPath);
+
     int getNewState();
     void setNewState(int newState);
 #endif

--- a/bindings/qt/QTMegaListener.cpp
+++ b/bindings/qt/QTMegaListener.cpp
@@ -134,6 +134,16 @@ void QTMegaListener::onSyncStateChanged(MegaApi *api, MegaSync *sync)
     QCoreApplication::postEvent(this, event, INT_MIN);
 }
 
+void QTMegaListener::onSyncEvent(MegaApi *api, MegaSync *sync, MegaSyncEvent *event)
+{
+    QTMegaEvent *ev = new QTMegaEvent(api, (QEvent::Type)QTMegaEvent::OnSyncEvent);
+
+    ev->setSync(sync->copy());
+    ev->setSyncEvent(event->copy());
+
+    QCoreApplication::postEvent(this, ev, INT_MIN);
+}
+
 void QTMegaListener::onSyncFileStateChanged(MegaApi *api, MegaSync *sync, string *localPath, int newState)
 {
     QTMegaEvent *event = new QTMegaEvent(api, (QEvent::Type)QTMegaEvent::OnFileSyncStateChanged);
@@ -200,6 +210,9 @@ void QTMegaListener::customEvent(QEvent *e)
 #if ENABLE_SYNC
         case QTMegaEvent::OnSyncStateChanged:
             if(listener) listener->onSyncStateChanged(event->getMegaApi(), event->getSync());
+            break;
+        case QTMegaEvent::OnSyncEvent:
+            if (listener) listener->onSyncEvent(event->getMegaApi(), event->getSync(), event->getSyncEvent());
             break;
         case QTMegaEvent::OnFileSyncStateChanged:
             if(listener) listener->onSyncFileStateChanged(event->getMegaApi(), event->getSync(), event->getLocalPath(), event->getNewState());

--- a/bindings/qt/QTMegaListener.h
+++ b/bindings/qt/QTMegaListener.h
@@ -30,6 +30,7 @@ public:
 
 #ifdef ENABLE_SYNC
     virtual void onSyncStateChanged(MegaApi *api,  MegaSync *sync);
+    virtual void onSyncEvent(MegaApi *api, MegaSync *sync, MegaSyncEvent *event);
     virtual void onSyncFileStateChanged(MegaApi *api, MegaSync *sync, std::string *localPath, int newState);
     virtual void onGlobalSyncStateChanged(MegaApi* api);
 #endif

--- a/bindings/qt/QTMegaSyncListener.cpp
+++ b/bindings/qt/QTMegaSyncListener.cpp
@@ -27,6 +27,16 @@ void QTMegaSyncListener::onSyncStateChanged(MegaApi *api, MegaSync *sync)
     QCoreApplication::postEvent(this, event, INT_MIN);
 }
 
+void QTMegaSyncListener::onSyncEvent(MegaApi *api, MegaSync *sync, MegaSyncEvent *event)
+{
+    QTMegaEvent *ev = new QTMegaEvent(api, (QEvent::Type)QTMegaEvent::OnSyncEvent);
+
+    ev->setSync(sync->copy());
+    ev->setSyncEvent(event->copy());
+
+    QCoreApplication::postEvent(this, ev, INT_MIN);
+}
+
 void QTMegaSyncListener::onSyncFileStateChanged(MegaApi *api, MegaSync *sync, string *localPath, int newState)
 {
     QTMegaEvent *event = new QTMegaEvent(api, (QEvent::Type)QTMegaEvent::OnFileSyncStateChanged);
@@ -43,6 +53,9 @@ void QTMegaSyncListener::customEvent(QEvent *e)
     {
         case QTMegaEvent::OnSyncStateChanged:
             if(listener) listener->onSyncStateChanged(event->getMegaApi(), event->getSync());
+            break;
+        case QTMegaEvent::OnSyncEvent:
+            if (listener) listener->onSyncEvent(event->getMegaApi(), event->getSync(), event->getSyncEvent());
             break;
         case QTMegaEvent::OnFileSyncStateChanged:
             if(listener) listener->onSyncFileStateChanged(event->getMegaApi(), event->getSync(), event->getLocalPath(), event->getNewState());

--- a/bindings/qt/QTMegaSyncListener.h
+++ b/bindings/qt/QTMegaSyncListener.h
@@ -16,6 +16,7 @@ public:
     virtual ~QTMegaSyncListener();
 
     virtual void onSyncStateChanged(MegaApi *api,  MegaSync *sync);
+    virtual void onSyncEvent(MegaApi *api, MegaSync *sync, MegaSyncEvent *event);
     virtual void onSyncFileStateChanged(MegaApi *api, MegaSync *sync, std::string *localPath, int newState);
 
 protected:

--- a/bindings/qt/sdk.pri
+++ b/bindings/qt/sdk.pri
@@ -29,6 +29,7 @@ SOURCES += src/attrmap.cpp \
     src/db.cpp \
     src/gfx.cpp \
     src/file.cpp \
+    src/filter.cpp \
     src/fileattributefetch.cpp \
     src/filefingerprint.cpp \
     src/filesystem.cpp \
@@ -395,6 +396,7 @@ HEADERS  += include/mega.h \
             include/mega/db.h \
             include/mega/gfx.h \
             include/mega/file.h \
+            include/mega/filter.h \
             include/mega/fileattributefetch.h \
             include/mega/filefingerprint.h \
             include/mega/filesystem.h \

--- a/bindings/wp8/MegaSDK.h
+++ b/bindings/wp8/MegaSDK.h
@@ -134,7 +134,8 @@ namespace mega
         RETRY_API_LOCK      = 3,
         RETRY_RATE_LIMIT    = 4,
         RETRY_LOCAL_LOCK    = 5,
-        RETRY_UNKNOWN       = 6
+        RETRY_IGNORE_FILE   = 6,
+        RETRY_UNKNOWN       = 7
     };
 
     public enum class MStorageState {
@@ -2833,7 +2834,10 @@ namespace mega
         * - MRetryReason::RETRY_LOCAL_LOCK = 5
         * SDK is waiting for a local locked file
         *
-        * - MRetryReason::RETRY_UNKNOWN = 6
+        * - MRetryReason::RETRY_IGNORE_FILE = 6
+        * SDK is waiting for an ignore file to load.
+        *
+        * - MRetryReason::RETRY_UNKNOWN = 7
         * SDK is waiting for the server to complete a request with unknown reason
         *
         */

--- a/bindings/wp8/vs2013/mega.vcxproj
+++ b/bindings/wp8/vs2013/mega.vcxproj
@@ -350,6 +350,7 @@
     <ClInclude Include="..\..\..\include\mega\db.h" />
     <ClInclude Include="..\..\..\include\mega\db\sqlite.h" />
     <ClInclude Include="..\..\..\include\mega\file.h" />
+    <ClInclude Include="..\..\..\include\mega\filter.h" />
     <ClInclude Include="..\..\..\include\mega\fileattributefetch.h" />
     <ClInclude Include="..\..\..\include\mega\filefingerprint.h" />
     <ClInclude Include="..\..\..\include\mega\filesystem.h" />
@@ -441,6 +442,7 @@
     <ClCompile Include="..\..\..\src\db.cpp" />
     <ClCompile Include="..\..\..\src\db\sqlite.cpp" />
     <ClCompile Include="..\..\..\src\file.cpp" />
+    <ClCompile Include="..\..\..\src\filter.cpp" />
     <ClCompile Include="..\..\..\src\fileattributefetch.cpp" />
     <ClCompile Include="..\..\..\src\filefingerprint.cpp" />
     <ClCompile Include="..\..\..\src\filesystem.cpp" />

--- a/bindings/wp8/vs2013/mega.vcxproj.filters
+++ b/bindings/wp8/vs2013/mega.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\..\..\include\mega\file.h">
       <Filter>SDK\Header</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\include\mega\filter.h">
+      <Filter>SDK\Header</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\include\mega\fileattributefetch.h">
       <Filter>SDK\Header</Filter>
     </ClInclude>
@@ -321,6 +324,9 @@
       <Filter>SDK\Source</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\file.cpp">
+      <Filter>SDK\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\filter.cpp">
       <Filter>SDK\Source</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\fileattributefetch.cpp">

--- a/bindings/wp8/vs2015/mega.vcxproj
+++ b/bindings/wp8/vs2015/mega.vcxproj
@@ -39,6 +39,7 @@
     <ClInclude Include="..\..\..\include\mega\db.h" />
     <ClInclude Include="..\..\..\include\mega\db\sqlite.h" />
     <ClInclude Include="..\..\..\include\mega\file.h" />
+    <ClInclude Include="..\..\..\include\mega\filter.h" />
     <ClInclude Include="..\..\..\include\mega\fileattributefetch.h" />
     <ClInclude Include="..\..\..\include\mega\filefingerprint.h" />
     <ClInclude Include="..\..\..\include\mega\filesystem.h" />
@@ -134,6 +135,7 @@
     <ClCompile Include="..\..\..\src\db.cpp" />
     <ClCompile Include="..\..\..\src\db\sqlite.cpp" />
     <ClCompile Include="..\..\..\src\file.cpp" />
+    <ClCompile Include="..\..\..\src\filter.cpp" />
     <ClCompile Include="..\..\..\src\fileattributefetch.cpp" />
     <ClCompile Include="..\..\..\src\filefingerprint.cpp" />
     <ClCompile Include="..\..\..\src\filesystem.cpp" />

--- a/bindings/wp8/vs2015/mega.vcxproj.filters
+++ b/bindings/wp8/vs2015/mega.vcxproj.filters
@@ -157,6 +157,9 @@
     <ClInclude Include="..\..\..\include\mega\file.h">
       <Filter>SDK\Header</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\include\mega\filter.h">
+      <Filter>SDK\Header</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\include\mega\fileattributefetch.h">
       <Filter>SDK\Header</Filter>
     </ClInclude>
@@ -409,6 +412,9 @@
       <Filter>SDK\Source</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\file.cpp">
+      <Filter>SDK\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\filter.cpp">
       <Filter>SDK\Source</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\fileattributefetch.cpp">

--- a/contrib/QtCreator/megacli.files
+++ b/contrib/QtCreator/megacli.files
@@ -42,6 +42,7 @@
 ../../include/mega/console.h
 ../../include/mega/db.h
 ../../include/mega/file.h
+../../include/mega/filter.h
 ../../include/mega/fileattributefetch.h
 ../../include/mega/filefingerprint.h
 ../../include/mega/filesystem.h
@@ -108,6 +109,7 @@
 ../../src/commands.cpp
 ../../src/db.cpp
 ../../src/file.cpp
+../../src/filter.cpp
 ../../src/fileattributefetch.cpp
 ../../src/filefingerprint.cpp
 ../../src/filesystem.cpp

--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -687,6 +687,7 @@ add_library(Mega STATIC
             ${MegaDir}/include/mega/raid.h
             ${MegaDir}/include/mega/logging.h
             ${MegaDir}/include/mega/file.h
+            ${MegaDir}/include/mega/filter.h
             ${MegaDir}/include/mega/sync.h
             ${MegaDir}/include/mega/utils.h
             ${MegaDir}/include/mega/account.h
@@ -711,6 +712,7 @@ add_library(Mega STATIC
             ${MegaDir}/src/commands.cpp 
             ${MegaDir}/src/db.cpp 
             ${MegaDir}/src/file.cpp 
+            ${MegaDir}/src/filter.cpp 
             ${MegaDir}/src/fileattributefetch.cpp 
             ${MegaDir}/src/filefingerprint.cpp 
             ${MegaDir}/src/filesystem.cpp 

--- a/include/mega.h
+++ b/include/mega.h
@@ -44,6 +44,7 @@
 #include "mega/fileattributefetch.h"
 #include "mega/filefingerprint.h"
 #include "mega/file.h"
+#include "mega/filter.h"
 #include "mega/filesystem.h"
 #include "mega/db.h"
 #include "mega/json.h"

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -172,6 +172,9 @@ public:
 
     bool isContainingPathOf(const LocalPath& path, const FileSystemAccess& fsaccess);
 
+    // Return the last part of the local path.
+    LocalPath lastPart(const FileSystemAccess& fsAccess) const;
+
     // Return a utf8 representation of the LocalPath (fsaccess is used to do the conversion)
     // No escaping or unescaping is done.
     std::string toPath(const FileSystemAccess& fsaccess) const;

--- a/include/mega/filter.h
+++ b/include/mega/filter.h
@@ -1,0 +1,190 @@
+/**
+ * @file mega/filter.h
+ * @brief Classes representing file filters.
+ *
+ * (c) 2013-2014 by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+#ifndef MEGA_FILTER_H
+#define MEGA_FILTER_H 1
+
+#include "types.h"
+
+namespace mega
+{
+
+// Forward Declarations (from Filesystem)
+struct MEGA_API FileAccess;
+struct MEGA_API InputStreamAccess;
+
+enum FilterStrategy
+{
+    FS_GLOB,
+    FS_REGEX,
+    NUM_FILTER_STRATEGIES
+}; /* FilterStrategy */
+
+enum FilterTarget
+{
+    FT_ALL,
+    FT_DIRECTORIES,
+    FT_FILES,
+    NUM_FILTER_TARGETS
+}; /* FilterTarget */
+
+enum FilterType
+{
+    FT_NAME,
+    FT_PATH,
+    NUM_FILTER_TYPES
+}; /* FilterType */
+
+class MEGA_API Filter
+{
+public:
+    virtual ~Filter();
+
+    // Returns true if this filter is applicable to the specified node type.
+    bool applicable(const nodetype_t type) const;
+
+    // Returns true if this filter is inheritable.
+    bool inheritable() const;
+
+    // Returns true if this filter matches the string s.
+    virtual bool match(const string& s) const = 0;
+
+    // Returns the filter's matching strategy.
+    virtual FilterStrategy strategy() const = 0;
+
+    // Returns the textual representation of this filter.
+    const string& text() const; 
+
+    // Returns the filter's target.
+    FilterTarget target() const;
+
+    // Returns the filter's type.
+    FilterType type() const;
+
+protected:
+    Filter(const string& text,
+           const bool caseSensitive,
+           const bool inheritable,
+           const FilterTarget target,
+           const FilterType type);
+
+    MEGA_DISABLE_COPY(Filter);
+    MEGA_DEFAULT_MOVE(Filter);
+
+    // Contains the textual representation of this filter.
+    const string mText;
+
+    // Specifies whether this rule is case sensitive or not.
+    const bool mCaseSensitive;
+
+    // Specifies whether this rule is inherited or not.
+    const bool mInheritable;
+
+    // Is this filter applicable to directories, files or both?
+    const FilterTarget mTarget;
+
+    // Specifies whether this is a name or path filter.
+    const FilterType mType;
+}; /* Filter */
+
+// Convenience types.
+using FilterPtr = unique_ptr<Filter>;
+using FilterVector = vector<FilterPtr>;
+
+class MEGA_API FilterClass
+{
+public:
+    FilterClass();
+
+    MEGA_DISABLE_COPY(FilterClass);
+    MEGA_DEFAULT_MOVE(FilterClass);
+
+    // Adds a filter to the class.
+    void add(FilterPtr&& filter);
+
+    // Clears all filters in this class.
+    void clear();
+
+    // Checks whether this class has any filters.
+    bool empty() const;
+
+    // Returns true if this class matches the name/path pair p.
+    bool match(const string_pair &p,
+               const nodetype_t type,
+               const bool onlyInheritable) const;
+
+private:
+    // Name filters.
+    FilterVector mNames;
+
+    // Path filters.
+    FilterVector mPaths;
+}; /* FilterClass */
+
+class MEGA_API FilterChain
+{
+public:
+    FilterChain();
+
+    MEGA_DISABLE_COPY(FilterChain);
+    MEGA_DEFAULT_MOVE(FilterChain);
+
+    // Adds the filter specified by text.
+    bool add(const string& text);
+
+    // Erases all filters in the chain.
+    void clear();
+
+    // Checks if the chain is empty.
+    bool empty() const;
+
+    // Checks if the name/path pair is to be excluded.
+    bool excluded(const string_pair& p,
+                  const nodetype_t type,
+                  const bool onlyInheritable) const;
+
+    // Checks if the name/path pair is to be included.
+    bool included(const string_pair& p,
+                  const nodetype_t type,
+                  const bool onlyInheritable) const;
+
+    // Loads a filter chain from disk.
+    // Chain is changed only if all filters could be added successfully.
+    bool load(InputStreamAccess& isAccess);
+    bool load(FileAccess& ifAccess);
+
+private:
+    // Exclusion filters.
+    FilterClass mExclusions;
+
+    // Inclusion filters.
+    FilterClass mInclusions;
+}; /* FilterChain */
+
+// Useful for debugging / logging.
+string toString(const Filter& filter);
+const string& toString(const FilterStrategy strategy);
+const string& toString(const FilterTarget target);
+const string& toString(const FilterType type);
+
+} /* mega */
+
+#endif /* ! MEGA_FILTER_H */
+

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -289,6 +289,7 @@ struct MEGA_API MegaApp
     virtual void transfer_complete(Transfer*) { }
 
     // sync status updates and events
+    virtual void syncupdate_filter_error(Sync*, LocalNode*) { }
     virtual void syncupdate_state(Sync*, syncstate_t) { }
     virtual void syncupdate_scanning(bool) { }
     virtual void syncupdate_local_folder_addition(Sync*, LocalNode*, const char*) { }

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -289,6 +289,7 @@ struct MEGA_API MegaApp
     virtual void transfer_complete(Transfer*) { }
 
     // sync status updates and events
+    virtual void syncupdate_blocked_file(Sync&, const LocalPath&) { }
     virtual void syncupdate_filter_error(Sync*, LocalNode*) { }
     virtual void syncupdate_state(Sync*, syncstate_t) { }
     virtual void syncupdate_scanning(bool) { }

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -832,7 +832,8 @@ public:
     string accountauth;
 
     // file that is blocking the sync engine
-    LocalPath blockedfile;
+    void blockedFile(Sync& sync, const LocalPath& path);
+    const LocalPath& blockedFile() const;
 
     // stats id
     static std::string statsid;
@@ -866,6 +867,8 @@ private:
 
     bool pendingscTimedOut = false;
 
+    // file that is blocking the sync engine
+    LocalPath blockedfile;
 
     // badhost report
     HttpReq* badhostcs;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -485,6 +485,12 @@ public:
     bool xferpaused[2];
 
 #ifdef ENABLE_SYNC
+    void purgeFilterState();
+
+    void restoreFilterState();
+
+    void updateFilterState();
+
     // active syncs
     sync_list syncs;
 
@@ -496,6 +502,9 @@ public:
 
     // whether we allow the automatic resumption of syncs
     bool allowAutoResumeSyncs = true;
+
+    // whether we load ignore files.
+    bool ignoreFilesEnabled = true;
 #endif
 
     // if set, symlinks will be followed except in recursive deletions
@@ -1260,6 +1269,9 @@ public:
     // sync debris folder name in //bin
     static const char* const SYNCDEBRISFOLDERNAME;
 
+    // tracks which nodes failed to load their ignore file.
+    localnode_list ignoreFileFailures;
+
     // we are adding the //bin/SyncDebris/yyyy-mm-dd subfolder(s)
     bool syncdebrisadding;
 
@@ -1331,7 +1343,8 @@ public:
     void syncupdate();
 
     // create missing folders, copy/start uploading missing files
-    bool syncup(LocalNode*, dstime*);
+    bool syncup(LocalNode* l, dstime* nds, size_t& parentPending);
+    bool syncup(LocalNode* l, dstime* nds);
 
     // sync putnodes() completion
     void putnodes_sync_result(error, NewNode*, int);

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -147,7 +147,7 @@ public:
 
     // scan items in specified path and add as children of the specified
     // LocalNode
-    bool scan(LocalPath*, FileAccess*);
+    bool scan(LocalPath* localpath, FileAccess* fa, LocalNode* localnode);
 
     // own position in session sync list
     sync_list::iterator sync_it{};
@@ -195,6 +195,10 @@ public:
     Sync(MegaClient*, SyncConfig, const char*, string*, Node*, bool, int, void*);
     ~Sync();
 
+    const LocalPath ignoreFileLocalName;
+    static const string ignoreFileName;
+
+    static const int IGNOREFILE_DELAY_DS;
     static const int SCANNING_DELAY_DS;
     static const int EXTRA_SCANNING_DELAY_DS;
     static const int FILE_UPDATE_DELAY_DS;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -322,11 +322,13 @@ typedef enum { SYNC_FAILED = -2, SYNC_CANCELED = -1, SYNC_INITIALSCAN = 0, SYNC_
 typedef enum { SYNCDEL_NONE, SYNCDEL_DELETED, SYNCDEL_INFLIGHT, SYNCDEL_BIN,
                SYNCDEL_DEBRIS, SYNCDEL_DEBRISDAY, SYNCDEL_FAILED } syncdel_t;
 
+typedef list<LocalNode*> localnode_list;
+
+typedef set<LocalNode*> localnode_set;
+
 typedef vector<LocalNode*> localnode_vector;
 
 typedef map<handle, LocalNode*> handlelocalnode_map;
-
-typedef set<LocalNode*> localnode_set;
 
 typedef multimap<int32_t, LocalNode*> idlocalnode_map;
 
@@ -480,10 +482,11 @@ typedef list<HttpReqCommandPutFA*> putfa_list;
 typedef map<handle, PendingContactRequest*> handlepcr_map;
 
 // Type-Value (for user attributes)
-typedef vector<string> string_vector;
 typedef map<string, string> string_map;
-typedef string_map TLV_map;
+typedef pair<string, string> string_pair;
+typedef vector<string> string_vector;
 
+typedef string_map TLV_map;
 
 // user attribute types
 typedef enum {
@@ -599,7 +602,16 @@ typedef enum { RECOVER_WITH_MASTERKEY = 9, RECOVER_WITHOUT_MASTERKEY = 10, CANCE
 
 typedef enum { EMAIL_REMOVED = 0, EMAIL_PENDING_REMOVED = 1, EMAIL_PENDING_ADDED = 2, EMAIL_FULLY_ACCEPTED = 3 } emailstatus_t;
 
-typedef enum { RETRY_NONE = 0, RETRY_CONNECTIVITY = 1, RETRY_SERVERS_BUSY = 2, RETRY_API_LOCK = 3, RETRY_RATE_LIMIT = 4, RETRY_LOCAL_LOCK = 5, RETRY_UNKNOWN = 6} retryreason_t;
+typedef enum {
+    RETRY_NONE = 0,
+    RETRY_CONNECTIVITY = 1,
+    RETRY_SERVERS_BUSY = 2,
+    RETRY_API_LOCK = 3,
+    RETRY_RATE_LIMIT = 4,
+    RETRY_LOCAL_LOCK = 5,
+    RETRY_IGNORE_FILE = 6,
+    RETRY_UNKNOWN = 7
+} retryreason_t;
 
 typedef enum {
     STORAGE_UNKNOWN = -9,
@@ -738,6 +750,27 @@ namespace CodeCounter
 }
 
 typedef enum {INVALID = -1, TWO_WAY = 0, UP_SYNC = 1, DOWN_SYNC = 2, CAMERA_UPLOAD = 3 } BackupType;
+
+template<class T>
+class ScopedValue
+{
+public:
+    ScopedValue(T& storage, const T& value)
+      : mStorage(storage)
+      , mOriginalValue(storage)
+    {
+        mStorage = value;
+    }
+
+    ~ScopedValue()
+    {
+        mStorage = mOriginalValue;
+    }
+
+private:
+    T& mStorage;
+    const T mOriginalValue;
+}; /* ScopedValue<T> */
 
 // Holds the config of a sync. Can be extended with future config options
 class SyncConfig : public Cacheable

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -605,6 +605,10 @@ public:
 
 };
 
+bool readLines(FileAccess& ifAccess, string_vector& destination);
+bool readLines(InputStreamAccess& isAccess, string_vector& destination);
+bool readLines(const std::string& input, string_vector& destination);
+
 bool wildcardMatch(const char* pszString, const char* pszMatch);
 bool wildcardMatch(const char* string, const string_vector &patterns);
 

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -543,7 +543,6 @@ private:
     void asyncThreadLoop();
 };
 
-
 template<class T>
 struct ThreadSafeDeque
 {
@@ -606,6 +605,8 @@ public:
 
 };
 
+bool wildcardMatch(const char* pszString, const char* pszMatch);
+bool wildcardMatch(const char* string, const string_vector &patterns);
 
 } // namespace
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -4711,6 +4711,7 @@ public:
         TYPE_REMOTE_RENAME,
         TYPE_FILE_GET,
         TYPE_FILE_PUT,
+        TYPE_BLOCKED_FILE,
         TYPE_FILTER_ERROR
     };
 

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -4697,13 +4697,21 @@ public:
      * Event types.
      */
     enum {
-        TYPE_LOCAL_FOLDER_ADITION, TYPE_LOCAL_FOLDER_DELETION,
-        TYPE_LOCAL_FILE_ADDITION, TYPE_LOCAL_FILE_DELETION,
-        TYPE_LOCAL_FILE_CHANGED, TYPE_LOCAL_MOVE,
-        TYPE_REMOTE_FOLDER_ADDITION, TYPE_REMOTE_FOLDER_DELETION,
-        TYPE_REMOTE_FILE_ADDITION, TYPE_REMOTE_FILE_DELETION,
-        TYPE_REMOTE_MOVE, TYPE_REMOTE_RENAME,
-        TYPE_FILE_GET, TYPE_FILE_PUT
+        TYPE_LOCAL_FOLDER_ADITION,
+        TYPE_LOCAL_FOLDER_DELETION,
+        TYPE_LOCAL_FILE_ADDITION,
+        TYPE_LOCAL_FILE_DELETION,
+        TYPE_LOCAL_FILE_CHANGED,
+        TYPE_LOCAL_MOVE,
+        TYPE_REMOTE_FOLDER_ADDITION,
+        TYPE_REMOTE_FOLDER_DELETION,
+        TYPE_REMOTE_FILE_ADDITION,
+        TYPE_REMOTE_FILE_DELETION,
+        TYPE_REMOTE_MOVE,
+        TYPE_REMOTE_RENAME,
+        TYPE_FILE_GET,
+        TYPE_FILE_PUT,
+        TYPE_FILTER_ERROR
     };
 
     virtual ~MegaSyncEvent();
@@ -7030,7 +7038,8 @@ class MegaApi
             RETRY_API_LOCK = 3,
             RETRY_RATE_LIMIT = 4,
             RETRY_LOCAL_LOCK = 5,
-            RETRY_UNKNOWN = 6
+            RETRY_IGNORE_FILE = 6,
+            RETRY_UNKNOWN = 7
         };
 
         enum {
@@ -12701,6 +12710,21 @@ class MegaApi
         bool isSynced(MegaNode *n);
 
         /**
+         * @brief Enable or disable ignore file functionality.
+         *
+         * @param enabled
+         * True if filtering rules should be loaded from ignore files.
+         */
+        void ignoreFilesEnabled(const bool enabled);
+
+        /**
+         * @brief Query whether ignore file functionality is enabled.
+         *
+         * @return True if ignore file functionality is enabled.
+         */
+        bool ignoreFilesEnabled();
+
+        /**
          * @brief Set a list of excluded file names
          *
          * Wildcards (* and ?) are allowed
@@ -12917,7 +12941,10 @@ class MegaApi
          * - MegaApi::RETRY_LOCAL_LOCK = 5
          * SDK is waiting for a local locked file
          *
-         * - MegaApi::RETRY_UNKNOWN = 6
+         * - MegaApi::RETRY_IGNORE_FILE = 6
+         * SDK is waiting for an ignore file to load.
+         *
+         * - MegaApi::RETRY_UNKNOWN = 7
          * SDK is waiting for the server to complete a request with unknown reason
          *
          */
@@ -12946,7 +12973,10 @@ class MegaApi
          * - MegaApi::RETRY_LOCAL_LOCK = 5
          * SDK is waiting for a local locked file
          *
-         * - MegaApi::RETRY_UNKNOWN = 6
+         * - MegaApi::RETRY_IGNORE_FILE = 6
+         * SDK is waiting for an ignore file to load.
+         *
+         * - MegaApi::RETRY_UNKNOWN = 7
          * SDK is waiting for the server to complete a request with unknown reason
          *
          * @deprecated Use MegaApi::isWaiting instead of this function.

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2297,6 +2297,8 @@ class MegaApiImpl : public MegaApp
         int getNumActiveSyncs();
         void stopSyncs(MegaRequestListener *listener=NULL);
         bool isSynced(MegaNode *n);
+        void ignoreFilesEnabled(const bool enabled);
+        bool ignoreFilesEnabled();
         void setExcludedNames(vector<string> *excludedNames);
         void setExcludedPaths(vector<string> *excludedPaths);
         void setExclusionLowerSizeLimit(long long limit);
@@ -3010,6 +3012,7 @@ protected:
 
 #ifdef ENABLE_SYNC
         // sync status updates and events
+        void syncupdate_filter_error(Sync* sync, LocalNode* node) override;
         void syncupdate_state(Sync*, syncstate_t) override;
         void syncupdate_scanning(bool scanning) override;
         void syncupdate_local_folder_addition(Sync* sync, LocalNode *localNode, const char *path) override;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -3012,6 +3012,7 @@ protected:
 
 #ifdef ENABLE_SYNC
         // sync status updates and events
+        void syncupdate_blocked_file(Sync& sync, const LocalPath& localPath) override;
         void syncupdate_filter_error(Sync* sync, LocalNode* node) override;
         void syncupdate_state(Sync*, syncstate_t) override;
         void syncupdate_scanning(bool scanning) override;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1054,6 +1054,11 @@ bool LocalPath::isContainingPathOf(const LocalPath& path, const FileSystemAccess
            !memcmp(path.localpath.data() + localpath.size() - fsaccess.localseparator.size(), fsaccess.localseparator.data(), fsaccess.localseparator.size())));
 }
 
+LocalPath LocalPath::lastPart(const FileSystemAccess& fsAccess) const
+{
+    return subpathFrom(lastpartlocal(fsAccess));
+}
+
 ScopedLengthRestore::ScopedLengthRestore(LocalPath& p)
     : path(p)
     , length(path.getLength())

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -1,0 +1,551 @@
+#include <array>
+#include <cassert>
+#include <cctype>
+#include <regex>
+
+#include "mega/filesystem.h"
+#include "mega/filter.h"
+#include "mega/utils.h"
+
+namespace mega
+{
+
+class GlobFilter
+  : public Filter
+{
+public:
+    GlobFilter(const string& text,
+               const bool caseSensitive,
+               const bool inheritable,
+               const FilterTarget target,
+               const FilterType type);
+
+    bool match(const string& s) const override;
+
+    FilterStrategy strategy() const override;
+
+private:
+    string mPattern;
+}; /* GlobFilter */
+
+class RegexFilter
+  : public Filter
+{
+public:
+    RegexFilter(const string& text,
+                const bool caseSensitive,
+                const bool inheritable,
+                const FilterTarget target,
+                const FilterType type);
+
+    bool match(const string& s) const override;
+
+    FilterStrategy strategy() const override;
+
+private:
+    // the compiled form of the filter text.
+    std::regex mRegex;
+}; /* RegexFilter */
+
+static std::regex::flag_type regexFlags(const bool caseSensitive);
+
+static bool isEmpty(const char* m, const char* n);
+
+static bool syntaxError(const string& text);
+
+static string toUpper(string text);
+
+bool Filter::applicable(const nodetype_t type) const
+{
+    switch (mTarget)
+    {
+    case FT_DIRECTORIES:
+        return type == FOLDERNODE;
+    case FT_FILES:
+        return type == FILENODE;
+    default:
+        return true;
+    }
+}
+
+bool Filter::inheritable() const
+{
+    return mInheritable;
+}
+
+const string& Filter::text() const
+{
+    return mText;
+}
+
+FilterTarget Filter::target() const
+{
+    return mTarget;
+}
+
+FilterType Filter::type() const
+{
+    return mType;
+}
+
+Filter::~Filter()
+{
+}
+
+Filter::Filter(const string& text,
+               const bool caseSensitive,
+               const bool inheritable,
+               const FilterTarget target,
+               const FilterType type)
+  : mText(text)
+  , mCaseSensitive(caseSensitive)
+  , mInheritable(inheritable)
+  , mTarget(target)
+  , mType(type)
+{
+}
+
+FilterClass::FilterClass()
+  : mNames()
+  , mPaths()
+{
+}
+
+void FilterClass::add(FilterPtr&& filter)
+{
+    switch (filter->type())
+    {
+    case FT_NAME:
+        mNames.emplace_back(std::move(filter));
+        break;
+    case FT_PATH:
+        mPaths.emplace_back(std::move(filter));
+        break;
+    default:
+        assert(!"Unknown filter type");
+        break;
+    }
+}
+
+void FilterClass::clear()
+{
+    mNames.clear();
+    mPaths.clear();
+}
+
+bool FilterClass::empty() const
+{
+    return mNames.empty() && mPaths.empty();
+}
+
+bool FilterClass::match(const string_pair& p,
+                        const nodetype_t type,
+                        const bool onlyInheritable) const
+{
+    for (auto &fp : mPaths)
+    {
+        if (onlyInheritable && !fp->inheritable())
+        {
+            LOG_debug << "Skipped uninheritable filter "
+                      << toString(*fp);
+            continue;
+        }
+
+        if (fp->applicable(type) && fp->match(p.second))
+        {
+            LOG_debug << p.second
+                      << " matched by "
+                      << toString(*fp);
+            return true;
+        }
+    }
+
+    for (auto &fn : mNames)
+    {
+        if (onlyInheritable && !fn->inheritable())
+        {
+            LOG_debug << "Skipped uninheritable filter "
+                      << toString(*fn);
+            continue;
+        }
+
+        if (fn->applicable(type) && fn->match(p.first))
+        {
+            LOG_debug << p.first
+                      << " matched by "
+                      << toString(*fn);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+FilterChain::FilterChain()
+  : mExclusions()
+  , mInclusions()
+{
+}
+
+bool FilterChain::add(const string& text)
+{
+    const char *m = text.data();
+    const char *n = m + text.size();
+    FilterTarget target;
+    FilterType type;
+    bool caseSensitive = false;
+    bool exclusion;
+    bool inheritable = true;
+    bool regex;
+
+    // what class of filter is this?
+    switch (*m++)
+    {
+    // exclusion filter.
+    case '-':
+        exclusion = true;
+        break;
+    // inclusion filter.
+    case '+':
+        exclusion = false;
+        break;
+    // invalid class of filter.
+    default:
+        return syntaxError(text);
+    }
+
+    // what kind of node does this filter target?
+    switch (*m)
+    {
+    // applies to all node types.
+    case 'a':
+        ++m;
+    // default to targeting all node types.
+    default:
+        target = FT_ALL;
+        break;
+    // applies only to directories.
+    case 'd':
+        target = FT_DIRECTORIES;
+        ++m;
+        break;
+    // applies only to files.
+    case 'f':
+        target = FT_FILES;
+        ++m;
+        break;
+    }
+
+    // what type of filter is this?
+    // default to name if not specified.
+    switch (*m)
+    {
+    // name filter, not inherited.
+    case 'N':
+        inheritable = false;
+    // name filter, inherited.
+    case 'n':
+        ++m;
+    // default to inherited name filter.
+    default:
+        type = FT_NAME;
+        break;
+    // path filter, always inherited.
+    case 'p':
+        type = FT_PATH;
+        ++m;
+        break;
+    }
+
+    // what matching strategy does this filter use?
+    // default to glob if not specified.
+    switch (*m)
+    {
+    // glob strategy.
+    case 'G':
+        caseSensitive = true;
+    case 'g':
+        ++m;
+    // default to glob strategy.
+    default:
+        regex = false;
+        break;
+    // regex strategy.
+    case 'R':
+        caseSensitive = true;
+    case 'r':
+        regex = true;
+        ++m;
+        break;
+    }
+
+    // make sure we're at the start of the pattern.
+    if (*m++ != ':')
+    {
+        return syntaxError(text);
+    }
+
+    // is the pattern effectively empty?
+    if (isEmpty(m, n))
+    {
+        return syntaxError(text);
+    }
+
+    // create the filter.
+    FilterPtr filter;
+
+    try
+    {
+        if (regex)
+        {
+            // this'll throw if the regex is malformed.
+            filter.reset(
+              new RegexFilter(m,
+                              caseSensitive,
+                              inheritable,
+                              target,
+                              type));
+        }
+        else
+        {
+            filter.reset(
+              new GlobFilter(m,
+                             caseSensitive,
+                             inheritable,
+                             target,
+                             type));
+        }
+    }
+    catch (std::regex_error&)
+    {
+        return syntaxError(text);
+    }
+
+    // add the filter.
+    if (exclusion)
+    {
+        LOG_debug << "Adding exclusion " << toString(*filter);
+        mExclusions.add(std::move(filter));
+    }
+    else
+    {
+        LOG_debug << "Adding inclusion " << toString(*filter);
+        mInclusions.add(std::move(filter));
+    }
+
+    return true;
+}
+
+void FilterChain::clear()
+{
+    mExclusions.clear();
+    mInclusions.clear();
+}
+
+bool FilterChain::empty() const
+{
+    return mExclusions.empty() && mInclusions.empty();
+}
+
+bool FilterChain::excluded(const string_pair& p,
+                           const nodetype_t type,
+                           const bool onlyInheritable) const
+{
+    return mExclusions.match(p, type, onlyInheritable);
+}
+
+bool FilterChain::included(const string_pair& p,
+                           const nodetype_t type,
+                           const bool onlyInheritable) const
+{
+    return mInclusions.match(p, type, onlyInheritable);
+}
+
+bool FilterChain::load(InputStreamAccess& isAccess)
+{
+    string_vector filters;
+
+    // read the filters, line by line.
+    // empty lines are omitted.
+    if (!readLines(isAccess, filters))
+    {
+        return false;
+    }
+
+    // save the current filters in case of error.
+    FilterClass exclusions(std::move(mExclusions));
+    FilterClass inclusions(std::move(mInclusions));
+
+    // make sure the filter vectors are in a well-defined state.
+    clear();
+
+    // add all the filters.
+    for (const auto &f : filters)
+    {
+        // skip comments.
+        if (f[0] == '#')
+        {
+            continue;
+        }
+
+        // try and add the filter.
+        if (!add(f))
+        {
+            // restore previous filters.
+            mExclusions = std::move(exclusions);
+            mInclusions = std::move(inclusions);
+
+            // changes are not committed.
+            return false;
+        }
+    }
+
+    // changes are committed.
+    return true;
+}
+
+bool FilterChain::load(FileAccess& ifAccess)
+{
+    FileInputStream isAccess(&ifAccess);
+
+    return load(isAccess);
+}
+
+const string& toString(const FilterStrategy strategy)
+{
+    static const std::array<string, NUM_FILTER_STRATEGIES> strings = {
+        "GLOB",
+        "REGEX"
+    }; /* strings */
+
+    assert(strategy < NUM_FILTER_STRATEGIES);
+
+    return strings.at(strategy);
+}
+
+string toString(const Filter& filter)
+{
+    ostringstream osstream;
+
+    osstream << toString(filter.type())
+             << "/"
+             << toString(filter.strategy())
+             << ":"
+             << filter.text();
+
+    return osstream.str();
+}
+
+const string& toString(const FilterTarget target)
+{
+    static const std::array<string, NUM_FILTER_TARGETS> strings = {
+        "ALL",
+        "DIRECTORIES",
+        "FILES"
+    }; /* strings */
+
+    assert(target < NUM_FILTER_TARGETS);
+
+    return strings.at(target);
+}
+
+const string& toString(const FilterType type)
+{
+    static const std::array<string, NUM_FILTER_TYPES> strings = {
+        "NAME",
+        "PATH"
+    }; /* strings */
+
+    assert(type < NUM_FILTER_TYPES);
+
+    return strings.at(type);
+}
+
+GlobFilter::GlobFilter(const string &text,
+                       const bool caseSensitive,
+                       const bool inheritable,
+                       const FilterTarget target,
+                       const FilterType type)
+  : Filter(text, caseSensitive, inheritable, target, type)
+  , mPattern(caseSensitive ? text : toUpper(text))
+{
+}
+
+bool GlobFilter::match(const string &s) const
+{
+    if (!mCaseSensitive)
+    {
+        return wildcardMatch(toUpper(s).c_str(), mPattern.c_str());
+    }
+
+    return wildcardMatch(s.c_str(), mPattern.c_str());
+}
+
+FilterStrategy GlobFilter::strategy() const
+{
+    return FS_GLOB;
+}
+
+RegexFilter::RegexFilter(const string& text,
+                         const bool caseSensitive,
+                         const bool inheritable,
+                         const FilterTarget target,
+                         const FilterType type)
+  : Filter(text, caseSensitive, inheritable, target, type)
+  , mRegex(text, regexFlags(caseSensitive))
+{
+}
+
+bool RegexFilter::match(const string& s) const
+{
+    return std::regex_match(s, mRegex);
+}
+
+FilterStrategy RegexFilter::strategy() const
+{
+    return FS_REGEX;
+}
+
+std::regex::flag_type regexFlags(const bool caseSensitive)
+{
+    using std::regex_constants::extended;
+    using std::regex_constants::icase;
+    using std::regex_constants::optimize;
+
+    const std::regex::flag_type flags = extended | optimize;
+
+    return caseSensitive ? flags | icase : flags;
+}
+
+bool isEmpty(const char* m, const char* n)
+{
+    const char* w = m;
+
+    while (m < n)
+    {
+        w += std::isspace(*m++) > 0;
+    }
+
+    return n == w;
+}
+
+bool syntaxError(const string& text)
+{
+    LOG_debug << "Syntax error parsing: " << text;
+
+    return false;
+}
+
+string toUpper(string text)
+{
+    for (char& character : text)
+    {
+        // overzealous casting to silence compiler.
+        character = (char)std::toupper((unsigned char)character);
+    }
+
+    return text;
+}
+
+} /* mega */
+

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3274,6 +3274,16 @@ int MegaApi::isNodeSyncable(MegaNode *node)
     return pImpl->isNodeSyncable(node);
 }
 
+void MegaApi::ignoreFilesEnabled(const bool enabled)
+{
+    pImpl->ignoreFilesEnabled(enabled);
+}
+
+bool MegaApi::ignoreFilesEnabled()
+{
+    return pImpl->ignoreFilesEnabled();
+}
+
 void MegaApi::setExcludedNames(vector<string> *excludedNames)
 {
     pImpl->setExcludedNames(excludedNames);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -1172,52 +1172,6 @@ string MegaNodePrivate::getLocalPath()
     return localPath;
 }
 
-
-bool WildcardMatch(const char *pszString, const char *pszMatch)
-//  cf. http://www.planet-source-code.com/vb/scripts/ShowCode.asp?txtCodeId=1680&lngWId=3
-{
-    const char *cp = nullptr;
-    const char *mp = nullptr;
-
-    while ((*pszString) && (*pszMatch != '*'))
-    {
-        if ((*pszMatch != *pszString) && (*pszMatch != '?'))
-        {
-            return false;
-        }
-        pszMatch++;
-        pszString++;
-    }
-
-    while (*pszString)
-    {
-        if (*pszMatch == '*')
-        {
-            if (!*++pszMatch)
-            {
-                return true;
-            }
-            mp = pszMatch;
-            cp = pszString + 1;
-        }
-        else if ((*pszMatch == *pszString) || (*pszMatch == '?'))
-        {
-            pszMatch++;
-            pszString++;
-        }
-        else
-        {
-            pszMatch = mp;
-            pszString = cp++;
-        }
-    }
-    while (*pszMatch == '*')
-    {
-        pszMatch++;
-    }
-    return !*pszMatch;
-}
-
 bool MegaApiImpl::is_syncable(Sync *sync, const char *name, const LocalPath& localpath)
 {
     // Don't sync these system files from OS X
@@ -1226,12 +1180,9 @@ bool MegaApiImpl::is_syncable(Sync *sync, const char *name, const LocalPath& loc
         return false;
     }
 
-    for (unsigned int i = 0; i < excludedNames.size(); i++)
+    if (wildcardMatch(name, excludedNames))
     {
-        if (WildcardMatch(name, excludedNames[i].c_str()))
-        {
-            return false;
-        }
+        return false;
     }
 
     MegaRegExp *regExp = NULL;
@@ -1247,12 +1198,9 @@ bool MegaApiImpl::is_syncable(Sync *sync, const char *name, const LocalPath& loc
     {             
         string utf8path = localpath.toPath(*fsAccess);
 
-        for (unsigned int i = 0; i < excludedPaths.size(); i++)
+        if (wildcardMatch(utf8path.c_str(), excludedPaths))
         {
-            if (WildcardMatch(utf8path.c_str(), excludedPaths[i].c_str()))
-            {
-                return false;
-            }
+            return false;
         }
 
 #ifdef USE_PCRE

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -1412,10 +1412,10 @@ char *MegaApiImpl::getBlockedPath()
         return MegaApi::strdup(path.c_str());
     }
 
-    if (!client->blockedfile.empty())
+    if (!client->blockedFile().empty())
     {
         const string path =
-          client->blockedfile.toPath(*fsAccess);
+          client->blockedFile().toPath(*fsAccess);
 
         return MegaApi::strdup(path.c_str());
     }
@@ -12781,6 +12781,22 @@ void MegaApiImpl::syncupdate_scanning(bool scanning)
     fireOnGlobalSyncStateChanged();
 }
 
+void MegaApiImpl::syncupdate_blocked_file(Sync& sync, const LocalPath& localPath)
+{
+    auto path = localPath.toPath(*fsAccess);
+
+    LOG_debug << "Sync - blocked file detected: " << path;
+
+    auto syncIt = syncMap.find(sync.tag);
+    if (syncIt != syncMap.end())
+    {
+        auto event = new MegaSyncEventPrivate(MegaSyncEvent::TYPE_BLOCKED_FILE);
+        event->setPath(path.c_str());
+
+        fireOnSyncEvent(syncIt->second, event);
+    }
+}
+
 void MegaApiImpl::syncupdate_filter_error(Sync* sync, LocalNode* node)
 {
     string path = node->ignoreFilePath().toPath(*fsAccess);
@@ -22164,7 +22180,9 @@ int MegaApiImpl::isWaiting()
 
     if (client->syncfslockretry || client->syncfsopsfailed)
     {
-        LOG_debug << "SDK waiting for a blocked file: " << client->blockedfile.toPath(*fsAccess);
+        LOG_debug << "SDK waiting for a blocked file: "
+                  << client->blockedFile().toPath(*fsAccess);
+
         return RETRY_LOCAL_LOCK;
     }
 #endif

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2611,7 +2611,7 @@ void MegaClient::exec()
                         else if (!syncfslockretry && sync->dirnotify->notifyq[DirNotify::RETRY].peekFront(notification))
                         {
                             syncfslockretrybt.backoff(Sync::SCANNING_DELAY_DS);
-                            blockedfile = notification.path;
+                            blockedFile(*sync, notification.path);
                             syncfslockretry = true;
                         }
                     }
@@ -12791,8 +12791,8 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
                 }
                 else
                 {
-                    blockedfile = localpath;
-                    LOG_warn << "Transient error deleting " << blockedfile.toPath(*fsaccess);
+                    blockedFile(*l->sync, localpath);
+                    LOG_warn << "Transient error deleting " << localpath.toPath(*fsaccess);
                     success = false;
                 }
 
@@ -12862,8 +12862,8 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
                 else if (success && fsaccess->transient_error)
                 {
                     // schedule retry
-                    blockedfile = curpath;
-                    LOG_debug << "Transient error moving localnode " << blockedfile.toPath(*fsaccess);
+                    blockedFile(*rit.second->localnode->sync, curpath);
+                    LOG_debug << "Transient error moving localnode " << curpath.toPath(*fsaccess);
                     success = false;
                 }
 
@@ -12961,8 +12961,8 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
                 }
                 else if (success && fsaccess->transient_error)
                 {
-                    blockedfile = localpath;
-                    LOG_debug << "Transient error creating folder " << blockedfile.toPath(*fsaccess);
+                    blockedFile(*l->sync, localpath);
+                    LOG_debug << "Transient error creating folder " << localpath.toPath(*fsaccess);
                     success = false;
                 }
                 else if (!fsaccess->transient_error)
@@ -14709,6 +14709,23 @@ handle MegaClient::getovhandle(Node *parent, string *name)
         }
     }
     return ovhandle;
+}
+
+void MegaClient::blockedFile(Sync& sync, const LocalPath& path)
+{
+    // Notify the application on the transition to a blocked file.
+    if (blockedfile.empty() && !path.empty())
+    {
+        app->syncupdate_blocked_file(sync, path);
+    }
+
+    // Remember which file was blocked.
+    blockedfile = path;
+}
+
+const LocalPath& MegaClient::blockedFile() const
+{
+    return blockedfile;
 }
 
 void MegaClient::userfeedbackstore(const char *message)

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -33,6 +33,9 @@
 
 namespace mega {
 
+const string Sync::ignoreFileName = ".megaignore";
+
+const int Sync::IGNOREFILE_DELAY_DS = 30;
 const int Sync::SCANNING_DELAY_DS = 5;
 const int Sync::EXTRA_SCANNING_DELAY_DS = 150;
 const int Sync::FILE_UPDATE_DELAY_DS = 30;
@@ -633,6 +636,7 @@ std::vector<SyncConfig> SyncConfigBag::all() const
 Sync::Sync(MegaClient* cclient, SyncConfig config, const char* cdebris,
            string* clocaldebris, Node* remotenode, bool cinshare, int ctag, void *cappdata)
 : localroot(new LocalNode)
+, ignoreFileLocalName(LocalPath::fromPath(ignoreFileName, *cclient->fsaccess))
 {
     isnetwork = false;
     client = cclient;
@@ -1113,12 +1117,10 @@ bool Sync::assignfsids()
 
 // scan localpath, add or update child nodes, call recursively for folder nodes
 // localpath must be prefixed with Sync
-bool Sync::scan(LocalPath* localpath, FileAccess* fa)
+bool Sync::scan(LocalPath* localpath, FileAccess* fa, LocalNode* localnode)
 {
-    if (fa)
-    {
-        assert(fa->type == FOLDERNODE);
-    }
+    assert(!fa || fa->type == FOLDERNODE);
+
     if (!localdebris.isContainingPathOf(*localpath, *client->fsaccess))
     {
         DirAccess* da;
@@ -1136,36 +1138,67 @@ bool Sync::scan(LocalPath* localpath, FileAccess* fa)
         // scan the dir, mark all items with a unique identifier
         if ((success = da->dopen(localpath, fa, false)))
         {
-            while (da->dnext(*localpath, localname, client->followsymlinks))
+            // prioritize handling of ignore files as they dictate how we
+            // should handle this directory's contents.
+            do
             {
-                name = localname.toName(*client->fsaccess);
+                ScopedLengthRestore restoreLen(*localpath);
+
+                localpath->appendWithSeparator(
+                  ignoreFileLocalName,
+                  false,
+                  client->fsaccess->localseparator);
+
+                auto fileaccess = client->fsaccess->newfileaccess(client->followsymlinks);
+                if (!fileaccess->fopen(*localpath))
+                {
+                    break;
+                }
+
+                LocalNode* node = nullptr;
+
+                if (initializing)
+                {
+                    node = checkpath(NULL, localpath, NULL, NULL, false, NULL);
+                }
+
+                if (!node || node == (LocalNode*)~0)
+                {
+                    dirnotify->notify(DirNotify::DIREVENTS, NULL, LocalPath(*localpath));
+                }
+            }
+            while (false);
+
+            nodetype_t type;
+
+            while (da->dnext(*localpath, localname, client->followsymlinks, &type))
+            {
+                // ignore files are processed above.
+                if (type == FILENODE && localname == ignoreFileLocalName)
+                {
+                    continue;
+                }
+
+                name = localname.toName(*client->fsaccess, mFilesystemType);
 
                 ScopedLengthRestore restoreLen(*localpath);
                 localpath->appendWithSeparator(localname, false, client->fsaccess->localseparator);
 
-                // check if this record is to be ignored
-                if (client->app->sync_syncable(this, name.c_str(), *localpath))
+                // skip the sync's debris folder
+                if (!localdebris.isContainingPathOf(*localpath, *client->fsaccess))
                 {
-                    // skip the sync's debris folder
-                    if (!localdebris.isContainingPathOf(*localpath, *client->fsaccess))
+                    LocalNode *l = NULL;
+                    if (initializing)
                     {
-                        LocalNode *l = NULL;
-                        if (initializing)
-                        {
-                            // preload all cached LocalNodes
-                            l = checkpath(NULL, localpath, nullptr, nullptr, false, da);
-                        }
-
-                        if (!l || l == (LocalNode*)~0)
-                        {
-                            // new record: place in notification queue
-                            dirnotify->notify(DirNotify::DIREVENTS, NULL, LocalPath(*localpath));
-                        }
+                        // preload all cached LocalNodes
+                        l = checkpath(NULL, localpath, nullptr, nullptr, false, da);
                     }
-                }
-                else
-                {
-                    LOG_debug << "Excluded: " << name;
+
+                    if (!l || l == (LocalNode*)~0)
+                    {
+                        // new record: place in notification queue
+                        dirnotify->notify(DirNotify::DIREVENTS, NULL, LocalPath(*localpath));
+                    }
                 }
             }
         }
@@ -1174,7 +1207,8 @@ bool Sync::scan(LocalPath* localpath, FileAccess* fa)
 
         return success;
     }
-    else return false;
+
+    return false;
 }
 
 // check local path - if !localname, localpath is relative to l, with l == NULL
@@ -1254,23 +1288,27 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
         string name = newname.size() ? newname : l->name;
         client->fsaccess->local2name(&name, mFilesystemType);
 
-        if (!client->app->sync_syncable(this, name.c_str(), tmppath))
-        {
-            LOG_debug << "Excluded: " << path;
-            return NULL;
-        }
-
         isroot = l == localroot.get() && !newname.size();
     }
 
     LOG_verbose << "Scanning: " << path << " in=" << initializing << " full=" << fullscan << " l=" << l;
     LocalPath* localpathNew = localname ? input_localpath : &tmppath;
 
-    // postpone moving nodes into nonexistent parents
-    if (parent && !parent->node)
+    if (parent)
     {
-        LOG_warn << "Parent doesn't exist yet: " << path;
-        return (LocalNode*)~0;
+        if (parent->loadPending())
+        {
+            parent->performPendingLoad();
+        }
+
+        if (!(parent->anyLoadPending() || parent->excluded()))
+        {
+            if (state != SYNC_INITIALSCAN && !parent->node)
+            {
+                LOG_warn << "Parent doesn't exist yet: " << path;
+                return (LocalNode*)~0;
+            }
+        }
     }
 
     // attempt to open/type this file
@@ -1313,7 +1351,7 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
 
                     if (l->type == FOLDERNODE)
                     {
-                        scan(localpathNew, fa.get());
+                        scan(localpathNew, fa.get(), l);
                     }
                     else
                     {
@@ -1402,6 +1440,11 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
                                     {
                                         LOG_debug << "File move/overwrite detected";
 
+                                        // there's no point updating a parent's filters when its
+                                        // ignore file is being overwitten as that'll happen when
+                                        // setnameparent(...) is called below.
+                                        l->inhibitFilterUpdate();
+
                                         // delete existing LocalNode...
                                         delete l;
 
@@ -1456,6 +1499,11 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
                             statecacheadd(l);
 
                             fa.reset();
+
+                            if (l->isIgnoreFile())
+                            {
+                                l->parent->loadFilters();
+                            }
 
                             if (isnetwork && l->type == FILENODE)
                             {
@@ -1640,7 +1688,7 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
                     // immediately scan folder to detect deviations from cached state
                     if (fullscan && fa->type == FOLDERNODE)
                     {
-                        scan(localpathNew, fa.get());
+                        scan(localpathNew, fa.get(), it->second);
                     }
                 }
                 else if (fa->mIsSymLink)
@@ -1672,7 +1720,7 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
             {
                 if (newnode)
                 {
-                    scan(localpathNew, fa.get());
+                    scan(localpathNew, fa.get(), l);
                     client->app->syncupdate_local_folder_addition(this, l, path.c_str());
 
                     if (!isroot)
@@ -1725,8 +1773,11 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
                     else if (changed)
                     {
                         client->app->syncupdate_local_file_change(this, l, path.c_str());
+
                         DBTableTransactionCommitter committer(client->tctable); // TODO:  can we use one committer for all the files in the folder?  Or for the whole recursion?
                         client->stopxfer(l, &committer);
+
+                        l->parent->loadFilters();
                     }
 
                     if (newnode || changed)

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1140,7 +1140,7 @@ bool Sync::scan(LocalPath* localpath, FileAccess* fa, LocalNode* localnode)
         {
             // prioritize handling of ignore files as they dictate how we
             // should handle this directory's contents.
-            do
+            if (initializing)
             {
                 ScopedLengthRestore restoreLen(*localpath);
 
@@ -1150,25 +1150,15 @@ bool Sync::scan(LocalPath* localpath, FileAccess* fa, LocalNode* localnode)
                   client->fsaccess->localseparator);
 
                 auto fileaccess = client->fsaccess->newfileaccess(client->followsymlinks);
-                if (!fileaccess->fopen(*localpath))
+                if (fileaccess->fopen(*localpath))
                 {
-                    break;
-                }
-
-                LocalNode* node = nullptr;
-
-                if (initializing)
-                {
-                    node = checkpath(NULL, localpath, NULL, NULL, false, NULL);
-                }
-
-                if (!node || node == (LocalNode*)~0)
-                {
-                    dirnotify->notify(DirNotify::DIREVENTS, NULL, LocalPath(*localpath));
+                    LocalNode* node = checkpath(NULL, localpath, NULL, NULL, false, NULL);
+                    if (!node || node == (LocalNode*)~0)
+                    {
+                        dirnotify->notify(DirNotify::DIREVENTS, NULL, LocalPath(*localpath));
+                    }
                 }
             }
-            while (false);
-
             nodetype_t type;
 
             while (da->dnext(*localpath, localname, client->followsymlinks, &type))

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1810,7 +1810,7 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
             dirnotify->notify(DirNotify::RETRY, ll, LocalPath(*localpathNew));
             client->syncfslockretry = true;
             client->syncfslockretrybt.backoff(SCANNING_DELAY_DS);
-            client->blockedfile = *localpathNew;
+            client->blockedFile(*this, *localpathNew);
         }
         else if (l)
         {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2440,5 +2440,63 @@ void MegaClientAsyncQueue::asyncThreadLoop()
     }
 }
 
+bool wildcardMatch(const char* pszString, const char* pszMatch)
+//  cf. http://www.planet-source-code.com/vb/scripts/ShowCode.asp?txtCodeId=1680&lngWId=3
+{
+    const char* cp = nullptr;
+    const char* mp = nullptr;
+
+    while ((*pszString) && (*pszMatch != '*'))
+    {
+        if ((*pszMatch != *pszString) && (*pszMatch != '?'))
+        {
+            return false;
+        }
+        pszMatch++;
+        pszString++;
+    }
+
+    while (*pszString)
+    {
+        if (*pszMatch == '*')
+        {
+            if (!*++pszMatch)
+            {
+                return true;
+            }
+            mp = pszMatch;
+            cp = pszString + 1;
+        }
+        else if ((*pszMatch == *pszString) || (*pszMatch == '?'))
+        {
+            pszMatch++;
+            pszString++;
+        }
+        else
+        {
+            pszMatch = mp;
+            pszString = cp++;
+        }
+    }
+    while (*pszMatch == '*')
+    {
+        pszMatch++;
+    }
+    return !*pszMatch;
+}
+
+bool wildcardMatch(const char* string, const string_vector &patterns)
+{
+    for (auto &pattern : patterns)
+    {
+        if (wildcardMatch(string, pattern.c_str()))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 } // namespace
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2440,6 +2440,58 @@ void MegaClientAsyncQueue::asyncThreadLoop()
     }
 }
 
+bool readLines(FileAccess& ifAccess, string_vector& destination)
+{
+    FileInputStream isAccess(&ifAccess);
+
+    return readLines(isAccess, destination);
+}
+
+bool readLines(InputStreamAccess& isAccess, string_vector& destination)
+{
+    std::string input(isAccess.size(), '\0');
+
+    return isAccess.read((byte*)input.data(), isAccess.size())
+           && readLines(input, destination);
+}
+
+bool readLines(const std::string& input, string_vector& destination)
+{
+    const char *current = input.data();
+    const char *end = current + input.size();
+
+    while (current < end && (*current == '\r' || *current == '\n'))
+    {
+        ++current;
+    }
+
+    while (current < end)
+    {
+        const char *delim = current;
+        const char *whitespace = current;
+
+        while (delim < end && *delim != '\r' && *delim != '\n')
+        {
+            ++delim;
+            whitespace += std::isspace(*whitespace) > 0;
+        }
+
+        if (delim != whitespace)
+        {
+            destination.emplace_back(current, delim);
+        }
+
+        while (delim < end && (*delim == '\r' || *delim == '\n'))
+        {
+            ++delim;
+        }
+
+        current = delim;
+    }
+
+    return true;
+}
+
 bool wildcardMatch(const char* pszString, const char* pszMatch)
 //  cf. http://www.planet-source-code.com/vb/scripts/ShowCode.asp?txtCodeId=1680&lngWId=3
 {

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -66,6 +66,39 @@ void WaitMillisec(unsigned n)
     usleep(n * 1000);
 #endif
 }
+
+bool createFile(const fs::path &path, const void *data, const size_t data_length)
+{
+#if (__cplusplus >= 201700L)
+    ofstream ostream(path, ios::binary);
+#else
+    ofstream ostream(path.u8string(), ios::binary);
+#endif
+
+    ostream.write(reinterpret_cast<const char *>(data), data_length);
+
+    return ostream.good();
+}
+
+bool createFile(const fs::path &path, const std::vector<uint8_t> &data)
+{
+    return createFile(path, data.data(), data.size());
+}
+
+bool createFile(const fs::path &p, const string &filename)
+{
+    return createFile(p / fs::u8path(filename), filename.data(), filename.size());
+}
+
+std::vector<uint8_t> randomData(const std::size_t length)
+{
+    std::vector<uint8_t> data(length);
+
+    std::generate_n(data.begin(), data.size(), [](){ return (uint8_t)std::rand(); });
+
+    return data;
+}
+
 struct Model
 {
     // records what we think the tree should look like after sync so we can confirm it
@@ -78,6 +111,46 @@ struct Model
         vector<uint8_t> data;
         vector<unique_ptr<ModelNode>> kids;
         ModelNode* parent = nullptr;
+        bool changed = false;
+
+        ModelNode() = default;
+
+        ModelNode(const ModelNode& other)
+          : type(other.type)
+          , name(other.name)
+          , data(other.data)
+          , kids()
+          , parent()
+          , changed(other.changed)
+        {
+            for (auto& child : other.kids)
+            {
+                addkid(std::make_unique<ModelNode>(*child));
+            }
+        }
+
+        void generate(const fs::path& path)
+        {
+            const fs::path ourPath = path / name;
+
+            if (type == file)
+            {
+                if (changed)
+                {
+                    ASSERT_TRUE(createFile(ourPath, data));
+                    changed = false;
+                }
+            }
+            else
+            {
+                fs::create_directory(ourPath);
+
+                for (auto& child : kids)
+                {
+                    child->generate(ourPath);
+                }
+            }
+        }
 
         string path() 
         {
@@ -86,11 +159,20 @@ struct Model
                 s = "/" + p->name + s;
             return s;
         }
-        void addkid(unique_ptr<ModelNode>&& p)
+
+        ModelNode* addkid()
+        {
+            return addkid(std::make_unique<ModelNode>());
+        }
+
+        ModelNode* addkid(unique_ptr<ModelNode>&& p)
         {
             p->parent = this;
             kids.emplace_back(move(p));
+
+            return kids.back().get();
         }
+
         bool typematchesnodetype(nodetype_t nodetype)
         {
             switch (type)
@@ -100,6 +182,7 @@ struct Model
             }
             return false;
         }
+
         void print(string prefix="")
         {
             cout << prefix << name << endl;
@@ -109,7 +192,6 @@ struct Model
                 in->print(prefix);
             }
         }
-
     };
 
     unique_ptr<ModelNode> makeModelSubfolder(const string& utf8Name)
@@ -307,13 +389,357 @@ struct Model
         }
     }
 
-    Model() : root(makeModelSubfolder("root"))
+    Model()
+      : root(makeModelSubfolder("root"))
     {
+    }
+
+    Model(const Model& other)
+      : root(std::make_unique<ModelNode>(*other.root))
+    {
+    }
+
+    Model& operator=(const Model &rhs)
+    {
+        Model temp(rhs);
+
+        swap(temp);
+
+        return *this;
+    }
+
+    ModelNode* addfile(const string& path,
+                       const void* data,
+                       const size_t data_length)
+    {
+        ModelNode* node = addnode(path, ModelNode::file);
+
+        node->data.resize(data_length);
+        memcpy(node->data.data(), data, data_length);
+
+        node->changed = true;
+
+        return node;
+    }
+
+    ModelNode* addfile(const string& path, const string& data)
+    {
+        return addfile(path, data.data(), data.size());
+    }
+
+    ModelNode* addfile(const string& path, const vector<uint8_t>& data)
+    {
+        return addfile(path, data.data(), data.size());
+    }
+
+    ModelNode* addfile(const string& path)
+    {
+        return addfile(path, path);
+    }
+
+    ModelNode* addfolder(const string& path)
+    {
+        return addnode(path, ModelNode::folder);
+    }
+
+    ModelNode* addnode(const string& path, ModelNode::nodetype type)
+    {
+        ModelNode* child;
+        ModelNode* node = root.get();
+        string name;
+        size_t current = 0;
+        size_t end = path.size();
+
+        while (current < end)
+        {
+            size_t delimiter = path.find('/', current);
+
+            if (delimiter == path.npos)
+            {
+                break;
+            }
+
+            name = path.substr(current, delimiter - current);
+
+            if (!(child = childnodebyname(node, name)))
+            {
+                child = node->addkid();
+
+                child->name = name;
+                child->type = ModelNode::folder;
+            }
+
+            assert(child->type == ModelNode::folder);
+
+            current = delimiter + 1;
+            node = child;
+        }
+
+        assert(current < end);
+
+        name = path.substr(current);
+
+        if (!(child = childnodebyname(node, name)))
+        {
+            child = node->addkid();
+
+            child->name = name;
+            child->type = type;
+        }
+
+        assert(child->type == type);
+
+        return child;
+    }
+
+    ModelNode* copynode(const string& src, const string& dst)
+    {
+        const ModelNode* source = findnode(src);
+        ModelNode* destination = addnode(dst, source->type);
+
+        destination->data = source->data;
+        destination->kids.clear();
+
+        for (auto& child : source->kids)
+        {
+            destination->addkid(std::make_unique<ModelNode>(*child));
+        }
+
+        return destination;
+    }
+
+    void generate(const fs::path& path)
+    {
+        fs::create_directories(path);
+
+        for (auto& child : root->kids)
+        {
+            child->generate(path);
+        }
+    }
+
+    void swap(Model& other)
+    {
+        using std::swap;
+
+        swap(root, other.root);
     }
 
     unique_ptr<ModelNode> root;
 };
 
+template<class T>
+struct PrinterTraits;
+
+template<>
+struct PrinterTraits<Model::ModelNode>
+{
+    using NodeType = Model::ModelNode;
+
+    static bool attached(const NodeType&)
+    {
+        return true;
+    }
+
+    static vector<NodeType*> children(const NodeType& node)
+    {
+        vector<NodeType*> result;
+
+        for (auto& child : node.kids)
+        {
+            result.emplace_back(child.get());
+        }
+
+        return result;
+    }
+
+    static bool ignored(const NodeType&)
+    {
+        return false;
+    }
+
+    static string name(const NodeType& node)
+    {
+        return node.name;
+    }
+
+    static string type()
+    {
+        return "ModelNode";
+    };
+}; /* PrinterTraits<Model::ModelNode> */
+
+template<>
+struct PrinterTraits<Node>
+{
+    using NodeType = Node;
+
+    static bool attached(const NodeType& node)
+    {
+        return node.localnode
+               && node.localnode->node == &node;
+    }
+
+    static vector<NodeType*> children(const NodeType& node)
+    {
+        vector<NodeType*> result;
+
+        for (auto& child : node.children)
+        {
+            result.emplace_back(child);
+        }
+
+        return result;
+    }
+
+    static bool ignored(const NodeType&)
+    {
+        return false;
+    }
+
+    static string name(const NodeType& node)
+    {
+        return node.displayname();
+    }
+
+    static string type()
+    {
+        return "Node";
+    }
+}; /* PrinterTraits<Node> */
+
+template<>
+struct PrinterTraits<LocalNode>
+{
+    using NodeType = LocalNode;
+
+    static bool attached(const NodeType& node)
+    {
+        return node.node
+               && node.node->localnode == &node;
+    }
+
+    static vector<NodeType*> children(const NodeType& node)
+    {
+        vector<NodeType*> result;
+
+        for (auto& child_it : node.children)
+        {
+            result.emplace_back(child_it.second);
+        }
+
+        return result;
+    };
+
+    static bool ignored(const NodeType& node)
+    {
+        return node.excluded();
+    }
+
+    static string name(const NodeType& node)
+    {
+        return node.name;
+    };
+
+    static string type()
+    {
+        return "LocalNode";
+    }
+}; /* PointerTraits<LocalNode> */
+
+class Printer
+{
+public:
+    template<class T>
+    void operator()(const T& node) const
+    {
+        print(node);
+    }
+
+    template<class T>
+    void print(const T& node) const
+    {
+        generateGraph(node);
+    }
+
+private:
+    template<class T>
+    void generateEdgeDef(const T& from, const T& to) const
+    {
+        cout << "\t"
+             << id(from)
+             << " -> "
+             << id(to)
+             << ";\n";
+    }
+
+    template<class T>
+    void generateEdgeDefs(const T& node) const
+    {
+        const auto children = PrinterTraits<T>::children(node);
+
+        for (auto& child : children)
+        {
+            generateEdgeDef(node, *child);
+        }
+
+        for (auto& child : children)
+        {
+            generateEdgeDefs(*child);
+        }
+    }
+
+    template<class T>
+    void generateGraph(const T& node) const
+    {
+        cout << "DOTBEGIN: "
+             << PrinterTraits<T>::type()
+             << "\n"
+             << "digraph {\n";
+
+        generateNodeDefs(node);
+        generateEdgeDefs(node);
+
+        cout << "}\n"
+             << "DOTEND\n";
+    }
+
+    template<class T>
+    void generateNodeDef(const T& node) const
+    {
+        bool isAttached =
+          PrinterTraits<T>::attached(node);
+        bool isIgnored =
+          PrinterTraits<T>::ignored(node);
+
+        cout << "\t"
+             << id(node)
+             << " [ label = \""
+             << PrinterTraits<T>::name(node)
+             << ":a"
+             << isAttached
+             << ",i"
+             << isIgnored
+             << "\" ]\n";
+    }
+
+    template<class T>
+    void generateNodeDefs(const T& node) const
+    {
+        generateNodeDef(node);
+
+        for (auto& child : PrinterTraits<T>::children(node))
+        {
+            generateNodeDefs(*child);
+        }
+    }
+
+    template<class T>
+    uintptr_t id(const T& node) const
+    {
+        return reinterpret_cast<uintptr_t>(&node);
+    }
+}; /* Printer */
 
 bool waitonresults(future<bool>* r1 = nullptr, future<bool>* r2 = nullptr, future<bool>* r3 = nullptr, future<bool>* r4 = nullptr)
 {
@@ -353,14 +779,22 @@ struct StandardClient : public MegaApp
     // thread as last member so everything else is initialised before we start it
     std::thread clientthread;
 
-    fs::path ensureDir(const fs::path& p)
+    string ensureDir(const fs::path& p)
     {
         fs::create_directories(p);
-        return p;
+
+        string result = p.u8string();
+
+        if (result.back() != fs::path::preferred_separator)
+        {
+            result += fs::path::preferred_separator;
+        }
+
+        return result;
     }
 
     StandardClient(const fs::path& basepath, const string& name)
-        : client_dbaccess_path(ensureDir(basepath / name / "").u8string())
+        : client_dbaccess_path(ensureDir(basepath / name / ""))
         , httpio(new HTTPIO_CLASS)
         , fsaccess(new FSACCESS_CLASS)
         , client(this, &waiter, httpio.get(), fsaccess.get(),
@@ -402,14 +836,14 @@ struct StandardClient : public MegaApp
         clientthread.join();
     }
 
-    void localLogout()
+    void localLogout(const bool clearCache = false)
     {
-        thread_do([](MegaClient& mc, promise<bool>&) {
+        thread_do([=](MegaClient& mc, promise<bool>&) {
             #ifdef _WIN32
                 // logout stalls in windows due to the issue above
                 mc.purgenodesusersabortsc(false);
             #else
-                mc.locallogout(false);
+                mc.locallogout(clearCache);
             #endif
         });
     }
@@ -417,41 +851,110 @@ struct StandardClient : public MegaApp
     static mutex om;
     bool logcb = false;
     chrono::steady_clock::time_point lastcb = std::chrono::steady_clock::now();
+
     string lp(LocalNode* ln) { return ln->getLocalPath().toName(*client.fsaccess, FS_UNKNOWN); }
-    void syncupdate_state(Sync*, syncstate_t state) override { if (logcb) { lock_guard<mutex> g(om);  cout << clientname << " syncupdate_state() " << state << endl; } }
-    void syncupdate_scanning(bool b) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_scanning()" << b << endl; } }
-    //void syncupdate_local_folder_addition(Sync* s, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_folder_addition() " << lp(ln) << " " << cp << endl; }}
-    //void syncupdate_local_folder_deletion(Sync*, LocalNode* ln) override { if (logcb) { lock_guard<mutex> g(om);  cout << clientname << " syncupdate_local_folder_deletion() " << lp(ln) << endl; }}
-    void syncupdate_local_folder_addition(Sync*, LocalNode* ln, const char* cp) override { lastcb = chrono::steady_clock::now(); }
-    void syncupdate_local_folder_deletion(Sync*, LocalNode* ln) override { lastcb = chrono::steady_clock::now(); }
-    void syncupdate_local_file_addition(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_file_addition() " << lp(ln) << " " << cp << endl; }}
-    void syncupdate_local_file_deletion(Sync*, LocalNode* ln) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_file_deletion() " << lp(ln) << endl; }}
-    void syncupdate_local_file_change(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_file_change() " << lp(ln) << " " << cp << endl; }}
-    void syncupdate_local_move(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_move() " << lp(ln) << " " << cp << endl; }}
-    void syncupdate_local_lockretry(bool b) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_lockretry() " << b << endl; }}
-    //void syncupdate_get(Sync*, Node* n, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_get()" << n->displaypath() << " " << cp << endl; }}
-    void syncupdate_put(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_put()" << lp(ln) << " " << cp << endl; }}
-    //void syncupdate_remote_file_addition(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_file_addition() " << n->displaypath() << endl; }}
-    //void syncupdate_remote_file_deletion(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_file_deletion() " << n->displaypath() << endl; }}
-    //void syncupdate_remote_folder_addition(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_folder_addition() " << n->displaypath() << endl; }}
-    //void syncupdate_remote_folder_deletion(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_folder_deletion() " << n->displaypath() << endl; }}
-    void syncupdate_remote_folder_addition(Sync*, Node* n) override { lastcb = chrono::steady_clock::now(); }
-    void syncupdate_remote_folder_deletion(Sync*, Node* n) override { lastcb = chrono::steady_clock::now(); }
-    void syncupdate_remote_copy(Sync*, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_copy() " << cp << endl; }}
-    //void syncupdate_remote_move(Sync*, Node* n1, Node* n2) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_move() " << n1->displaypath() << " " << n2->displaypath() << endl; }}
-    //void syncupdate_remote_rename(Sync*, Node* n, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_rename() " << n->displaypath() << " " << cp << endl; }}
-    //void syncupdate_treestate(LocalNode* ln) override { if (logcb) { lock_guard<mutex> g(om);   cout << clientname << " syncupdate_treestate() " << ln->ts << " " << ln->dts << " " << lp(ln) << endl; }}
 
+    void onCallback() { lastcb = chrono::steady_clock::now(); };
 
+    void syncupdate_state(Sync*, syncstate_t state) override { if (logcb) { lock_guard<mutex> g(om);  cout << clientname << " syncupdate_state() " << state << endl; } onCallback(); }
+    void syncupdate_scanning(bool b) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_scanning()" << b << endl; } onCallback(); }
+    //void syncupdate_local_folder_addition(Sync* s, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_folder_addition() " << lp(ln) << " " << cp << endl; } onCallback(); }
+    //void syncupdate_local_folder_deletion(Sync*, LocalNode* ln) override { if (logcb) { lock_guard<mutex> g(om);  cout << clientname << " syncupdate_local_folder_deletion() " << lp(ln) << endl; } onCallback(); }
+    void syncupdate_local_folder_addition(Sync*, LocalNode* ln, const char* cp) override { onCallback(); }
+    void syncupdate_local_folder_deletion(Sync*, LocalNode* ln) override { onCallback(); }
+    void syncupdate_local_file_addition(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_file_addition() " << lp(ln) << " " << cp << endl; } onCallback(); }
+    void syncupdate_local_file_deletion(Sync*, LocalNode* ln) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_file_deletion() " << lp(ln) << endl; } onCallback(); }
+    void syncupdate_local_file_change(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_file_change() " << lp(ln) << " " << cp << endl; } onCallback(); }
+    void syncupdate_local_move(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_move() " << lp(ln) << " " << cp << endl; } onCallback(); }
+    void syncupdate_local_lockretry(bool b) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_local_lockretry() " << b << endl; } onCallback(); }
+    //void syncupdate_get(Sync*, Node* n, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_get()" << n->displaypath() << " " << cp << endl; } onCallback(); }
+    void syncupdate_put(Sync*, LocalNode* ln, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_put()" << lp(ln) << " " << cp << endl; } onCallback(); }
+    void syncupdate_remote_file_addition(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_file_addition() " << n->displaypath() << endl; } onCallback(); }
+    void syncupdate_remote_file_deletion(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_file_deletion() " << n->displaypath() << endl; } onCallback(); }
+    //void syncupdate_remote_folder_addition(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_folder_addition() " << n->displaypath() << endl; } onCallback(); }
+    //void syncupdate_remote_folder_deletion(Sync*, Node* n) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_folder_deletion() " << n->displaypath() << endl; } onCallback(); }
+    void syncupdate_remote_folder_addition(Sync*, Node* n) override { onCallback(); }
+    void syncupdate_remote_folder_deletion(Sync*, Node* n) override { onCallback(); }
+    void syncupdate_remote_copy(Sync*, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_copy() " << cp << endl; } onCallback(); }
+    void syncupdate_remote_move(Sync*, Node* n1, Node* n2) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_move() " << n1->displaypath() << " " << n2->displaypath() << endl; } onCallback(); }
+    void syncupdate_remote_rename(Sync*, Node* n, const char* cp) override { if (logcb) { lock_guard<mutex> g(om); cout << clientname << " syncupdate_remote_rename() " << n->displaypath() << " " << cp << endl; } onCallback(); }
+    //void syncupdate_treestate(LocalNode* ln) override { if (logcb) { lock_guard<mutex> g(om);   cout << clientname << " syncupdate_treestate() " << ln->ts << " " << ln->dts << " " << lp(ln) << endl; } onCallback(); }
+
+    bool sync_syncable(Sync* sync, const char *name, LocalPath& localPath, Node*) override
+    {
+        return sync_syncable(sync, name, localPath);
+    }
+
+    bool sync_syncable(Sync*, const char *name, LocalPath& localPath) override
+    {
+        if (logcb)
+        {
+            lock_guard<mutex> guard(om);
+
+            cout << clientname
+                 << " sync_syncable(): name = "
+                 << name
+                 << ", localPath = "
+                 << localPath.toPath(*client.fsaccess)
+                 << endl;
+        }
+
+        return !wildcardMatch(name, mExcludedNames);
+    }
+
+    vector<string> mExcludedNames;
     
     std::atomic<unsigned> transfersAdded{0}, transfersRemoved{0}, transfersPrepared{0}, transfersFailed{0}, transfersUpdated{0}, transfersComplete{0};
-    void transfer_added(Transfer*) override { ++transfersAdded; }
-    void transfer_removed(Transfer*) override { ++transfersRemoved; }
-    void transfer_prepare(Transfer*) override { ++transfersPrepared; }
-    void transfer_failed(Transfer*,  const Error&, dstime = 0) override { ++transfersFailed; }
-    void transfer_update(Transfer*) override { ++transfersUpdated; }
-    void transfer_complete(Transfer*) override { ++transfersComplete; }
 
+    std::set<Transfer*> mTransfers;
+
+    void transfer_added(Transfer* transfer) override
+    {
+        onCallback();
+
+        mTransfers.emplace(transfer);
+
+        ++transfersAdded;
+    }
+
+    void transfer_removed(Transfer* transfer) override
+    {
+        onCallback();
+
+        mTransfers.erase(transfer);
+
+        ++transfersRemoved;
+    }
+
+    void transfer_prepare(Transfer*) override
+    {
+        onCallback();
+        ++transfersPrepared;
+    }
+
+    void transfer_failed(Transfer* transfer, const Error&, dstime = 0) override
+    {
+        onCallback();
+
+        mTransfers.erase(transfer);
+
+        ++transfersFailed;
+    }
+
+    void transfer_update(Transfer*) override
+    {
+        onCallback();
+        ++transfersUpdated;
+    }
+
+    void transfer_complete(Transfer* transfer) override
+    {
+        onCallback();
+
+        mTransfers.erase(transfer);
+
+        ++transfersComplete;
+    }
 
     void threadloop()
         try
@@ -529,7 +1032,16 @@ struct StandardClient : public MegaApp
         return nextfunctionSCpromise.get_future();
     }
 
-    enum resultprocenum { PRELOGIN, LOGIN, FETCHNODES, PUTNODES, UNLINK, MOVENODE };
+    enum resultprocenum
+    {
+        PRELOGIN,
+        LOGIN,
+        FETCHNODES,
+        PUTNODES,
+        UNLINK,
+        MOVENODE,
+        SETATTR
+    };
 
     void preloginFromEnv(const string& userenv, promise<bool>& pb)
     {
@@ -645,28 +1157,61 @@ struct StandardClient : public MegaApp
             entry.emplace_back(move(f), h);
         }
 
+        bool emittedFromSync(resultprocenum rpe) const
+        {
+            return rpe == MOVENODE
+                   || rpe == SETATTR;
+        }
+
+        const char* resultFunction(resultprocenum rpe) const
+        {
+            switch (rpe)
+            {
+            case FETCHNODES:
+                return "fetchnodes_result";
+            case LOGIN:
+                return "login_result";
+            case MOVENODE:
+                return "rename_result";
+            case PRELOGIN:
+                return "prelogin_result";
+            case PUTNODES:
+                return "putnodes_result";
+            case SETATTR:
+                return "setattr_result";
+            case UNLINK:
+                return "unlink_result";
+            default:
+                break;
+            }
+
+            assert(!"Unhandled result proc enumerant");
+
+            // Silence the compiler.
+            return "UNHANDLED";
+        }
+
         void processresult(resultprocenum rpe, error e, handle h = UNDEF)
         {
             //cout << "procenum " << rpe << " result " << e << endl;
             auto& entry = m[rpe];
-            if (rpe == MOVENODE)
+
+            // make sure this result doesn't originate from a sync.
+            if (emittedFromSync(rpe)
+                && (entry.empty() || entry.front().h != h))
             {
-                // rename_result is called back for our app requests but also for sync objects as well, so we need to skip those... todo: should we change that?
-                if (entry.empty() || entry.front().h != h)
-                {
-                    cout << "received unsolicited rename_result call" << endl;
-                    return;
-                }
+                cout << "received unsolicited "
+                     << resultFunction(rpe)
+                     << " call"
+                     << endl;
+
+                return;
             }
-            if (!entry.empty())
-            {
-                entry.front().f(e);
-                entry.pop_front();
-            }
-            else
-            {
-                assert(!entry.empty());
-            }
+
+            assert(entry.size());
+
+            entry.front().f(e);
+            entry.pop_front();
         }
     } resultproc;
 
@@ -993,7 +1538,13 @@ struct StandardClient : public MegaApp
         }
         for (auto& n2 : n->children)
         {
-            if (!n2.second->deleted) ns.emplace(n2.second->name, n2.second); // todo: should LocalNodes marked as deleted actually have been removed by now?
+            LocalNode& child = *n2.second;
+
+            if (!(child.deleted || child.excluded()))
+            {
+                // todo: should LocalNodes marked as deleted actually have been removed by now?
+                ns.emplace(child.name, &child);
+            }
         }
 
         int matched = 0;
@@ -1069,7 +1620,7 @@ struct StandardClient : public MegaApp
             std::vector<uint8_t> buffer;
             std::ifstream istream(p, ios::binary);
 
-            buffer.reserve(mn->data.size());
+            buffer.resize(mn->data.size());
 
             istream.read(reinterpret_cast<char *>(buffer.data()), buffer.capacity());
 
@@ -1179,6 +1730,19 @@ struct StandardClient : public MegaApp
         if (confirm & CONFIRM_REMOTE && !recursiveConfirm(mnode, client.nodebyhandle(si->second.h), descendants, "Sync " + to_string(syncid), 0, firstreported))
         {
             cout << clientname << " syncid " << syncid << " comparison against remote nodes failed" << endl;
+
+            auto root = client.nodebyhandle(si->second.h);
+            auto sync = syncByTag(syncid);
+
+            assert(root);
+            assert(sync);
+            
+            Printer p;
+
+            p(*mnode);
+            p(*sync->localroot);
+            p(*root);
+
             return false;
         }
 
@@ -1228,6 +1792,11 @@ struct StandardClient : public MegaApp
         resultproc.processresult(FETCHNODES, e);
     }
 
+    void setattr_result(handle h, error e) override
+    {
+        resultproc.processresult(SETATTR, e, h);
+    }
+
     void unlink_result(handle, error e) override
     { 
         resultproc.processresult(UNLINK, e);
@@ -1247,17 +1816,59 @@ struct StandardClient : public MegaApp
         resultproc.processresult(MOVENODE, e, h);
     }
 
+    bool deleteremote(const string& path)
+    {
+        future<bool> result =
+          thread_do([=](StandardClient& client, promise<bool>& result)
+                    {
+                        client.deleteremote(path, result);
+                    });
+
+        return result.get();
+    }
+
     void deleteremote(string path, promise<bool>& pb )
     {
         if (Node* n = drillchildnodebyname(gettestbasenode(), path))
         {
-        resultproc.prepresult(UNLINK, [ &pb](error e) { pb.set_value(!e); });
+            resultproc.prepresult(UNLINK, [&pb](error e) { pb.set_value(!e); });
             client.unlink(n);
         }
         else
         {
             pb.set_value(false);
         }
+    }
+
+    bool deleteremotedebris()
+    {
+        future<bool> result =
+          thread_do([](StandardClient& client, promise<bool>& result)
+                    {
+                        client.deleteremotedebris(result);
+                    });
+
+        return result.get();
+    }
+
+    void deleteremotedebris(promise<bool>& result)
+    {
+        Node* debris =
+          drillchildnodebyname(getcloudrubbishnode(), "SyncDebris");
+
+        if (debris)
+        {
+            deleteremotenode(debris, result);
+        }
+        else
+        {
+            result.set_value(true);
+        }
+    }
+
+    void deleteremotenode(Node* n, promise<bool>& pb)
+    {
+        deleteremotenodes(vector<Node*>(1, n), pb);
     }
 
     void deleteremotenodes(vector<Node*> ns, promise<bool>& pb)
@@ -1276,10 +1887,21 @@ struct StandardClient : public MegaApp
         }
     }
 
+    bool movenode(const string& currentPath, const string& newParentPath)
+    {
+        future<bool> result =
+          thread_do([=](StandardClient& client, promise<bool>& result)
+                    {
+                        client.movenode(currentPath, newParentPath, result);
+                    });
+
+        return result.get();
+    }
+
     void movenode(string path, string newparentpath, promise<bool>& pb)
     {
         Node* n = drillchildnodebyname(gettestbasenode(), path);
-        Node* p = drillchildnodebyname(gettestbasenode(), path);
+        Node* p = drillchildnodebyname(gettestbasenode(), newparentpath);
         if (n && p)
         {
             resultproc.prepresult(MOVENODE, [&pb](error e) { pb.set_value(!e); }, n->nodehandle);
@@ -1318,7 +1940,58 @@ struct StandardClient : public MegaApp
         pb.set_value(false);
     }
 
+    bool setattr(Node& node)
+    {
+        future<bool> result =
+          thread_do([&](StandardClient& client, promise<bool>& result)
+                    {
+                        client.setattr(node, result);
+                    });
 
+        return result.get();
+    }
+
+    void setattr(Node& node, promise<bool>& result)
+    {
+        resultproc.prepresult(SETATTR,
+                              [&](error e)
+                              {
+                                  result.set_value(!e);
+                              },
+                              node.nodehandle);
+
+        client.setattr(&node);
+    }
+
+    bool putnodes(handle parentHandle, NewNode* newNodes, int numNodes)
+    {
+        future<bool> result =
+          thread_do([=](StandardClient& client, promise<bool>& result)
+                    {
+                        client.putnodes(parentHandle, newNodes, numNodes, result);
+                    });
+
+        return result.get();
+    }
+
+    void putnodes(handle parentHandle,
+                  NewNode* newNodes,
+                  int numNodes,
+                  promise<bool>& result)
+    {
+        resultproc.prepresult(PUTNODES,
+                              [&](error e)
+                              {
+                                  result.set_value(!e);
+                              });
+
+        client.putnodes(parentHandle, newNodes, numNodes);
+    }
+
+    void putnodes_prepareOneFolder(NewNode& node, const string &name)
+    {
+        client.putnodes_prepareOneFolder(&node, name);
+    }
 
     void waitonsyncs(chrono::seconds d = chrono::seconds(2))
     {
@@ -1368,6 +2041,11 @@ struct StandardClient : public MegaApp
 
     }
 
+    bool login_reset()
+    {
+        return login_reset("MEGA_EMAIL", "MEGA_PWD");
+    }
+
     bool login_reset(const string& user, const string& pw)
     {
         future<bool> p1;
@@ -1401,6 +2079,11 @@ struct StandardClient : public MegaApp
         return true;
     }
 
+    bool login_reset_makeremotenodes(const string& prefix, int depth = 0, int fanout = 0)
+    {
+        return login_reset_makeremotenodes("MEGA_EMAIL", "MEGA_PWD", prefix, depth, fanout);
+    }
+
     bool login_reset_makeremotenodes(const string& user, const string& pw, const string& prefix, int depth, int fanout)
     {
         if (!login_reset(user, pw))
@@ -1415,6 +2098,11 @@ struct StandardClient : public MegaApp
             return false;
         }
         return true;
+    }
+
+    bool login_fetchnodes(bool makeBaseFolder = false)
+    {
+        return login_fetchnodes("MEGA_EMAIL", "MEGA_PWD", makeBaseFolder);
     }
 
     bool login_fetchnodes(const string& user, const string& pw, bool makeBaseFolder = false)
@@ -1477,68 +2165,85 @@ struct StandardClient : public MegaApp
         fb = thread_do([syncid, mnode, ignoreDebris, confirm](StandardClient& sc, promise<bool>& pb) { pb.set_value(sc.confirmModel(syncid, mnode, confirm, ignoreDebris)); });
         return fb.get();
     }
-
 };
-
 
 void waitonsyncs(chrono::seconds d = std::chrono::seconds(4), StandardClient* c1 = nullptr, StandardClient* c2 = nullptr, StandardClient* c3 = nullptr, StandardClient* c4 = nullptr)
 {
-    auto start = chrono::steady_clock::now();
     std::vector<StandardClient*> v{ c1, c2, c3, c4 };
     bool onelastsyncdown = true;
+    bool last_add_del = false;
+    bool last_all_idle = false;
+    auto start = chrono::steady_clock::now();
+
+    v.erase(std::remove(v.begin(), v.end(), nullptr), v.end());
+
     for (;;)
     {
-        bool any_add_del = false;
-        vector<int> syncstates;
+        bool curr_add_del = false;
+        bool curr_all_idle;
+        bool changed;
 
-        for (auto vn : v) if (vn)
+        for (auto vn : v)
         {
-            vn->thread_do([&syncstates, &any_add_del](StandardClient& mc, promise<bool>&)
-            {
-                for (auto& sync : mc.client.syncs)
-                {
-                    syncstates.push_back(sync->state);
-                    if (sync->deleteq.size() || sync->insertq.size())
-                        any_add_del = true;
-                }
-                if (!(mc.client.todebris.empty() && mc.client.tounlink.empty() && mc.client.synccreate.empty() 
-                    && mc.client.transferlist.transfers[GET].empty() && mc.client.transferlist.transfers[PUT].empty()))
-                {
-                    any_add_del = true;
-                }
-            });
+            auto result = 
+              vn->thread_do([&](StandardClient& sc, promise<bool>& result)
+                            {
+                                bool any_add_del = false;
+
+                                for (auto& sync : sc.client.syncs)
+                                {
+                                    any_add_del |= sync->deleteq.size() > 0;
+                                    any_add_del |= sync->deleteq.size() > 0;
+                                }
+
+                                any_add_del |= sc.client.nodenotify.size() > 0;
+                                any_add_del |= sc.client.synccreate.size() > 0;
+                                any_add_del |= sc.client.todebris.size() > 0;
+                                any_add_del |= sc.client.tounlink.size() > 0;
+                                any_add_del |= sc.client.transferlist.transfers[GET].size() > 0;
+                                any_add_del |= sc.client.transferlist.transfers[PUT].size() > 0;
+
+                                result.set_value(any_add_del);
+                            });
+
+            curr_add_del |= result.get();
         }
 
-        bool allactive = true;
-        {
-            //lock_guard<mutex> g(StandardClient::om);
-            //std::cout << "sync state: ";
-            //for (auto n : syncstates)
-            //{
-            //    cout << n;
-            //    if (n != SYNC_ACTIVE) allactive = false;
-            //}
-            //cout << endl;
-        }
+        changed = curr_add_del ^ last_add_del;
 
-        if (any_add_del || StandardClient::debugging)
+        if (curr_add_del || changed || StandardClient::debugging)
         {
             start = chrono::steady_clock::now();
         }
 
         if (onelastsyncdown && (chrono::steady_clock::now() - start + d/2) > d)
         {
+            start = chrono::steady_clock::now();
+
             // synced folders that were removed remotely don't have the corresponding local folder removed unless we prompt an extra syncdown.  // todo:  do we need to fix
-            for (auto vn : v) if (vn) vn->client.syncdownrequired = true;
+            for (auto vn : v)
+            {
+                vn->client.syncdownrequired = true;
+            }
+
             onelastsyncdown = false;
         }
 
-        for (auto vn : v) if (vn)
+        curr_all_idle =
+          std::all_of(v.begin(),
+                      v.end(),
+                      [&](StandardClient* sc) -> bool
+                      {
+                          auto now = chrono::steady_clock::now();
+                          return (now - start) > d && (now - sc->lastcb) > d;
+                      });
+
+        changed = curr_all_idle ^ last_all_idle;
+        last_all_idle = curr_all_idle;
+
+        if (curr_all_idle && !changed)
         {
-            if (allactive && ((chrono::steady_clock::now() - start) > d) && ((chrono::steady_clock::now() - vn->lastcb) > d))
-            {
-                return;
-            }
+            return;
         }
 
         WaitMillisec(400);
@@ -1571,35 +2276,12 @@ fs::path makeNewTestRoot(fs::path p)
     #ifndef NDEBUG
     bool b =
     #endif
-    fs::create_directory(p);
+    fs::create_directories(p);
     assert(b);
     return p;
 }
 
 //std::atomic<int> fileSizeCount = 20;
-
-bool createFile(const fs::path &path, const void *data, const size_t data_length)
-{
-#if (__cplusplus >= 201700L)
-    ofstream ostream(path, ios::binary);
-#else
-    ofstream ostream(path.u8string(), ios::binary);
-#endif
-
-    ostream.write(reinterpret_cast<const char *>(data), data_length);
-
-    return ostream.good();
-}
-
-bool createFile(const fs::path &path, const std::vector<uint8_t> &data)
-{
-    return createFile(path, data.data(), data.size());
-}
-
-bool createFile(const fs::path &p, const string &filename)
-{
-    return createFile(p / fs::u8path(filename), filename.data(), filename.size());
-}
 
 bool createFileWithTimestamp(const fs::path &path,
                              const std::vector<uint8_t> &data,
@@ -1756,15 +2438,6 @@ public:
     const fs::path &localRoot(const StandardClient &client) const
     {
         return client.syncSet.at(0).localpath;
-    }
-
-    std::vector<uint8_t> randomData(const std::size_t length) const
-    {
-        std::vector<uint8_t> data(length);
-
-        std::generate_n(data.begin(), data.size(), [](){ return (uint8_t)std::rand(); });
-
-        return data;
     }
 
     void startSyncs()
@@ -3122,4 +3795,3570 @@ GTEST_TEST(Sync, BasicSync_CreateAndReplaceLinkUponSyncDown)
 
 #endif
 
+class FilterFixture
+  : public ::testing::Test
+{
+public:
+    struct Client
+      : public StandardClient
+    {
+        Client(const fs::path& basePath, const string& name)
+          : StandardClient(basePath, name)
+          , mOnFileAdded()
+          , mOnFileComplete()
+        {
+            localNodesMustHaveNodes = false;
+        };
+
+        void file_added(File* file) override
+        {
+            if (mOnFileAdded)
+            {
+                mOnFileAdded(*file);
+            }
+        }
+
+        void file_complete(File* file) override
+        {
+            if (mOnFileComplete)
+            {
+                mOnFileComplete(*file);
+            }
+        }
+
+        Node* nodebyhandle(handle h)
+        {
+            return client.nodebyhandle(h);
+        }
+
+        void syncupdate_filter_error(Sync*, LocalNode* node) override
+        {
+            if (mOnFilterError)
+            {
+                mOnFilterError(*node);
+            }
+        }
+
+        function<void(File&)> mOnFileAdded;
+        function<void(File&)> mOnFileComplete;
+        function<void(LocalNode&)> mOnFilterError;
+    };
+
+    struct LocalFSModel
+      : public Model
+    {
+        LocalFSModel() = default;
+
+        LocalFSModel(const Model& other)
+          : Model(other)
+        {
+        }
+
+        LocalFSModel &operator=(const Model& other)
+        {
+            Model::operator=(other);
+            return *this;
+        }
+    }; /* LocalFSModel */
+
+    struct LocalNodeModel
+      : public Model
+    {
+        LocalNodeModel() = default;
+
+        LocalNodeModel(const Model& other)
+          : Model(other)
+        {
+        }
+
+        LocalNodeModel& operator=(const Model& other)
+        {
+            Model::operator=(other);
+            return *this;
+        }
+    }; /* LocalNodeModel */
+
+    struct RemoteNodeModel
+      : public Model
+    {
+        RemoteNodeModel() = default;
+
+        RemoteNodeModel(const Model& other)
+          : Model(other)
+        {
+        }
+
+        RemoteNodeModel& operator=(const Model& other)
+        {
+            Model::operator=(other);
+            return *this;
+        }
+    }; /* RemoteNodeModel */
+
+    FilterFixture()
+      : cd()
+      , cdu()
+      , cu()
+    {
+        const fs::path root = makeNewTestRoot(LOCAL_TEST_FOLDER);
+
+        cd  = std::make_unique<Client>(root, "cd");
+        cdu = std::make_unique<Client>(root, "cdu");
+        cu  = std::make_unique<Client>(root, "cu");
+
+        cd->logcb = true;
+        cdu->logcb = true;
+        cu->logcb = true;
+    }
+
+    bool confirm(Client& client,
+                 LocalFSModel& model,
+                 const int syncID = 0,
+                 const bool ignoreDebris = true)
+    {
+        return client.confirmModel_mainthread(
+                 model.root.get(),
+                 syncID,
+                 ignoreDebris,
+                 StandardClient::CONFIRM_LOCALFS);
+    }
+
+    bool confirm(Client& client,
+                 LocalNodeModel& model,
+                 const int syncID = 0,
+                 const bool ignoreDebris = true)
+    {
+        return client.confirmModel_mainthread(
+                 model.root.get(),
+                 syncID,
+                 ignoreDebris,
+                 StandardClient::CONFIRM_LOCALNODE);
+    }
+
+    bool confirm(Client& client,
+                 Model& model,
+                 const int syncID = 0,
+                 const bool ignoreDebris = true)
+    {
+        return client.confirmModel_mainthread(
+                 model.root.get(),
+                 syncID,
+                 ignoreDebris);
+    }
+
+    bool confirm(Client& client,
+                 RemoteNodeModel& model,
+                 const int syncID = 0,
+                 const bool ignoreDebris = true)
+    {
+        return client.confirmModel_mainthread(
+                 model.root.get(),
+                 syncID,
+                 ignoreDebris,
+                 StandardClient::CONFIRM_REMOTE);
+    }
+
+    string debrisFilePath(const string& debrisName,
+                          const string& path) const
+    {
+        ostringstream ostream;
+
+        ostream << debrisName
+                << "/"
+                << todaysDate()
+                << "/"
+                << path;
+              
+        return ostream.str();
+    }
+
+    fs::path root(Client& client) const
+    {
+        return client.fsBasePath;
+    }
+
+    bool setupSync(Client& client,
+                   const string& localFolder,
+                   const int syncID = 0)
+    {
+        return setupSync(client, localFolder, client.clientname, syncID);
+    }
+
+    bool setupSync(Client& client,
+                   const string& localFolder,
+                   const string& remoteFolder,
+                   const int syncID = 0)
+    {
+        return client.setupSync_mainthread(localFolder,
+                                           remoteFolder,
+                                           syncID);
+    }
+
+    string todaysDate() const
+    {
+        size_t minimumLength = strlen("yyyy-mm-dd");
+
+        string result(minimumLength + 1, 'X');
+
+        time_t rawTime = time(nullptr);
+        tm* localTime = localtime(&rawTime);
+
+        assert(strftime(&result[0], result.size(), "%F", localTime));
+        result.resize(minimumLength);
+
+        return result;
+    }
+
+    void waitOnSyncs(Client* c0,
+                     Client* c1 = nullptr,
+                     Client* c2 = nullptr)
+    {
+        static chrono::seconds timeout(4);
+
+        waitonsyncs(timeout, c0, c1, c2);
+    }
+
+    // download client.
+    std::unique_ptr<Client> cd;
+    // download / upload client.
+    std::unique_ptr<Client> cdu;
+    // upload client.
+    std::unique_ptr<Client> cu;
+}; /* FilterFixture */
+
+TEST_F(FilterFixture, CaseSensitiveFilter)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up filesystem.
+    localFS.addfile("a/f");
+    localFS.addfile("a/g");
+    localFS.addfile("b/F");
+    localFS.addfile("b/G");
+    localFS.addfile(".megaignore", "-G:f\n-:g\n");
+    localFS.generate(root(*cu) / "root");
+
+    // Set up local node tree.
+    localTree = localFS;
+    localTree.removenode("a/f");
+    localTree.removenode("a/g");
+    localTree.removenode("b/G");
+
+    // Remote node tree is consistent with local node tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for synchronization.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(FilterFixture, FilterChangeWhileDownloading)
+{
+    // Random file data.
+    const auto data = randomData(16384);
+
+    // Ignore file data.
+    const string ignoreFile = "-:f";
+   
+    // Set up cloud.
+    {
+        // Build and generate model.
+        Model model;
+
+        model.addfile("f", data);
+        model.generate(root(*cu) / "root");
+
+        // Log in client.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+
+        // Add and start sync.
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        // Wait for synchronization to complete.
+        waitOnSyncs(cu.get());
+
+        // Confirm model.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Log out client.
+        cu.reset();
+    }
+
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile(".megaignore", ignoreFile);
+    localFS.addfile("f", data);
+
+    // Set up local model.
+    localTree = localFS;
+    localTree.removenode("f");
+    
+    // Set up remote model.
+    remoteTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_fetchnodes());
+
+    // Set download speed limit at 1kbps.
+    cdu->client.setmaxdownloadspeed(1024);
+
+    // Exclude "x" once it begins downloading.
+    cdu->mOnFileAdded =
+      [&](File& file)
+      {
+          string name;
+
+          file.displayname(&name);
+
+          if (name != "f")
+          {
+              return;
+          }
+
+          ASSERT_TRUE(createFile(root(*cdu) / "root" / ".megaignore",
+                                 ignoreFile.data(),
+                                 ignoreFile.size()));
+      };
+
+    // Remove download limit once .megaignore is uploaded.
+    cdu->mOnFileComplete =
+      [&](File& file)
+      {
+          string name;
+
+          file.displayname(&name);
+
+          // Make sure .megaignore completes first.
+          ASSERT_TRUE(name == ".megaignore"
+                      || cdu->client.getmaxdownloadspeed() == 0);
+
+          // Remove limit when .megaignore completes.
+          if (name == ".megaignore")
+          {
+              cdu->client.setmaxdownloadspeed(0);
+          }
+      };
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(FilterFixture, FilterChangeWhileUploading)
+{
+    // Random file data.
+    const auto data = randomData(16384);
+
+    // Ignore file data.
+    const string ignoreFile = "-:f";
+
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile("f");
+    localFS.generate(root(*cdu) / "root");
+    localFS.addfile(".megaignore", ignoreFile);
+
+    // Set up local tree.
+    localTree = localFS;
+    localTree.removenode("f");
+
+    // Set up remote tree.
+    remoteTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes("x"));
+
+    // Set upload speed limit to 1kbps.
+    cdu->client.setmaxuploadspeed(1024);
+    
+    cdu->mOnFileAdded =
+      [&](File& file)
+      {
+          string name;
+
+          file.displayname(&name);
+
+          // remove speed limit when .megaignore starts uploading.
+          if (name == ".megaignore")
+          {
+              cdu->client.setmaxuploadspeed(0);
+          }
+
+          // create .megaignore when f starts uploading.
+          if (name == "f")
+          {
+              ASSERT_TRUE(createFile(root(*cdu) / "root" / ".megaignore",
+                                     ignoreFile.data(),
+                                     ignoreFile.size()));
+          }
+      };
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(FilterFixture, GlobalFilter)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Configure global filters.
+    cu->mExcludedNames.emplace_back("*~");
+
+    // Setup local FS.
+    localFS.addfile(".megaignore", "+:b~");
+    localFS.addfile("d/a~");
+    localFS.addfile("d/b~");
+    localFS.addfile("a~");
+    localFS.addfile("b~");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("d/a~");
+    localTree.removenode("a~");
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(FilterFixture, NameFilter)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile(".megaignore",
+                    // exclude all *.n* in the tree.
+                    "-:*.n*\n"
+                    // include all *.ni in the tree.
+                    "+:*.ni\n"
+                    // include all *.nN in the root.
+                    "+N:*.nN\n"
+                    // exclude all *.X* in the root.
+                    "-N:*.X*\n"
+                    // include all *.Xi in the root.
+                    "+N:*.Xi\n");
+
+    // excluded by -:*.n*
+    localFS.addfile("d/df.n");
+    // included by +:*.ni
+    localFS.addfile("d/df.ni");
+    // excluded by -:*.n*
+    localFS.addfile("d/df.nN");
+    // included as no matching exclusion rule.
+    localFS.addfile("d/df.X");
+    // excluded by -:*.n*
+    localFS.addfile("f.n");
+    // included by +:*.ni
+    localFS.addfile("f.ni");
+    // excluded by -:*.n*
+    localFS.addfile("f.nN");
+    // excluded by -N:*.X*
+    localFS.addfile("f.X");
+    // included by +N:*.Xi
+    localFS.addfile("f.Xi");
+    // excluded by -:*.n*
+    localFS.addfile("d.n/f.ni");
+
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local tree.
+    localTree = localFS;
+
+    localTree.removenode("d/df.n");
+    localTree.removenode("d/df.nN");
+    localTree.removenode("f.n");
+    localTree.removenode("f.X");
+    localTree.removenode("d.n");
+
+    // Setup remote tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(FilterFixture, PathFilter)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile(".megaignore",
+                    // exclude path d*/d*
+                    "-p:d*/d*\n"
+                    // include path di*/di*
+                    "+p:di*/di*\n"
+                    // include path dL
+                    "+p:dL\n"
+                    // include everything under dJ
+                    "+p:dJ*\n");
+
+    // excluded by -p:d*/d*
+    localFS.addfile("d/d/f");
+    // included as no matching rule.
+    localFS.addfile("d/f");
+    // included by +p:di*/di*
+    localFS.addfile("di/di/f");
+    // included as no matching rule.
+    localFS.addfile("di/f");
+    // excluded by -p:d*/d*
+    localFS.addfile("dL/d/f");
+    // included by +p:dL
+    localFS.addfile("dL/f");
+    // included by +p:dJ*
+    localFS.addfile("dJ/d/f");
+    localFS.addfile("dJ/f");
+
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local tree.
+    localTree = localFS;
+    localTree.removenode("d/d");
+    localTree.removenode("dL/d");
+
+    // Setup remote tree.
+    remoteTree = localTree;
+        
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(FilterFixture, TargetSpecificFilter)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local filesystem.
+    {
+        const string ignoreFile =
+          // Exclude directories matching *a.
+          "-d:*a\n"
+          // Exclude files matching *b.
+          "-f:*b\n"
+          // Exclude anything matching *c.
+          "-:*c\n"
+          // Include everything containing an x.
+          "+:*x*\n";
+
+        localFS.addfile("da/fa", "fa");
+        localFS.addfile("da/fb", "fb");
+        localFS.addfile("da/fc", "fc");
+        localFS.addfile("da/fxb", "fxb");
+        localFS.addfile("da/fxc", "fxc");
+        localFS.addfile(".megaignore", ignoreFile);
+        localFS.addfile("fa");
+        localFS.addfile("fb");
+        localFS.addfile("fxb");
+        localFS.addfile("fc");
+        localFS.addfile("fxc");
+        localFS.copynode("da", "db");
+        localFS.copynode("da", "dc");
+        localFS.copynode("da", "dxa");
+        localFS.copynode("da", "dxc");
+
+        localFS.generate(root(*cu) / "root");
+    }
+
+    // Set up local node tree.
+    localTree = localFS;
+
+    // Excluded by -d:*a
+    localTree.removenode("da");
+
+    // Excluded by -f:*b
+    localTree.removenode("db/fb");
+    localTree.removenode("dxa/fb");
+    localTree.removenode("dxc/fb");
+    localTree.removenode("fb");
+
+    // Excluded by -:*c
+    localTree.removenode("db/fc");
+    localTree.removenode("dc");
+    localTree.removenode("dxa/fc");
+    localTree.removenode("dxc/fc");
+    localTree.removenode("fc");
+
+    // Remote node tree is consistent with local node tree.
+    remoteTree = localTree;
+
+    // Log in the client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start the sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(FilterFixture, ToggleFunctionality)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup global filters.
+    // These are always active.
+    cdu->mExcludedNames.emplace_back("*~");
+
+    // Setup models.
+    localFS.addfile("d/f");
+    localFS.addfile("g");
+    localFS.addfile("h~");
+    localFS.addfile(".megaignore", "-:d\n-:g\n");
+    localFS.generate(root(*cdu) / "root");
+
+    localTree = localFS;
+    localTree.removenode("h~");
+    remoteTree = localTree;
+
+    // Disable ignore file functionality.
+    // (Shortcut here as the client's not active.)
+    cdu->client.ignoreFilesEnabled = false;
+
+    // Log in the client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for sync.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Enable ignore file functionality.
+    cdu->thread_do([](MegaClient& client, promise<bool>&)
+                   {
+                       // MegaApi performs these steps.
+                       client.ignoreFilesEnabled = true;
+                       client.restoreFilterState();
+                   });
+    
+    // Filters are applied.
+    // d and g are no longer visible.
+    localTree.removenode("d");
+    localTree.removenode("g");
+
+    // Wait for sync.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Disable ignore file functionality.
+    cdu->thread_do([](MegaClient& client, promise<bool>&)
+                   {
+                       client.ignoreFilesEnabled = false;
+                       client.purgeFilterState();
+                   });
+
+    // Once again, everything's included except for those nodes excluded by
+    // global filters.
+    localTree = localFS;
+    localTree.removenode("h~");
+
+    // Wait for sync.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(FilterFixture, TriggersFilterErrorEvent)
+{
+    Model model;
+
+    // Set up model.
+    model.addfile(".megaignore", "bad");
+    model.generate(root(*cu) / "root");
+
+    auto eventHandler =
+      [&](LocalNode& node)
+      {
+          const string expectedName =
+            (root(*cu) / "root").u8string();
+
+          // Node should be the ignore file's parent.
+          if (expectedName == node.name)
+          {
+              cu->mOnFilterError = nullptr;
+          }
+      };
+
+    // Log in the client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Hook filter_error event.
+    cu->mOnFilterError = eventHandler;
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Let the sync try and synchronize.
+    waitOnSyncs(cu.get());
+
+    // Was the event triggered during initial scan?
+    ASSERT_FALSE(cu->mOnFilterError);
+
+    // Correct the ignore file.
+    model.addfile(".megaignore", "#");
+    model.generate(root(*cu) / "root");
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm model.
+    ASSERT_TRUE(confirm(*cu, model));
+    
+    // Hook the event.
+    cu->mOnFilterError = eventHandler;
+
+    // Break the ignore file again.
+    model.addfile(".megaignore", "verybad");
+    model.generate(root(*cu) / "root");
+
+    // Let the sync think.
+    waitOnSyncs(cu.get());
+
+    // Was the event triggered during normal operation?
+    ASSERT_FALSE(cu->mOnFilterError);
+
+    // Do we only trigger the event when there's no existing error?
+    cu->mOnFilterError = eventHandler;
+
+    model.addfile(".megaignore", "reallybad");
+    model.generate(root(*cu) / "root");
+
+    // Wait for sync to idle.
+    waitOnSyncs(cu.get());
+
+    // The event shouldn't have been triggered.
+    ASSERT_TRUE(cu->mOnFilterError);
+}
+
+class LocalToCloudFilterFixture
+  : public FilterFixture
+{
+public:
+    string debrisFilePath(const string& path) const
+    {
+        return FilterFixture::debrisFilePath("SyncDebris", path);
+    }
+}; /* LocalToCloudFilterFixture */
+
+TEST_F(LocalToCloudFilterFixture, DoesntDownloadIgnoredNodes)
+{
+    // Set up cloud.
+    {
+        Model model;
+
+        model.addfile("d/f");
+        model.addfile("f");
+        model.generate(root(*cu) / "root");
+
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+        waitOnSyncs(cu.get());
+
+        ASSERT_TRUE(confirm(*cu, model));
+
+        cu.reset();
+    }
+    
+    // Set up local FS.
+    LocalFSModel localFS;
+
+    localFS.addfile(".megaignore", "-:d\n-:f\n");
+    localFS.generate(root(*cd) / "root");
+
+    // Set up local and remote trees.
+    LocalNodeModel localTree = localFS;
+    RemoteNodeModel remoteTree = localFS;
+
+    localTree.removenode("d");
+    localTree.removenode("f");
+
+    remoteTree.addfile("d/f");
+    remoteTree.addfile("f");
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for sync and confirm models.
+    waitOnSyncs(cd.get());
+
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntDownloadWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up cloud.
+    {
+        Model model;
+
+        // Populate FS.
+        model.addfile("da/fa");
+        model.addfile("da/fb");
+        model.addfile("db/fa");
+        model.addfile("db/fb");
+        model.addfile("fa");
+        model.addfile("fb");
+        model.generate(root(*cu) / "root");
+
+        // Log in upload client.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+
+        // Add and start sync.
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        // Wait for upload to complete.
+        waitOnSyncs(cu.get());
+
+        // Make sure everything's where it should be.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Set up remote tree.
+        remoteTree = model;
+    }
+
+    // Set up local FS.
+    localFS.addfile(".megaignore", "bad");
+    localFS.generate(root(*cd) / "root");
+
+    // Local tree is consistent with local FS.
+    localTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Let the sync try and synchronize.
+    waitOnSyncs(cd.get());
+
+    // Verify models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntMoveIgnoredNodes)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("0/fx");
+    localFS.addfolder("1");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local node tree.
+    localTree = localFS;
+
+    // Setup remote note tree.
+    remoteTree = localFS;
+
+    // Log in the client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Filter out 0/fx.
+    localFS.addfile("0/.megaignore", "-:*x");
+    localFS.generate(root(*cu) / "root");
+
+    // 0/fx should remain in the cloud.
+    // 1/fx should be added to the cloud.
+    remoteTree = localFS;
+    remoteTree.copynode("0/fx", "1/fx");
+
+    // 0/fx should become 1/fx in both local models.
+    localFS.copynode("0/fx", "1/fx");
+    localFS.removenode("0/fx");
+    localTree = localFS;
+
+    // Rename 0/fx to 1/fx.
+    fs::rename(root(*cu) / "root" / "0"/ "fx",
+               root(*cu) / "root" / "1"/ "fx");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntMoveWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile("a/.megaignore", "#");
+    localFS.addfile("a/fa");
+    localFS.addfile("a/fb");
+    localFS.addfolder("b");
+    localFS.generate(root(*cu) / "root");
+
+    // Set up local and remote trees.
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Log in the client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start the sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for our tree to upload.
+    waitOnSyncs(cu.get());
+
+    // Make sure everything looks as we expect.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Break the ignore file.
+    // Move a/fa to b/fa.
+    localFS.addfile("a/.megaignore", "bad");
+    localFS.generate(root(*cu) / "root");
+    localFS.movenode("a/fa", "b");
+
+    fs::rename(root(*cu) / "root" / "a" / "fa",
+               root(*cu) / "root" / "b" / "fa");
+
+    // Local tree should remain consistent with FS.
+    localTree = localFS;
+
+    // Remote tree should have both a/fa and b/fa.
+    remoteTree.copynode("a/fa" , "b/fa");
+
+    // Try and synchronize.
+    waitOnSyncs(cu.get());
+
+    // Do the models agree?
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Move a to b/a.
+    localFS.movenode("a", "b");
+
+    fs::rename(root(*cu) / "root" / "a",
+               root(*cu) / "root" / "b" / "a");
+
+    // Original a will be from the cloud.
+    localFS.addfile("a/.megaignore", "#");
+    localFS.addfile("a/fa");
+    localFS.addfile("a/fb");
+
+    // Local tree should remain consistent with FS.
+    localTree = localFS;
+
+    // Remote tree should have both a and b/a.
+    remoteTree.copynode("a", "b/a");
+
+    // But not b/a/.megaignore, b/a/fa or b/a/fb.
+    remoteTree.removenode("b/a/.megaignore");
+    remoteTree.removenode("b/a/fa");
+    remoteTree.removenode("b/a/fb");
+
+    // Give client some time to try and synchronize.
+    waitOnSyncs(cu.get());
+
+    // Do the models agree?
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntRenameIgnoredNodes)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("fx");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local node tree.
+    localTree = localFS;
+
+    // Setup remote note tree.
+    remoteTree = localFS;
+
+    // Log in the client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Filter out fx.
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.generate(root(*cu) / "root");
+
+    // fu should be added to the cloud.
+    // fx should remain in the cloud.
+    remoteTree = localFS;
+    remoteTree.copynode("fx", "fu");
+
+    // fx should beecome fu in both local models.
+    localFS.copynode("fx", "fu");
+    localFS.removenode("fx");
+    localTree = localFS;
+
+    // Rename fx to fu.
+    fs::rename(root(*cu) / "root" / "fx",
+               root(*cu) / "root" / "fu");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntRenameWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile("d/f");
+    localFS.addfile("f");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local tree is consistent with local FS.
+    localTree = localFS;
+
+    // Remote tree is consistent with local tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Make sure everything uploaded.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Add a broken ignore file.
+    localFS.addfile(".megaignore", "bad");
+    localFS.generate(root(*cdu) / "root");
+
+    // Rename d to dd.
+    localFS.copynode("d", "dd");
+
+    fs::rename(root(*cdu) / "root" / "d",
+               root(*cdu) / "root" / "dd");
+
+    // d will not be redownloaded as the tree is blocked.
+    localFS.removenode("d");
+
+    // Rename f to ff.
+    localFS.copynode("f", "ff");
+
+    fs::rename(root(*cdu) / "root" / "f",
+               root(*cdu) / "root" / "ff");
+
+    // f will not be redownloaded as the tree is blocked.
+    localFS.removenode("f");
+
+    // Local tree is somewhat stale as the tree is blocked.
+    // It is unchanged except for the .megaignore file.
+    localTree.addfile(".megaignore", "bad");
+
+    // Let the sync think for awhile.
+    waitOnSyncs(cdu.get());
+
+    // Confirm the models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    //ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntRubbishIgnoredNodes)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("fx");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local node tree.
+    localTree = localFS;
+
+    // Setup remote note tree.
+    remoteTree = localFS;
+
+    // Log in the client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Filter out fx.
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.generate(root(*cu) / "root");
+
+    // fx should remain in the cloud.
+    remoteTree = localFS;
+
+    // fx should no longer be visible in ether local model.
+    localFS.removenode("fx");
+    localTree = localFS;
+
+    // Remove fx from the FS.
+    ASSERT_TRUE(fs::remove(root(*cu) / "root" / "fx"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntRubbishWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile("d/f");
+    localFS.addfile("f");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local tree is consistent with local FS.
+    localTree = localFS;
+
+    // Remote node tree is consistent with local node tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for uploads to complete.
+    waitOnSyncs(cdu.get());
+
+    // Check that everything's as we expect.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Add a broken ignore file.
+    localFS.addfile(".megaignore", "bad");
+    localFS.generate(root(*cdu) / "root");
+
+    // Remove d.
+    localFS.removenode("d");
+    fs::remove_all(root(*cdu) / "root" / "d");
+
+    // Remove f.
+    localFS.removenode("f");
+    fs::remove(root(*cdu) / "root" / "f");
+
+    // Local tree still contains d and f.
+    // Local tree now contains .megaignore.
+    // Remote tree is unchanged.
+    localTree.addfile(".megaignore", "bad");
+
+    // Try and synchronize changes.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    // d and f should still be present in the cloud.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntUploadIgnoredNodes)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfolder("du");
+    localFS.addfolder("dx");
+    localFS.addfile("fu");
+    localFS.addfile("fx");
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local tree
+    localTree = localFS;
+    localTree.removenode("dx");
+    localTree.removenode("fx");
+
+    // Setup remote tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm model expectations.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, DoesntUploadWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    fs::create_directories(root(*cu) / "root");
+
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Get initial sync scan out of the way.
+    waitOnSyncs(cu.get());
+
+    // Set up local FS.
+    localFS.addfile("0/.megaignore", "bad");
+    localFS.generate(root(*cu) / "root");
+
+    // Local tree is consistent with FS.
+    localTree = localFS;
+
+    // Remote tree contains 0 but none of its contents.
+    remoteTree = localTree;
+    remoteTree.removenode("0/.megaignore");
+
+    // Try and synchronize.
+    waitOnSyncs(cu.get());
+
+    // Is everything as we'd expect?
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterAdded)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("fu");
+    localFS.addfile("fx");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for and confirm sync.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Add filter.
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.addfile("fxx");
+    localFS.generate(root(*cu) / "root");
+
+    // fx+ should not be visible in local tree.
+    localTree = localFS;
+    localTree.removenode("fx");
+    localTree.removenode("fxx");
+
+    // fxx should not be visible in remote tree.
+    remoteTree = localFS;
+    remoteTree.removenode("fxx");
+
+    // Wait for and confirm sync.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterChanged)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.addfile("fu");
+    localFS.addfile("fx");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("fx");
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for and confirm sync.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Update filter.
+    localFS.addfile(".megaignore", "-:*u");
+    localFS.generate(root(*cu) / "root");
+
+    // fu should be ignored.
+    // fx should not be ignored.
+    localTree = localFS;
+    localTree.removenode("fu");
+
+    // f[ux] should both be present in remote tree.
+    remoteTree = localFS;
+
+    // Wait for and confirm sync.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterDeferredChange)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("0/.megaignore", "-:f");
+    localFS.addfile("0/f");
+    localFS.addfile("1/.megaignore", "-:g");
+    localFS.addfile("1/g");
+    localFS.addfile(".megaignore", "-:?");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("0");
+    localTree.removenode("1");
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync and confirm models.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Change 0/.megaignore.
+    // Filter reload will be deferred.
+    localFS.addfile("0/.megaignore", "#-:f");
+    localFS.generate(root(*cu) / "root");
+
+    // Remove 1/.megaignore.
+    // Filter clear will be deferred.
+    localFS.removenode("1/.megaignore");
+
+    ASSERT_TRUE(fs::remove(root(*cu) / "root" / "1" / ".megaignore"));
+
+    // Wait for sync.
+    // This should be a no-op as our changes are to ignored nodes.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Remove .megaignore.
+    // This should perform any pending filter reloads.
+    ASSERT_TRUE(fs::remove(root(*cu) / "root" / ".megaignore"));
+
+    // Update models.
+    localFS.removenode(".megaignore");
+
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Wait for sync.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterMovedAcrossHierarchy)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("0/.megaignore", "-:x");
+    localFS.addfile("0/u");
+    localFS.addfile("0/x");
+    localFS.addfile("1/u");
+    localFS.addfile("1/x");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("0/x");
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync and confirm models.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Move 0/.megaignore to 1.
+    fs::rename(root(*cu) / "root" / "0" / ".megaignore",
+               root(*cu) / "root" / "1" / ".megaignore");
+
+    localFS.movenode("0/.megaignore", "1");
+
+    // Update local and remote trees.
+    localTree = localFS;
+    localTree.removenode("1/x");
+    remoteTree = localFS;
+
+    // Wait for synchronization.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterMovedBetweenSyncs)
+{
+    LocalFSModel s0LocalFS;
+    LocalFSModel s1LocalFS;
+    LocalNodeModel s0LocalTree;
+    LocalNodeModel s1LocalTree;
+    RemoteNodeModel s0RemoteTree;
+    RemoteNodeModel s1RemoteTree;
+
+    // Sync 0
+    {
+        // Set up local FS.
+        s0LocalFS.addfile(".megaignore", "-:x");
+        s0LocalFS.addfile("x");
+        s0LocalFS.generate(root(*cdu) / "s0");
+
+        // Set up local tree.
+        s0LocalTree = s0LocalFS;
+        s0LocalTree.removenode("x");
+
+        // Set up remote tree.
+        s0RemoteTree = s0LocalTree;
+    }
+
+    // Sync 1
+    {
+        // Set up local FS.
+        s1LocalFS.addfile("x");
+        s1LocalFS.generate(root(*cdu) / "s1");
+
+        // Set up local and remote trees.
+        s1LocalTree = s1LocalFS;
+        s1RemoteTree = s1LocalTree;
+    }
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset());
+
+    // Create sync directories.
+    {
+        // Will be freed by putnodes_result(...).
+        NewNode* nodes = new NewNode[2];
+
+        cdu->putnodes_prepareOneFolder(nodes[0], "s0");
+        cdu->putnodes_prepareOneFolder(nodes[1], "s1");
+
+        Node* root = cdu->gettestbasenode();
+
+        ASSERT_TRUE(cdu->putnodes(root->nodehandle, nodes, 2));
+
+        ASSERT_TRUE(cdu->drillchildnodebyname(root, "s0"));
+        ASSERT_TRUE(cdu->drillchildnodebyname(root, "s1"));
+    }
+
+    // Add and start syncs.
+    ASSERT_TRUE(setupSync(*cdu, "s0", "s0", 0));
+    ASSERT_TRUE(setupSync(*cdu, "s1", "s1", 1));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, s0LocalFS, 0));
+    ASSERT_TRUE(confirm(*cdu, s0LocalTree, 0));
+    ASSERT_TRUE(confirm(*cdu, s0RemoteTree, 0));
+
+    ASSERT_TRUE(confirm(*cdu, s1LocalFS, 1));
+    ASSERT_TRUE(confirm(*cdu, s1LocalTree, 1));
+    ASSERT_TRUE(confirm(*cdu, s1RemoteTree, 1));
+
+    // Move cdu/s0/.megaignore to cdu/s1/.megaignore.
+    fs::rename(root(*cdu) / "s0" / ".megaignore",
+               root(*cdu) / "s1" / ".megaignore");
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // .megaignore no longer exists in cdu/s0.
+    // as a consequence, cdu/s0/x is no longer ignored.
+    s0LocalFS.removenode(".megaignore");
+
+    s0LocalTree.removenode(".megaignore");
+    s0LocalTree.addfile("x");
+
+    s0RemoteTree = s0LocalTree;
+
+    // .megaignore has been added to cdu/s1.
+    // as a consequence, cdu/s1/x is now ignored.
+    s1LocalFS.addfile(".megaignore", "-:x");
+
+    s1LocalTree = s1LocalFS;
+    s1LocalTree.removenode("x");
+
+    s1RemoteTree = s1LocalFS;
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, s0LocalFS, 0));
+    ASSERT_TRUE(confirm(*cdu, s0LocalTree, 0));
+    ASSERT_TRUE(confirm(*cdu, s0RemoteTree, 0));
+
+    ASSERT_TRUE(confirm(*cdu, s1LocalFS, 1));
+    ASSERT_TRUE(confirm(*cdu, s1LocalTree, 1));
+    ASSERT_TRUE(confirm(*cdu, s1RemoteTree, 1));
+
+    // Add a new .megaignore to cdu/s0.
+    // Add cdu/s0/y for it to ignore.
+    s0LocalFS.addfile(".megaignore", "-:y");
+    s0LocalFS.addfile("y");
+    s0LocalFS.generate(root(*cdu) / "s0");
+
+    s0LocalTree = s0LocalFS;
+    s0LocalTree.removenode("y");
+    s0RemoteTree = s0LocalTree;
+
+    // Add cdu/s1/y.
+    s1LocalFS.addfile("y");
+    s1LocalFS.generate(root(*cdu) / "s1");
+
+    s1LocalTree.addfile("y");
+    s1RemoteTree = s1LocalFS;
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, s0LocalFS, 0));
+    ASSERT_TRUE(confirm(*cdu, s0LocalTree, 0));
+    ASSERT_TRUE(confirm(*cdu, s0RemoteTree, 0));
+
+    ASSERT_TRUE(confirm(*cdu, s1LocalFS, 1));
+    ASSERT_TRUE(confirm(*cdu, s1LocalTree, 1));
+    ASSERT_TRUE(confirm(*cdu, s1RemoteTree, 1));
+
+    // Move cdu/s0/.megaignore to cdu/s1/.megaignore.
+    fs::rename(root(*cdu) / "s0" / ".megaignore",
+               root(*cdu) / "s1" / ".megaignore");
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // .megaignore no longer exists in cdu/s0.
+    // as a consequence, cdu/s0/y is no longer ignored.
+    s0LocalFS.removenode(".megaignore");
+
+    s0LocalTree.removenode(".megaignore");
+    s0LocalTree.addfile("y");
+
+    s0RemoteTree = s0LocalTree;
+
+    // cdu/s1/.megaignore has been overwritten.
+    // as a consequence, cdu/s1/x is no longer ignored.
+    // as a consequence, cdu/s1/y is ignored.
+    s1LocalFS.addfile(".megaignore", "-:y");
+
+    s1LocalTree = s1LocalFS;
+    s1LocalTree.removenode("y");
+
+    s1RemoteTree = s1LocalFS;
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, s0LocalFS, 0));
+    ASSERT_TRUE(confirm(*cdu, s0LocalTree, 0));
+    ASSERT_TRUE(confirm(*cdu, s0RemoteTree, 0));
+
+    ASSERT_TRUE(confirm(*cdu, s1LocalFS, 1));
+    ASSERT_TRUE(confirm(*cdu, s1LocalTree, 1));
+    ASSERT_TRUE(confirm(*cdu, s1RemoteTree, 1));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterMovedDownHierarchy)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile(".megaignore", "-:x");
+    localFS.addfile("0/u");
+    localFS.addfile("0/x");
+    localFS.addfile("1/u");
+    localFS.addfile("1/x");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("0/x");
+    localTree.removenode("1/x");
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync and confirm models.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Move 0/.megaignore to root.
+    fs::rename(root(*cu) / "root" / ".megaignore",
+               root(*cu) / "root" / "0" / ".megaignore");
+
+    localFS.movenode(".megaignore", "0");
+
+    // 1/x is now visible in the local and remote trees.
+    localTree = localFS;
+    localTree.removenode("0/x");
+    remoteTree = localTree;
+
+    // Wait for synchronization.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterMovedUpHierarchy)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("0/.megaignore", "-:x");
+    localFS.addfile("0/u");
+    localFS.addfile("0/x");
+    localFS.addfile("1/u");
+    localFS.addfile("1/x");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("0/x");
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync and confirm models.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Move 0/.megaignore to root.
+    fs::rename(root(*cu) / "root" / "0" / ".megaignore",
+               root(*cu) / "root" / ".megaignore");
+
+    localFS.movenode("0/.megaignore", "");
+
+    // [01]/x is now ignored in the local tree.
+    localTree = localFS;
+    localTree.removenode("0/x");
+    localTree.removenode("1/x");
+
+    // all nodes except for 0/x are visible in the remote tree.
+    remoteTree = localFS;
+    remoteTree.removenode("0/x");
+
+    // Wait for synchronization.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterOverwritten)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.addfile("fu");
+    localFS.addfile("fx");
+    localFS.addfile("megaignore", "-:*u");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("fx");
+    remoteTree = localTree;
+
+    // Log in to client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Move megaignore over .megaignore
+    fs::rename(root(*cu) / "root" / "megaignore",
+               root(*cu) / "root" / ".megaignore");
+
+    localFS.removenode(".megaignore");
+    localFS.copynode("megaignore", ".megaignore");
+    localFS.removenode("megaignore");
+
+    // fu should become ignored.
+    // fx should become visible in local tree.
+    localTree = localFS;
+    localTree.removenode("fu");
+
+    // f[ux] should be visible in the remote tree.
+    remoteTree = localFS;
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, FilterRemoved)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.addfile("fx");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote trees.
+    localTree = localFS;
+    localTree.removenode("fx");
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for and confirm sync.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Remove filter from FS.
+    localFS.removenode(".megaignore");
+
+    ASSERT_TRUE(fs::remove(root(*cu) / "root" / ".megaignore"));
+
+    // fx should be present in both local and remote trees.
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Wait for and confirm sync.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+TEST_F(LocalToCloudFilterFixture, MoveToIgnoredRubbishesRemote)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("0/f");
+    localFS.addfile("1/.megaignore", "-:f");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote tree.
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Ensure remote debris is clear.
+    ASSERT_TRUE(cu->deleteremotedebris());
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync to complete and confirm models.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Move 0/f to 1/f.
+    fs::rename(root(*cu) / "root" / "0" / "f",
+               root(*cu) / "root" / "1" / "f");
+
+    localFS.movenode("0/f", "1");
+
+    // Neither 0/f or 1/f are present in local or remote tree.
+    localTree = localFS;
+    localTree.removenode("1/f");
+    remoteTree = localTree;
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Verify that 0/f was moved into the remote debris.
+    Node* u = cu->drillchildnodebyname(cu->getcloudrubbishnode(),
+                                       debrisFilePath("f"));
+    ASSERT_TRUE(u);
+}
+
+TEST_F(LocalToCloudFilterFixture, RenameToIgnoredRubbishesRemote)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile(".megaignore", "-:x");
+    localFS.addfile("u");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote tree.
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Ensure remote debris is clear.
+    ASSERT_TRUE(cu->deleteremotedebris());
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for sync to complete and confirm models.
+    waitOnSyncs(cu.get());
+
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Rename u to x.
+    fs::rename(root(*cu) / "root" / "u",
+               root(*cu) / "root" / "x");
+
+    localFS.copynode("u", "x");
+    localFS.removenode("u");
+
+    // u is no longer present in either the local or remote tree.
+    localTree.removenode("u");
+    remoteTree = localTree;
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Verify that u was moved into the remote debris.
+    Node* u = cu->drillchildnodebyname(cu->getcloudrubbishnode(),
+                                       debrisFilePath("u"));
+    ASSERT_TRUE(u);
+}
+
+TEST_F(LocalToCloudFilterFixture, UnblocksWhenIgnoreFileCorrected)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Log in client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes(cu->clientname));
+
+    // Add and start sync.
+    fs::create_directories(root(*cu) / "root");
+    ASSERT_TRUE(setupSync(*cu, "root"));
+
+    // Wait for initial scan to complete.
+    waitOnSyncs(cu.get());
+
+    // Set up local FS.
+    localFS.addfile(".megaignore", "bad");
+    localFS.addfile("d/f");
+    localFS.addfile("f");
+    localFS.generate(root(*cu) / "root");
+
+    // Local tree only contains the ignore file.
+    // Remote tree contains nothing.
+    localTree.addfile(".megaignore", "bad");
+
+    // Try and synchronize.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Correct ignore file.
+    localFS.addfile(".megaignore", "-:f");
+    localFS.generate(root(*cu) / "root");
+
+    // Local tree contains d.
+    localTree.addfile(".megaignore", "-:f");
+    localTree.addfolder("d");
+
+    // Remote node tree matches local node tree.
+    remoteTree = localTree;
+
+    // Wait for sync to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Break the ignore file again.
+    localFS.addfile(".megaignore", "bad");
+    localFS.generate(root(*cu) / "root");
+
+    // Try and synchronize.
+    waitOnSyncs(cu.get());
+
+    // Remove the ignore file.
+    localFS.removenode(".megaignore");
+    fs::remove(root(*cu) / "root" / ".megaignore");
+
+    // Local tree is now consistent with FS.
+    localTree = localFS;
+
+    // Remote tree now contains d and f.
+    remoteTree = localTree;
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+}
+
+class CloudToLocalFilterFixture
+  : public FilterFixture
+{
+public:
+    string debrisFilePath(const string& path) const
+    {
+        return FilterFixture::debrisFilePath(MEGA_DEBRIS_FOLDER, path);
+    }
+}; /* CloudToLocalFilterFixture */
+
+TEST_F(CloudToLocalFilterFixture, DoesntDownloadIgnoredNodes)
+{
+    // Set up cloud.
+    {
+        Model model;
+
+        model.addfile(".megaignore", "-:f");
+        model.addfile("d/f");
+        model.addfile("d/g");
+        model.addfile("f");
+        model.addfile("g");
+        model.generate(root(*cu) / "root");
+
+        // Disable filtering functionality.
+        cu->client.ignoreFilesEnabled = false;
+
+        // Upload.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        waitOnSyncs(cu.get());
+
+        // Confirm.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Logout.
+        cu.reset();
+    }
+
+    // Set up models.
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    localFS.addfile(".megaignore", "-:f");
+    localFS.addfile("d/g");
+    localFS.addfile("g");
+
+    localTree = localFS;
+
+    remoteTree = localFS;
+    remoteTree.addfile("d/f");
+    remoteTree.addfile("d/g");
+    remoteTree.addfile("f");
+    remoteTree.addfile("g");
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntDownloadWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up cloud.
+    {
+        Model model;
+
+        model.addfile(".megaignore", "bad");
+        model.addfile("d/f");
+        model.addfile("f");
+        model.generate(root(*cu) / "root");
+
+        // Disable ignore file functionality.
+        cu->client.ignoreFilesEnabled = false;
+
+        // Log in client.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+
+        // Add and start sync.
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+        
+        // Wait for upload to complete.
+        waitOnSyncs(cu.get());
+
+        // Make sure everything's where it should be.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Log out client.
+        cu.reset();
+
+        // Remote tree is consistent with model.
+        remoteTree = model;
+    }
+
+    // Set up local FS.
+    localFS.addfile(".megaignore", "bad");
+
+    // Local node tree is consistent with local FS.
+    localTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_fetchnodes());
+
+    // Add and start sync.
+    fs::create_directories(root(*cdu) / "root");
+    ASSERT_TRUE(setupSync(*cdu, "root", "x"));
+
+    // Try and synchronize.
+    waitOnSyncs(cdu.get());
+
+    // Sync should be blocked on the ignore file.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntMoveIgnoredNodes)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("d/fx");
+    localFS.generate(root(*cdu) / "root");
+
+    // Setup local node tree.
+    localTree = localFS;
+
+    // Setup remote note tree.
+    remoteTree = localFS;
+
+    // Log in the client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Filter out fx.
+    localFS.addfile(".megaignore", "-:*x");
+    localFS.generate(root(*cdu) / "root");
+
+    // fx should remain in the cloud.
+    remoteTree = localFS;
+
+    // fx should now be ignored in the local tree.
+    localTree = localFS;
+    localTree.removenode("d/fx");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Move cdu/d/fx to cdu/fx.
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+        ASSERT_TRUE(cu->movenode("cdu/d/fx", "cdu"));
+
+        cu.reset();
+    }
+
+    // Update models.
+    remoteTree.movenode("d/fx", "");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntMoveWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local filesystem.
+    localFS.addfile("da/f");
+    localFS.addfile("f");
+    localFS.addfolder("db");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local node tree matches local FS.
+    localTree = localFS;
+
+    // Remote node tree matches local node tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Everything as we expect?
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Add a broken ignore file.
+    localFS.addfile(".megaignore", "bad");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local node tree matches local FS.
+    localTree = localFS;
+
+    // Let the sync try and synchronize.
+    waitOnSyncs(cdu.get());
+
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+
+        // Move cdu/da to cdu/db/da.
+        remoteTree.movenode("da", "db");
+        ASSERT_TRUE(cu->movenode("cdu/da", "cdu/db"));
+
+        // Move cdu/f to cdu/db/f.
+        remoteTree.movenode("f", "db");
+        ASSERT_TRUE(cu->movenode("cdu/f", "cdu/db"));
+
+        cu.reset();
+    }
+
+    // Wait for sync.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntRenameIgnoredNodes)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("x");
+    localFS.generate(root(*cdu) / "root");
+
+    // Setup local node tree.
+    localTree = localFS;
+
+    // Setup remote note tree.
+    remoteTree = localFS;
+
+    // Log in the client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Filter out fx.
+    localFS.addfile(".megaignore", "-:x");
+    localFS.generate(root(*cdu) / "root");
+
+    // x should remain in the cloud.
+    remoteTree = localFS;
+
+    // x should now be ignored in the local tree.
+    localTree = localFS;
+    localTree.removenode("x");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Rename cdu/x to cdu/y.
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+
+        Node* node =
+          cu->drillchildnodebyname(cu->gettestbasenode(), "cdu/x");
+        ASSERT_TRUE(node);
+
+        node->attrs.map['n'] = "y";
+        ASSERT_TRUE(cu->setattr(*node));
+
+        cu.reset();
+    }
+
+    // Update models.
+    localFS.addfile("y", "x");
+    localTree.addfile("y", "x");
+    remoteTree.copynode("x", "y");
+    remoteTree.removenode("x");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntRenameWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local filesysten.
+    localFS.addfile("d/f");
+    localFS.addfile("f");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local tree matches local FS.
+    localTree = localFS;
+
+    // Remote tree matches local tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Add a broken ignore file.
+    localFS.addfile(".megaignore", "bad");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local tree is consistent with local FS.
+    localTree = localFS;
+
+    // Let the sync try and complete.
+    waitOnSyncs(cdu.get());
+
+    // Remotely rename cdu/d, cdu/f.
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+
+        // Remotely rename cdu/d to cdu/dd.
+        Node* node =
+          cu->drillchildnodebyname(cu->gettestbasenode(), "cdu/d");
+        ASSERT_TRUE(node);
+
+        node->attrs.map['n'] = "dd";
+        ASSERT_TRUE(cu->setattr(*node));
+
+        remoteTree.copynode("d", "dd");
+        remoteTree.removenode("d");
+
+        // Remotely rename cdu/f to cdu/ff.
+        node = cu->drillchildnodebyname(cu->gettestbasenode(), "cdu/f");
+        ASSERT_TRUE(node);
+
+        node->attrs.map['n'] = "ff";
+        ASSERT_TRUE(cu->setattr(*node));
+
+        remoteTree.copynode("f", "ff");
+        remoteTree.removenode("f");
+
+        cu.reset();
+    }
+
+    // Wait for sync.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntRubbishIgnoredNodes)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local FS.
+    localFS.addfile("x");
+    localFS.generate(root(*cdu) / "root");
+
+    // Setup local node tree.
+    localTree = localFS;
+
+    // Setup remote note tree.
+    remoteTree = localFS;
+
+    // Log in the client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Filter out fx.
+    localFS.addfile(".megaignore", "-:x");
+    localFS.generate(root(*cdu) / "root");
+
+    // x should remain in the cloud.
+    remoteTree = localFS;
+
+    // x should now be ignored in the local tree.
+    localTree = localFS;
+    localTree.removenode("x");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Remove cdu/x.
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+        ASSERT_TRUE(cu->deleteremote("cdu/x"));
+
+        cu.reset();
+    }
+
+    // Update models.
+    remoteTree.removenode("x");
+
+    // Wait for sync to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntRubbishWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local filesystem.
+    localFS.addfile("d/f");
+    localFS.addfile("f");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local node tree matches local FS.
+    localTree = localFS;
+
+    // Remote node tree matches local node tree.
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Check everything synchronized correctly.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Add a broken ignore file.
+    localFS.addfile(".megaignore", "bad");
+    localFS.generate(root(*cdu) / "root");
+
+    // Local node tree matches local FS.
+    localTree = localFS;
+
+    // Try and synchronize.
+    waitOnSyncs(cdu.get());
+
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+
+        // Remove cdu/d.
+        remoteTree.removenode("d");
+        ASSERT_TRUE(cu->deleteremote("cdu/d"));
+
+        // Remove cdu/f.
+        remoteTree.removenode("f");
+        ASSERT_TRUE(cu->deleteremote("cdu/f"));
+
+        cu.reset();
+    }
+    
+    // Wait for sync.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntUploadIgnoredNodes)
+{
+    const string ignoreFile = "-:da\n-:f\n";
+
+    // Set up cloud.
+    {
+        Model model;
+
+        model.addfile(".megaignore", ignoreFile);
+        model.generate(root(*cu) / "root");
+
+        // Disable filtering functionality.
+        cu->client.ignoreFilesEnabled = false;
+
+        // Upload.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        waitOnSyncs(cu.get());
+
+        // Confirm.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Logout.
+        cu.reset();
+    }
+
+    // Set up models.
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    localFS.addfile("da/f");
+    localFS.addfile("da/g");
+    localFS.addfile("db/f");
+    localFS.addfile("db/g");
+    localFS.addfile("f");
+    localFS.addfile("g");
+    localFS.generate(root(*cd) / "root");
+    localFS.addfile(".megaignore", ignoreFile);
+
+    localTree = localFS;
+    localTree.removenode("da");
+    localTree.removenode("db/f");
+    localTree.removenode("f");
+
+    remoteTree = localTree;
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, DoesntUploadWhenBlocked)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile(".megaignore", "#");
+    localFS.addfile("d/f");
+    localFS.addfile("f");
+    localFS.generate(root(*cu) / "root");
+
+    // Local node tree is consistent with local FS.
+    localTree = localFS;
+
+    // Remote node tree is consistent with local node tree.
+    remoteTree = localTree;
+
+    // Log in clients.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start syncs.
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+    ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Verify sync completed correctly.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Break the ignore file on the uploader side.
+    LocalFSModel uLocalFS = localFS;
+
+    uLocalFS.addfile(".megaignore", "bad");
+    uLocalFS.generate(root(*cu) / "root");
+
+    // Alter x/d/f and x/f.
+    uLocalFS.addfile("d/f", "ff");
+    uLocalFS.addfile("f", "ff");
+    uLocalFS.generate(root(*cu) / "root");
+
+    // Add x/g and x/d/g.
+    uLocalFS.addfile("g");
+    uLocalFS.addfile("d/g");
+    uLocalFS.generate(root(*cu) / "root");
+
+    // Wait for the uploader to try and synchronize.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Confirm models.
+
+    // Only local FS should change for uploader.
+    ASSERT_TRUE(confirm(*cu, uLocalFS));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // Nothing should've changed for the downloader.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, FilterAdded)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Setup local fs.
+    localFS.addfile("x");
+    localFS.generate(root(*cu) / "root");
+
+    // Setup local and remote tree.
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Log in "upload" client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+
+    // Log in "download" client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start syncs.
+    ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Add .megaignore to "upload" client.
+    localFS.addfile(".megaignore", "-:x");
+    localFS.generate(root(*cu) / "root");
+
+    // x will become ignored.
+    localTree = localFS;
+    localTree.removenode("x");
+
+    // .megaignore's now in the cloud.
+    remoteTree = localFS;
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, FilterChanged)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile(".megaignore", "-:x");
+    localFS.addfile("x");
+    localFS.addfile("y");
+    localFS.generate(root(*cu) / "root");
+
+    // Set up local tree.
+    localTree = localFS;
+    localTree.removenode("x");
+
+    // Set up remote tree.
+    remoteTree = localTree;
+
+    // Log in clients.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start syncs.
+    ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+    
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    // x is not present under cd.
+    localFS.removenode("x");
+
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Update ignore file on uploader side.
+    localFS.addfile(".megaignore", "-:y");
+    localFS.generate(root(*cu) / "root");
+
+    // Update models.
+    localFS.addfile("x");
+
+    // x is no longer ignored.
+    // y is now ignored.
+    localTree = localFS;
+    localTree.removenode("y");
+
+    // remote contains everything.
+    remoteTree = localFS;
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cu, localFS));
+    ASSERT_TRUE(confirm(*cu, localTree));
+    ASSERT_TRUE(confirm(*cu, remoteTree));
+
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, FilterDeferredChange)
+{
+    Model model;
+
+    // Set up remote model.
+    model.addfile(".megaignore", "-:d");
+    model.addfile("d/.megaignore", "-:x");
+    model.addfile("d/x");
+    model.addfile("d/y");
+    model.generate(root(*cu) / "root");
+
+    // Disable ignore files on the uploading client.
+    // This is so we can make remote changes to the ignored ignore file.
+    cu->client.ignoreFilesEnabled = false;
+
+    // Log in "uploading" client.
+    ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get());
+
+    // Confirm model.
+    ASSERT_TRUE(confirm(*cu, model));
+
+    // Set up local FS.
+    LocalFSModel localFS;
+
+    localFS.addfile(".megaignore", "-:d");
+
+    // Set up local model.
+    LocalNodeModel localTree = localFS;
+
+    // Set up remote model.
+    RemoteNodeModel remoteTree = model;
+
+    remoteTree.addfile("d/.megaignore", "-:x");
+    remoteTree.addfile("d/x");
+    remoteTree.addfile("d/y");
+
+    // Log in "downloading" client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add sync and start sync.
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Change x/d/.megaignore to include x and exclude y.
+    model.addfile("d/.megaignore", "-:y");
+    model.generate(root(*cu) / "root");
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Update models.
+    remoteTree = model;
+
+    // Confirm uploader model.
+    ASSERT_TRUE(confirm(*cu, model));
+
+    // Confirm downloader models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Change x/.megaignore to allow x/d.
+    model.addfile(".megaignore", "#-:d");
+    model.generate(root(*cu) / "root");
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cu.get(), cd.get());
+
+    // Update models.
+    localFS = model;
+    localFS.removenode("d/y");
+    localTree = localFS;
+    remoteTree = model;
+
+    // Confirm uploader model.
+    ASSERT_TRUE(confirm(*cu, model));
+
+    // Confirm downloader models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, FilterMovedAcrossHierarchy)
+{
+    // Set up cloud.
+    {
+        Model model;
+
+        // Setup model.
+        model.addfile("a/.megaignore", "-:fa");
+        model.addfile("a/fa");
+        model.addfile("b/fa");
+        model.generate(root(*cu) / "root");
+
+        // Disable ignore file functionality.
+        cu->client.ignoreFilesEnabled = false;
+
+        // Upload tree.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        waitOnSyncs(cu.get());
+
+        // Confirm model.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Logout.
+        cu.reset();
+    }
+
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+ 
+    // Setup local FS.
+    localFS.addfile("a/.megaignore", "-:fa");
+    localFS.addfile("b/fa");
+
+    // Setup local tree.
+    localTree = localFS;
+
+    // Setup remote tree.
+    remoteTree = localFS;
+    remoteTree.addfile("a/fa");
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Move x/a/.megaignore to x/b/.megaignore.
+    {
+        ASSERT_TRUE(cdu->login_fetchnodes());
+        ASSERT_TRUE(cdu->movenode("x/a/.megaignore", "x/b"));
+        cdu.reset();
+    }
+
+    // Wait for sync.
+    waitOnSyncs(cd.get());
+
+    // Update models.
+    // a/.megaignore -> b/.megaignore.
+    // a/fa should become included.
+    // b/fa should become excluded.
+    localFS.addfile("a/fa");
+    localFS.movenode("a/.megaignore", "b");
+
+    localTree = localFS;
+    localTree.removenode("b/fa");
+
+    remoteTree.movenode("a/.megaignore", "b");
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, FilterMovedDownHierarchy)
+{
+    // Set up cloud.
+    {
+        Model model;
+
+        // Setup model.
+        model.addfile(".megaignore", "-:fa");
+        model.addfile("a/fa");
+        model.addfile("b/fa");
+        model.generate(root(*cu) / "root");
+
+        // Disable ignore file functionality.
+        cu->client.ignoreFilesEnabled = false;
+
+        // Upload tree.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        waitOnSyncs(cu.get());
+
+        // Confirm model.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Logout.
+        cu.reset();
+    }
+
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+ 
+    // Setup local FS.
+    localFS.addfile(".megaignore", "-:fa");
+    localFS.addfolder("a");
+    localFS.addfolder("b");
+
+    // Setup local tree.
+    localTree = localFS;
+
+    // Setup remote tree.
+    remoteTree = localFS;
+    remoteTree.addfile("a/fa");
+    remoteTree.addfile("b/fa");
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Move x/.megaignore to x/a/.megaignore.
+    {
+        ASSERT_TRUE(cdu->login_fetchnodes());
+        ASSERT_TRUE(cdu->movenode("x/.megaignore", "x/a"));
+        cdu.reset();
+    }
+
+    // Wait for sync.
+    waitOnSyncs(cd.get());
+
+    // Update models.
+    // .megaignore -> a/.megaignore.
+    // a/fa should remain excluded.
+    // b/fa should become included.
+    localFS.addfile("b/fa");
+    localFS.movenode(".megaignore", "a");
+
+    localTree = localFS;
+
+    remoteTree = localFS;
+    remoteTree.addfile("a/fa");
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, FilterMovedUpHierarchy)
+{
+    // Set up cloud.
+    {
+        Model model;
+
+        // Setup model.
+        model.addfile("a/.megaignore", "-:fa");
+        model.addfile("a/fa");
+        model.addfile("b/fa");
+        model.generate(root(*cu) / "root");
+
+        // Disable ignore file functionality.
+        cu->client.ignoreFilesEnabled = false;
+
+        // Upload tree.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        waitOnSyncs(cu.get());
+
+        // Confirm model.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Logout.
+        cu.reset();
+    }
+
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+ 
+    // Setup local FS.
+    localFS.addfile("a/.megaignore", "-:fa");
+    localFS.addfile("b/fa");
+
+    // Setup local tree.
+    localTree = localFS;
+
+    // Setup remote tree.
+    remoteTree = localFS;
+    remoteTree.addfile("a/fa");
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Move x/a/.megaignore to x/.megaignore.
+    {
+        ASSERT_TRUE(cdu->login_fetchnodes());
+        ASSERT_TRUE(cdu->movenode("x/a/.megaignore", "x"));
+        cdu.reset();
+    }
+
+    // Wait for sync.
+    waitOnSyncs(cd.get());
+
+    // Update models.
+    // a/.megaignore -> .megaignore.
+    // [ab]/fa should both be excluded.
+    localFS.movenode("a/.megaignore", "");
+
+    localTree = localFS;
+    localTree.removenode("b/fa");
+
+    remoteTree = localFS;
+    remoteTree.addfile("a/fa");
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, FilterRemoved)
+{
+    // Set up cloud.
+    {
+        Model model;
+
+        // Setup model.
+        model.addfile(".megaignore", "-:fa");
+        model.addfile("fa");
+        model.generate(root(*cu) / "root");
+
+        // Disable ignore file functionality.
+        cu->client.ignoreFilesEnabled = false;
+
+        // Upload tree.
+        ASSERT_TRUE(cu->login_reset_makeremotenodes("x"));
+        ASSERT_TRUE(setupSync(*cu, "root", "x"));
+
+        waitOnSyncs(cu.get());
+
+        // Confirm model.
+        ASSERT_TRUE(confirm(*cu, model));
+
+        // Logout.
+        cu.reset();
+    }
+
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+ 
+    // Setup local FS.
+    localFS.addfile(".megaignore", "-:fa");
+
+    // Setup local tree.
+    localTree = localFS;
+
+    // Setup remote tree.
+    remoteTree = localFS;
+    remoteTree.addfile("fa");
+
+    // Log in client.
+    ASSERT_TRUE(cd->login_fetchnodes());
+
+    // Add and start sync.
+    fs::create_directories(root(*cd) / "root");
+    ASSERT_TRUE(setupSync(*cd, "root", "x"));
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cd.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+
+    // Remove x/.megaignore.
+    {
+        ASSERT_TRUE(cdu->login_fetchnodes());
+        ASSERT_TRUE(cdu->deleteremote("x/.megaignore"));
+        cdu.reset();
+    }
+
+    // Wait for sync.
+    waitOnSyncs(cd.get());
+
+    // Update models.
+    // .megaignore -> gone.
+    // fa should now be included.
+    localFS.removenode(".megaignore");
+    localFS.addfile("fa");
+
+    localTree = localFS;
+    remoteTree = localFS;
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cd, localFS));
+    ASSERT_TRUE(confirm(*cd, localTree));
+    ASSERT_TRUE(confirm(*cd, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, MoveToIgnoredRubbishesRemote)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile("d/.megaignore", "-:f");
+    localFS.addfile("f");
+    localFS.generate(root(*cdu) / "root");
+
+    // Set up local tree.
+    localTree = localFS;
+
+    // Set up remote tree.
+    remoteTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+    
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+    
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Move f to d/f.
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+        ASSERT_TRUE(cu->movenode("cdu/f", "cdu/d"));
+
+        cu.reset();
+    }
+
+    // f has moved into the local debris.
+    localFS.copynode("f", debrisFilePath("f"));
+    localFS.removenode("f");
+
+    localTree = localFS;
+
+    // f has moved to d/f in the cloud.
+    remoteTree.movenode("f", "d");
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS, 0, false));
+    ASSERT_TRUE(confirm(*cdu, localTree, 0, false));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
+TEST_F(CloudToLocalFilterFixture, RenameToIgnoredRubbishesRemote)
+{
+    LocalFSModel localFS;
+    LocalNodeModel localTree;
+    RemoteNodeModel remoteTree;
+
+    // Set up local FS.
+    localFS.addfile(".megaignore", "-:y");
+    localFS.addfile("x");
+    localFS.generate(root(*cdu) / "root");
+
+    // Set up local tree.
+    localTree = localFS;
+
+    // Set up remote tree.
+    remoteTree = localFS;
+
+    // Log in client.
+    ASSERT_TRUE(cdu->login_reset_makeremotenodes(cdu->clientname));
+    
+    // Add and start sync.
+    ASSERT_TRUE(setupSync(*cdu, "root"));
+    
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS));
+    ASSERT_TRUE(confirm(*cdu, localTree));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+
+    // Rename cdu/x to cdu/y.
+    {
+        ASSERT_TRUE(cu->login_fetchnodes());
+
+        Node* node =
+          cu->drillchildnodebyname(cu->gettestbasenode(), "cdu/x");
+        ASSERT_TRUE(node);
+
+        node->attrs.map['n'] = "y";
+        ASSERT_TRUE(cu->setattr(*node));
+
+        cu.reset();
+    }
+
+    // x has moved into the local debris.
+    localFS.copynode("x", debrisFilePath("x"));
+    localFS.removenode("x");
+
+    localTree = localFS;
+
+    // x has become y in the cloud.
+    remoteTree.copynode("x", "y");
+    remoteTree.removenode("x");
+
+    // Wait for synchronization to complete.
+    waitOnSyncs(cdu.get());
+
+    // Confirm models.
+    ASSERT_TRUE(confirm(*cdu, localFS, 0, false));
+    ASSERT_TRUE(confirm(*cdu, localTree, 0, false));
+    ASSERT_TRUE(confirm(*cdu, remoteTree));
+}
+
 #endif
+

--- a/tests/unit/utils_test.cpp
+++ b/tests/unit/utils_test.cpp
@@ -34,3 +34,31 @@ TEST(utils, hashCombine_integer)
     ASSERT_EQ(2654435811ull, hash);
 #endif
 }
+
+TEST(utils, readLines)
+{
+    static const std::string input =
+        "\r"
+        "\n"
+        "     \r"
+        "  a\r\n"
+        "b\n"
+        "c\r"
+        "  d  \r"
+        "     \n"
+        "efg\n";
+    static const std::vector<std::string> expected = {
+        "  a",
+        "b",
+        "c",
+        "  d  ",
+        "efg"
+    };
+
+    std::vector<std::string> output;
+
+    ASSERT_TRUE(mega::readLines(input, output));
+    ASSERT_EQ(output.size(), expected.size());
+    ASSERT_TRUE(std::equal(expected.begin(), expected.end(), output.begin()));
+}
+


### PR DESCRIPTION
Also fixed a couple of warnings building 32 bit