### PR TITLE
Filesystem Tweaks

### DIFF
--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -40,7 +40,8 @@ enum FileSystemType
     FS_NTFS = 5,
     FS_FUSE = 6,
     FS_SDCARDFS = 7,
-    FS_F2FS = 8
+    FS_F2FS = 8,
+    FS_XFS = 9
 };
 
 // generic host filesystem node ID interface

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -410,15 +410,14 @@ struct MEGA_API FileSystemAccess : public EventTrigger
 
     // check if character is lowercase hex ASCII
     bool islchex(char) const;
-    bool isControlChar(unsigned char c) const;
-    bool islocalfscompatible(unsigned char, bool isEscape, FileSystemType = FS_UNKNOWN) const;
+    bool islocalfscompatible(unsigned char, FileSystemType = FS_UNKNOWN) const;
     void escapefsincompatible(string*, FileSystemType fileSystemType) const;
 
     FileSystemType getFilesystemType(const LocalPath& dstPath) const;
     const char *fstypetostring(FileSystemType type) const;
     virtual bool getlocalfstype(const LocalPath& path, FileSystemType& type) const = 0;
     FileSystemType getlocalfstype(const LocalPath& path) const;
-    void unescapefsincompatible(string*,FileSystemType) const;
+    void unescapefsincompatible(string*) const;
 
     // convert MEGA path (UTF-8) to local format
     virtual void path2local(const string*, string*) const = 0;

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -22,58 +22,26 @@
 #ifndef MEGA_FILESYSTEM_H
 #define MEGA_FILESYSTEM_H 1
 
-#if defined (__linux__) && !defined (__ANDROID__)
-#include <linux/magic.h>
-#endif
-
-#if defined (__linux__) || defined (__ANDROID__) // __ANDROID__ is always included in __linux__
-#include <sys/vfs.h>
-#elif defined  (__APPLE__) || defined (USE_IOS)
-#include <sys/mount.h>
-#include <sys/param.h>
-#elif defined(_WIN32) || defined(WINDOWS_PHONE)
-#include <winsock2.h>
-#include <Windows.h>
-#endif
-
 #include "types.h"
 #include "utils.h"
 #include "waiter.h"
 
