### PR TITLE
SDK-1170 - Added ignoreAttributes parameter to FileAccess:fopen(...).

### DIFF
--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -245,7 +245,7 @@ struct MEGA_API FileAccess
     // blocking mode: open for reading, writing or reading and writing.
     // This one really does open the file, and openf(), closef() will have no effect
     // If iteratingDir is supplied, this fopen() call must be for the directory entry being iterated by dopen()/dnext()
-    virtual bool fopen(LocalPath&, bool read, bool write, DirAccess* iteratingDir = nullptr) = 0;
+    virtual bool fopen(LocalPath&, bool read, bool write, DirAccess* iteratingDir = nullptr, bool ignoreAttributes = false) = 0;
 
     // nonblocking open: Only prepares for opening.  Actually stats the file/folder, getting mtime, size, type.
     // Call openf() afterwards to actually open it if required.  For folders, returns false with type==FOLDERNODE.

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -148,7 +148,7 @@ public:
     DIR* dp;
 #endif
 
-    bool fopen(LocalPath&, bool read, bool write, DirAccess* iteratingDir = nullptr) override;
+    bool fopen(LocalPath&, bool read, bool write, DirAccess* iteratingDir = nullptr, bool ignoreAttributes = false) override;
 
     void updatelocalname(LocalPath&) override;
     bool fread(string *, unsigned, unsigned, m_off_t);

--- a/include/mega/win32/megafs.h
+++ b/include/mega/win32/megafs.h
@@ -154,8 +154,8 @@ public:
     HANDLE hFind;
     WIN32_FIND_DATAW ffd;
 
-    bool fopen(LocalPath&, bool, bool, DirAccess* iteratingDir) override;
-    bool fopen_impl(LocalPath&, bool, bool, bool, DirAccess* iteratingDir);
+    bool fopen(LocalPath&, bool read, bool write, DirAccess* iteratingDir, bool ignoreAttributes) override;
+    bool fopen_impl(LocalPath&, bool read, bool write, bool async, DirAccess* iteratingDir, bool ignoreAttributes);
     void updatelocalname(LocalPath&) override;
     bool fread(string *, unsigned, unsigned, m_off_t);
     bool fwrite(const byte *, unsigned, m_off_t);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -12402,7 +12402,7 @@ error MegaClient::addsync(SyncConfig syncConfig, const char* debris, string* loc
     }
 
     auto fa = fsaccess->newfileaccess();
-    if (fa->fopen(rootpath, true, false))
+    if (fa->fopen(rootpath, true, false, nullptr, true))
     {
         if (fa->type == FOLDERNODE)
         {

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -405,7 +405,7 @@ int PosixFileAccess::stealFileDescriptor()
     return toret;
 }
 
-bool PosixFileAccess::fopen(LocalPath& f, bool read, bool write, DirAccess* iteratingDir)
+bool PosixFileAccess::fopen(LocalPath& f, bool read, bool write, DirAccess* iteratingDir, bool)
 {
     struct stat statbuf;
 

--- a/tests/unit/DefaultedFileAccess.h
+++ b/tests/unit/DefaultedFileAccess.h
@@ -31,7 +31,7 @@ public:
     : mega::FileAccess{nullptr}
     {}
 
-    bool fopen(mega::LocalPath&, bool, bool, mega::DirAccess* iteratingDir = nullptr) override
+    bool fopen(mega::LocalPath&, bool, bool, mega::DirAccess* iteratingDir = nullptr, bool = false) override
     {
         throw NotImplemented{__func__};
     }

--- a/tests/unit/FsNode.cpp
+++ b/tests/unit/FsNode.cpp
@@ -64,7 +64,7 @@ FsNode::FileAccess::FileAccess(const FsNode& fsNode)
 : mFsNode{fsNode}
 {}
 
-bool FsNode::FileAccess::fopen(LocalPath& path, bool, bool, mega::DirAccess* iteratingDir)
+bool FsNode::FileAccess::fopen(LocalPath& path, bool, bool, mega::DirAccess* iteratingDir, bool)
 {
     mPath = path;
     return sysopen();

--- a/tests/unit/FsNode.h
+++ b/tests/unit/FsNode.h
@@ -131,7 +131,7 @@ private:
     public:
         explicit FileAccess(const FsNode& fsNode);
 
-        bool fopen(mega::LocalPath& path, bool, bool, mega::DirAccess* iteratingDir = nullptr) override;
+        bool fopen(mega::LocalPath& path, bool, bool, mega::DirAccess* iteratingDir = nullptr, bool = false) override;
 
         bool sysstat(mega::m_time_t* curr_mtime, m_off_t* curr_size) override;
 

--- a/tests/unit/Sync_test.cpp
+++ b/tests/unit/Sync_test.cpp
@@ -79,7 +79,7 @@ public:
 
     MEGA_DISABLE_COPY_MOVE(MockFileAccess)
 
-    bool fopen(mega::LocalPath& path, bool, bool, mega::DirAccess* iteratingDir) override
+    bool fopen(mega::LocalPath& path, bool, bool, mega::DirAccess* iteratingDir, bool) override
     {
         mPath = path;
         return sysopen();


### PR DESCRIPTION
fopen(...) will fail to open files on Windows possessing certain
attributes. These attributes are used by Windows to mark files as being
hidden or as having special significance to the system.

This new flag gives the caller control over whether such files are
rejected and is intended to be used when verifying the presence of a
sync root.