### PR TITLE
make lastPushedTransferTag an int, for consistent typing

### DIFF
--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1974,7 +1974,7 @@ class TransferQueue
     protected:
         std::deque<MegaTransferPrivate *> transfers;
         std::mutex mutex;
-        long long lastPushedTransfer = 0;
+        int lastPushedTransferTag = 0;
 
     public:
         TransferQueue();
@@ -1992,7 +1992,7 @@ class TransferQueue
 
         void removeWithFolderTag(int folderTag, std::function<void(MegaTransferPrivate *)> callback);
         void removeListener(MegaTransferListener *listener);
-        long long getLastPushedTag() const;
+        int getLastPushedTag() const;
 };
 
 class MegaApiImpl : public MegaApp

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22283,9 +22283,9 @@ void TreeProcCopy::proc(MegaClient* client, Node* n)
     else nc++;
 }
 
-long long TransferQueue::getLastPushedTag() const
+int TransferQueue::getLastPushedTag() const
 {
-    return lastPushedTransfer;
+    return lastPushedTransferTag;
 }
 
 TransferQueue::TransferQueue()
@@ -22296,7 +22296,7 @@ void TransferQueue::push(MegaTransferPrivate *transfer)
 {
     mutex.lock();
     transfers.push_back(transfer);
-    transfer->setPlaceInQueue(++lastPushedTransfer);
+    transfer->setPlaceInQueue(++lastPushedTransferTag);
     mutex.unlock();
 }
 


### PR DESCRIPTION
Clients already expect transfer tag to be int (ie, only 32 bit)
Avoids warnings when 64 bit got truncated to 32 bit