### PR TITLE
megacli: reshow password prompt when the user presses enter without a…

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -7900,6 +7900,10 @@ void megacli()
             {
                 process_line(line);
             }
+            else if (prompt != COMMAND)
+            {
+                setprompt(prompt);
+            }
             free(line);
             line = NULL;
 


### PR DESCRIPTION
…ny other characters

Without this change, megacli for windows gets stuck and won't accept a password or any other input afterward