-#if defined (__linux__) && !defined (__ANDROID__)
-// Define magic constants (for linux), in case they are not defined in headers
-#ifndef HFS_SUPER_MAGIC
-#define HFS_SUPER_MAGIC 0x4244
-#endif
-
-#ifndef NTFS_SB_MAGIC
-#define NTFS_SB_MAGIC   0x5346544e
-#endif
-
-#elif defined (__ANDROID__)
-// Define magic constants (for Android), in case they are not defined in headers
-#ifndef SDCARDFS_SUPER_MAGIC
-#define SDCARDFS_SUPER_MAGIC 0x5DCA2DF5
-#endif
-
-#ifndef FUSEBLK_SUPER_MAGIC
-#define FUSEBLK_SUPER_MAGIC  0x65735546
-#endif
-
-#ifndef FUSECTL_SUPER_MAGIC
-#define FUSECTL_SUPER_MAGIC  0x65735543
-#endif
-
-#ifndef F2FS_SUPER_MAGIC
-#define F2FS_SUPER_MAGIC 0xF2F52010
-#endif
-#endif
-
 namespace mega {
 
 // Enumeration for filesystem families
-enum FileSystemType {FS_UNKNOWN = -1, FS_APFS = 0, FS_HFS = 1, FS_EXT = 2, FS_FAT32 = 3,
-                     FS_EXFAT = 4, FS_NTFS = 5, FS_FUSE = 6, FS_SDCARDFS = 7, FS_F2FS = 8};
+enum FileSystemType
+{
+    FS_UNKNOWN = -1,
+    FS_APFS = 0,
+    FS_HFS = 1,
+    FS_EXT = 2,
+    FS_FAT32 = 3,
+    FS_EXFAT = 4,
+    FS_NTFS = 5,
+    FS_FUSE = 6,
+    FS_SDCARDFS = 7,
+    FS_F2FS = 8
+};
 
 // generic host filesystem node ID interface
 struct MEGA_API FsNodeId
@@ -447,7 +415,8 @@ struct MEGA_API FileSystemAccess : public EventTrigger
 
     FileSystemType getFilesystemType(const LocalPath& dstPath) const;
     const char *fstypetostring(FileSystemType type) const;
-    FileSystemType getlocalfstype(const LocalPath& dstPath) const;
+    virtual bool getlocalfstype(const LocalPath& path, FileSystemType& type) const = 0;
+    FileSystemType getlocalfstype(const LocalPath& path) const;
     void unescapefsincompatible(string*,FileSystemType) const;
 
     // convert MEGA path (UTF-8) to local format

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -63,6 +63,8 @@ struct MEGA_API PosixDirAccess : public DirAccess
 class MEGA_API PosixFileSystemAccess : public FileSystemAccess
 {
 public:
+    using FileSystemAccess::getlocalfstype;
+
     int notifyfd;
 
 #ifdef USE_INOTIFY
@@ -86,6 +88,8 @@ public:
     std::unique_ptr<FileAccess> newfileaccess(bool followSymLinks = true) override;
     DirAccess* newdiraccess() override;
     DirNotify* newdirnotify(LocalPath&, LocalPath&, Waiter*) override;
+
+    bool getlocalfstype(const LocalPath& path, FileSystemType& type) const override;
 
     void tmpnamelocal(LocalPath&) const override;
 

--- a/include/mega/win32/megafs.h
+++ b/include/mega/win32/megafs.h
@@ -50,7 +50,12 @@ struct MEGA_API WinDirNotify;
 class MEGA_API WinFileSystemAccess : public FileSystemAccess
 {
 public:
+    using FileSystemAccess::getlocalfstype;
+
     std::unique_ptr<FileAccess> newfileaccess(bool followSymLinks = true) override;
+    
+    bool getlocalfstype(const LocalPath& path, FileSystemType& type) const override;
+
     DirAccess* newdiraccess() override;
     DirNotify* newdirnotify(LocalPath&, LocalPath&, Waiter*) override;
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -70,6 +70,8 @@ const char *FileSystemAccess::fstypetostring(FileSystemType type) const
             return "SDCARDFS";
         case FS_F2FS:
             return "F2FS";
+        case FS_XFS:
+            return "XFS";
         case FS_UNKNOWN:    // fall through
             return "UNKNOWN FS";
     }
@@ -137,6 +139,7 @@ bool FileSystemAccess::islocalfscompatible(unsigned char c, bool isEscape, FileS
             return c != '\x3A' && c != '\x2F';
         case FS_F2FS:
         case FS_EXT:
+        case FS_XFS:
             // f2fs and ext2/ext3/ext4 restricted characters =>  / NULL
             return c != '\x00' && c != '\x2F';
         case FS_FAT32:

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -2823,7 +2823,7 @@ void MegaTransferPrivate::setPath(const char* path)
 
     for (int i = int(strlen(path) - 1); i >= 0; i--)
     {
-        if (strchr(::mega::FileSystemAccess::getPathSeparator(), path[i]))
+        if (strchr(FileSystemAccess::getPathSeparator(), path[i]))
         {
             setFileName(&(path[i+1]));
             char *parentPath = MegaApi::strdup(path);
@@ -8189,7 +8189,7 @@ void MegaApiImpl::startDownload(bool startFirst, MegaNode *node, const char* loc
 #endif
 
         int c = localPath[strlen(localPath)-1];
-        if (strchr(::mega::FileSystemAccess::getPathSeparator(), c))
+        if (strchr(FileSystemAccess::getPathSeparator(), c))
         {
             transfer->setParentPath(localPath);
         }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8133,15 +8133,10 @@ void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *
 
     if (fileName || transfer->getFileName())
     {
-       std::string auxName = fileName
-               ? fileName
-               : transfer->getFileName();
+       std::string auxName =
+         fileName ? fileName : transfer->getFileName();
 
-       std::string path = localPath
-               ? localPath
-               : "";
-
-       client->fsaccess->unescapefsincompatible(&auxName, fsType);
+       client->fsaccess->unescapefsincompatible(&auxName);
        transfer->setFileName(auxName.c_str());
     }
 
@@ -8870,8 +8865,7 @@ char *MegaApiImpl::unescapeFsIncompatible(const char *name, const char *path)
         return NULL;
     }
     string filename = name;
-    string localpath = path ? path : "";
-    client->fsaccess->unescapefsincompatible(&filename, client->fsaccess->getFilesystemType(LocalPath::fromPath(localpath, *client->fsaccess)));
+    client->fsaccess->unescapefsincompatible(&filename);
     return MegaApi::strdup(filename.c_str());
 }
 

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -71,6 +71,10 @@ extern JavaVM *MEGAjvm;
 #define F2FS_SUPER_MAGIC 0xF2F52010
 #endif /* ! F2FS_SUPER_MAGIC */
 
+#ifndef XFS_SUPER_MAGIC
+#define XFS_SUPER_MAGIC 0x58465342
+#endif /* ! XFS_SUPER_MAGIC */
+
 #endif /* __linux__ */
 
 #if defined(__APPLE__) || defined(USE_IOS)
@@ -1870,6 +1874,9 @@ bool PosixFileSystemAccess::getlocalfstype(const LocalPath& path, FileSystemType
             type = FS_SDCARDFS;
             break;
 #endif /* __ANDROID__ */
+        case XFS_SUPER_MAGIC:
+            type = FS_XFS;
+            break;
         default:
             type = FS_UNKNOWN;
             break;

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -4387,190 +4387,147 @@ TEST_F(SdkTest, SdkGetRegisteredContacts)
     ASSERT_EQ(js2, std::get<2>(table[1])); // ud
 }
 
-TEST_F(SdkTest, invalidFileNames)
+TEST_F(SdkTest, EscapesIncompatibleCharacters)
 {
-    LOG_info << "___TEST invalidFileNames___";
+    const string input = "\\/:?\"<>|*";
 
-    FSACCESS_CLASS fsa;
-    auto aux = LocalPath::fromPath(fs::current_path().u8string(), fsa);
+    // Generate expected string.
+    ostringstream osstream;
 
-#if defined (__linux__) || defined (__ANDROID__)
-    if (fileSystemAccess.getlocalfstype(aux) == FS_EXT)
+    for (auto& character : input)
     {
-        // Escape set of characters and check if it's the expected one
-        const char *name = megaApi[0]->escapeFsIncompatible("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~", fs::current_path().c_str());
-        ASSERT_TRUE (!strcmp(name, "!\"#$%&'()*+,-.%2f:;<=>?@[\\]^_`{|}~"));
-        delete [] name;
-
-        // Unescape set of characters and check if it's the expected one
-        name = megaApi[0]->unescapeFsIncompatible("%21%22%23%24%25%26%27%28%29%2a%2b%2c%2d"
-                                                            "%2e%2f%30%31%32%33%34%35%36%37"
-                                                            "%38%39%3a%3b%3c%3d%3e%3f%40%5b"
-                                                            "%5c%5d%5e%5f%60%7b%7c%7d%7e",
-                                                            fs::current_path().c_str());
-
-        ASSERT_TRUE(!strcmp(name, "%21%22%23%24%25%26%27%28%29%2a%2b%2c%2d%2e"
-                                  "/%30%31%32%33%34%35%36%37%38%39%3a%3b%3c%3d%3e"
-                                  "%3f%40%5b%5c%5d%5e%5f%60%7b%7c%7d%7e"));
-        delete [] name;
-    }
-#elif defined  (__APPLE__) || defined (USE_IOS)
-    if (fileSystemAccess.getlocalfstype(aux) == FS_APFS
-            || fileSystemAccess.getlocalfstype(aux) == FS_HFS)
-    {
-        // Escape set of characters and check if it's the expected one
-        const char *name = megaApi[0]->escapeFsIncompatible("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~", fs::current_path().c_str());
-        ASSERT_TRUE (!strcmp(name, "!\"#$%&'()*+,-./%3a;<=>?@[\\]^_`{|}~"));
-        delete [] name;
-
-        // Unescape set of characters and check if it's the expected one
-        name = megaApi[0]->unescapeFsIncompatible("%21%22%23%24%25%26%27%28%29%2a%2b%2c%2d"
-                                                            "%2e%2f%30%31%32%33%34%35%36%37"
-                                                            "%38%39%3a%3b%3c%3d%3e%3f%40%5b"
-                                                            "%5c%5d%5e%5f%60%7b%7c%7d%7e",
-                                                            fs::current_path().c_str());
-
-        ASSERT_TRUE(!strcmp(name, "%21%22%23%24%25%26%27%28%29%2a%2b%2c%2d%2e"
-                                  "%2f%30%31%32%33%34%35%36%37%38%39:%3b%3c%3d%3e"
-                                  "%3f%40%5b%5c%5d%5e%5f%60%7b%7c%7d%7e"));
-        delete [] name;
-    }
-#elif defined(_WIN32) || defined(_WIN64) || defined(WINDOWS_PHONE)
-    if (fileSystemAccess.getlocalfstype(aux) == FS_NTFS)
-    {
-        // Escape set of characters and check if it's the expected one
-        const char *name = megaApi[0]->escapeFsIncompatible("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~", fs::current_path().u8string().c_str());
-        ASSERT_TRUE (!strcmp(name, "!%22#$%&'()%2a+,-.%2f%3a;%3c=%3e%3f@[%5c]^_`{%7c}~"));
-        delete [] name;
-
-        // Unescape set of characters and check if it's the expected one
-        name = megaApi[0]->unescapeFsIncompatible("%21%22%23%24%25%26%27%28%29%2a%2b%2c%2d"
-                                                            "%2e%2f%30%31%32%33%34%35%36%37"
-                                                            "%38%39%3a%3b%3c%3d%3e%3f%40%5b"
-                                                            "%5c%5d%5e%5f%60%7b%7c%7d%7e",
-                                                            fs::current_path().u8string().c_str());
-
-        ASSERT_TRUE(!strcmp(name, "%21\"%23%24%25%26%27%28%29*%2b%2c%2d"
-                                  "%2e/%30%31%32%33%34%35%36%37"
-                                  "%38%39:%3b<%3d>?%40%5b"
-                                  "\\%5d%5e%5f%60%7b|%7d%7e"));
-
-        delete [] name;
-    }
-#endif
-
-    // Maps filename unescaped (original) to filename escaped (expected result): f%2ff => f/f
-    std::unique_ptr<MegaStringMap> fileNamesStringMap = std::unique_ptr<MegaStringMap>{MegaStringMap::createInstance()};
-    fs::path uploadPath = fs::current_path() / "upload_invalid_filenames";
-    if (fs::exists(uploadPath))
-    {
-        fs::remove_all(uploadPath);
-    }
-    fs::create_directories(uploadPath);
-
-    for (int i = 0x01; i <= 0xA0; i++)
-    {
-        // skip [0-9] [A-Z] [a-z]
-        if ((i >= 0x30 && i <= 0x39)
-                || (i >= 0x41 && i <= 0x5A)
-                || (i >= 0x61 && i <= 0x7A))
-        {
-            continue;
-        }
-
-        // Create file with unescaped character ex: f%5cf
-        char unescapedName[6];
-        sprintf(unescapedName, "f%%%02xf", i);
-        if (createLocalFile(uploadPath, unescapedName))
-        {
-            const char *unescapedFileName = megaApi[0]->unescapeFsIncompatible(unescapedName, uploadPath.u8string().c_str());
-            fileNamesStringMap->set(unescapedName, unescapedFileName);
-            delete [] unescapedFileName;
-        }
-
-        // Create another file with the original character if supported f\f
-        if ((i >= 0x01 && i <= 0x20)
-                || (i >= 0x7F && i <= 0xA0))
-        {
-            // Skip control characters
-            continue;
-        }
-
-        char escapedName[4];
-        sprintf(escapedName, "f%cf", i);
-        const char *escapedFileName = megaApi[0]->escapeFsIncompatible(escapedName, uploadPath.u8string().c_str());
-        if (escapedFileName && !strcmp(escapedName, escapedFileName))
-        {
-            // Only create those files with supported characters, those ones that need unescaping
-            // has been created above
-            if (createLocalFile(uploadPath, escapedName))
-            {
-                const char * unescapedFileName = megaApi[0]->unescapeFsIncompatible(escapedName, uploadPath.u8string().c_str());
-                fileNamesStringMap->set(escapedName, unescapedFileName);
-                delete [] unescapedFileName;
-            }
-        }
-        delete [] escapedFileName;
+        osstream << "%"
+                 << std::hex
+                 << std::setfill('0')
+                 << std::setw(2)
+                 << +character;
     }
 
-    TransferTracker uploadListener(megaApi[0].get());
-    megaApi[0]->startUpload(uploadPath.u8string().c_str(), std::unique_ptr<MegaNode>{megaApi[0]->getRootNode()}.get(), &uploadListener);
-    ASSERT_EQ(API_OK, uploadListener.waitForResult());
+    // Escape input string.
+    const char *output =
+      megaApi[0]->escapeFsIncompatible(input.c_str());
 
-    ::mega::unique_ptr <MegaNode> n(megaApi[0]->getNodeByPath("/upload_invalid_filenames"));
-    ASSERT_TRUE(n.get());
-    ::mega::unique_ptr <MegaNode> authNode(megaApi[0]->authorizeNode(n.get()));
-    ASSERT_TRUE(authNode.get());
-    MegaNodeList *children(authNode->getChildren());
-    ASSERT_TRUE(children && children->size());
+    ASSERT_NE(output, nullptr);
 
-    for (int i = 0; i < children->size(); i++)
+    // Compare and release.
+    const bool eq = string(output) == osstream.str();
+    delete[] output;
+
+    EXPECT_TRUE(eq);
+}
+
+TEST_F(SdkTest, EscapesIncompatibleCharactersOnDownload)
+{
+    // a/b/c!.txt
+    static const string fileName = "a%2fb%2fc%21.txt";
+
+    // For convenience.
+    MegaApi* api = megaApi[0].get();
+
+    // Get root node.
+    unique_ptr<MegaNode> root(api->getRootNode());
+    ASSERT_NE(root, nullptr);
+    
+    // Create file to upload containing escaped characters.
+    deleteFile(fileName);
+    createFile(fileName);
+
+    // Upload the file.
     {
-        MegaNode *child = children->get(i);
-        const char *uploadedName = child->getName();
-        const char *uploadedNameEscaped = megaApi[0]->escapeFsIncompatible(child->getName(), uploadPath.u8string().c_str());
-        const char *expectedName = fileNamesStringMap->get(uploadedNameEscaped);
-        delete [] uploadedNameEscaped;
+        TransferTracker tracker(api);
+        api->startUpload(fileName.c_str(), root.get(), &tracker);
+        ASSERT_EQ(API_OK, tracker.waitForResult());
+    }
+    
+    // Delete the file, we're done with it.
+    deleteFile(fileName);
 
-        // Conditions to check if uploaded fileName is correct:
-        // 1) Escaped uploaded filename must be found in fileNamesStringMap (original filename found)
-        // 2) Uploaded filename must be equal than the expected value (original filename unescaped)
-        ASSERT_TRUE (uploadedName && expectedName && !strcmp(uploadedName, expectedName));
+    // Check file exists in the cloud.
+    root.reset(api->authorizeNode(root.get()));
+    ASSERT_NE(root, nullptr);
+
+    MegaNodeList* children = root->getChildren();
+    ASSERT_NE(children, nullptr);
+
+    MegaNode* child = children->get(0);
+    ASSERT_NE(child, nullptr);
+    ASSERT_STREQ(child->getName(), "a/b/c%21.txt");
+
+    // Download the file.
+    {
+        TransferTracker tracker(api);
+
+        string targetPath = fs::current_path().u8string();
+        targetPath.append(FileSystemAccess::getPathSeparator());
+
+        api->startDownload(child, targetPath.c_str(), &tracker);
+        ASSERT_EQ(API_OK, tracker.waitForResult());
     }
 
-    // Download files
-    fs::path downloadPath = fs::current_path() / "download_invalid_filenames";
-    if (fs::exists(downloadPath))
-    {
-        fs::remove_all(downloadPath);
-    }
-    fs::create_directories(downloadPath);
-    TransferTracker downloadListener(megaApi[0].get());
-    megaApi[0]->startDownload(authNode.get(), downloadPath.u8string().c_str(), &downloadListener);
-    ASSERT_EQ(API_OK, downloadListener.waitForResult());
+    // Was the filename correctly escaped on download?
+    ASSERT_TRUE(fileexists(fileName));
+    deleteFile(fileName);
+}
 
-    for (fs::directory_iterator itpath (downloadPath); itpath != fs::directory_iterator(); ++itpath)
-    {
-        std::string downloadedName = itpath->path().filename().u8string();
-        if (!downloadedName.compare(".") || !downloadedName.compare(".."))
-        {
-            continue;
-        }
+TEST_F(SdkTest, UnescapesIncompatibleCharacters)
+{
+    const string input = "\\/:?\"<>|*%5a%21";
 
-        // Conditions to check if downloaded fileName is correct:
-        // download filename must be found in fileNamesStringMap (original filename found)
-        ASSERT_TRUE(fileNamesStringMap->get(downloadedName.c_str()));
-    }
+    // Escape input string.
+    const char* escaped =
+      megaApi[0]->escapeFsIncompatible(input.c_str());
 
-#ifdef WIN32
-    // double check a few well known paths
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("c:", fsa)), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("c:\\", fsa)), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("C:\\", fsa)), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("C:\\Program Files", fsa)), FS_NTFS);
-    ASSERT_EQ(fileSystemAccess.getlocalfstype(LocalPath::fromPath("c:\\Program Files\\Windows NT", fsa)), FS_NTFS);
-#endif
+    ASSERT_NE(escaped, nullptr);
 
