### PR TITLE
Buffer space is now correctly allocated.

### DIFF
--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1070,11 +1070,11 @@ struct StandardClient : public MegaApp
             std::vector<uint8_t> buffer;
             std::ifstream istream(p, ios::binary);
 
-            buffer.reserve(mn->data.size());
+            buffer.resize(mn->data.size());
 
             istream.read(reinterpret_cast<char *>(buffer.data()), buffer.capacity());
 
-            if (static_cast<size_t>(istream.gcount()) != buffer.capacity()
+            if (static_cast<size_t>(istream.gcount()) != buffer.size()
                 || !std::equal(mn->data.begin(), mn->data.end(), buffer.begin()))
             {
                 return false;


### PR DESCRIPTION
Use resize(...) instead of reserve(...).