+    // Unescape the escaped string.
+    const char* unescaped =
+      megaApi[0]->unescapeFsIncompatible(escaped);
+
+    // Release escaped, we're done with it.
+    delete[] escaped;
+    ASSERT_NE(unescaped, nullptr);
+
+    // Compare and release.
+    const bool eq = input == string(unescaped);
+    delete[] unescaped;
+
+    EXPECT_TRUE(eq);
+}
+
+TEST_F(SdkTest, UnescapesIncompatibleCharactersOnUpload)
+{
+    // a/b/c!.txt
+    static const string fileName = "a%2fb%2fc%21.txt";
+
+    // For convenience.
+    MegaApi* api = megaApi[0].get();
+
+    // Get root node.
+    unique_ptr<MegaNode> root(api->getRootNode());
+    ASSERT_NE(root, nullptr);
+    
+    // Create file to upload containing escaped characters.
+    deleteFile(fileName);
+    createFile(fileName);
+
+    // Upload the file.
+    TransferTracker tracker(api);
+    api->startUpload(fileName.c_str(), root.get(), &tracker);
+    ASSERT_EQ(API_OK, tracker.waitForResult());
+    
+    // Delete the file, we're done with it.
+    deleteFile(fileName);
+
+    // Check if the file's name was correctly unescaped.
+    root.reset(api->authorizeNode(root.get()));
+    ASSERT_NE(root, nullptr);
+
+    MegaNodeList* children = root->getChildren();
+    ASSERT_NE(children, nullptr);
+
+    MegaNode* child = children->get(0);
+    ASSERT_NE(child, nullptr);
+    ASSERT_STREQ(child->getName(), "a/b/c%21.txt");
 }
 
 TEST_F(SdkTest, RecursiveUploadWithLogout)

--- a/tests/unit/DefaultedFileSystemAccess.h
+++ b/tests/unit/DefaultedFileSystemAccess.h
@@ -27,6 +27,8 @@ namespace mt {
 class DefaultedFileSystemAccess : public mega::FileSystemAccess
 {
 public:
+    using FileSystemAccess::getlocalfstype;
+
     DefaultedFileSystemAccess(const std::string &separator = "/")
     {
         notifyerr = false;
@@ -40,6 +42,10 @@ public:
     mega::DirAccess* newdiraccess() override
     {
         throw NotImplemented{__func__};
+    }
+    bool getlocalfstype(const mega::LocalPath&, mega::FileSystemType& type) const override
+    {
+        return type = mega::FS_UNKNOWN, false;
     }
     void path2local(const std::string*, std::string*) const override
     {

--- a/tests/unit/utils_test.cpp
+++ b/tests/unit/utils_test.cpp
@@ -42,7 +42,7 @@ TEST(Filesystem, EscapesIncompatibleCharacters)
     using namespace mega;
 
     // Most restrictive set of characters.
-    string name = "\\/:?\"<>|*+,;=[]";
+    string name = "\\/:?\"<>|*";
 
     // Build expected result string.
     ostringstream osstream;
@@ -63,11 +63,11 @@ TEST(Filesystem, EscapesIncompatibleCharacters)
     ASSERT_EQ(name, osstream.str());
 }
 
-TEST(Filesystem, UnescapesAllEscapedCharacters)
+TEST(Filesystem, UnescapesEscapedCharacters)
 {
     using namespace mega;
 
-    const string expected = "\\/:?\"<>|*+,;=[]";
+    const string expected = "\\/:?\"<>|*%21";
     string name = expected;
 
     FSACCESS_CLASS fsAccess;


### PR DESCRIPTION
The purpose of this changeset is twofold:
1. Fix a bug where we determine the filesystem of a directory's parent rather than itself.
2. Reorganize the code a little to make things a little cleaner.

The bug fixed by 1. occurs when we try to determine the filesystem type of a path that doesn't end up in a directory separator. Current code truncates the leaf of the path and returns the filesystem type of the resulting path. On Linux, this can result in the wrong filesystem type being returned.

Say our sync root is /mnt/zug. We ask for /mnt/zug's filesystem type but return /mnt's. You can see the problem.

What we do now is check the filesystem type of the path as given. If this fails, we try to determine the filesystem type of path's parent. We'll usually perform a single stat as the path will exist. At worst, we perform two stat calls.

The changes introduced by 2 could be considered aesthetic. To me, it seemed worthwhile moving the POSIX and Windows parts of the code into posix/fs.cpp and win32/fs.cpp respectively. This reduces the use of preprocessor conditionals.
