### PR TITLE
SDK-1177. Avoid sending large numbers of "server busy" event 99427 on recovery

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -862,7 +862,7 @@ private:
     HttpReq* badhostcs;
 
     // Working lock
-    HttpReq* workinglockcs;
+    unique_ptr<HttpReq> workinglockcs;
 
     // notify URL for new server-client commands
     string scnotifyurl;
@@ -1057,6 +1057,10 @@ public:
     // reqs[r] is open for adding commands
     // reqs[r^1] is being processed on the API server
     HttpReq* pendingcs;
+
+    // Only queue the "Server busy" event once, until the current cs completes, otherwise we may DDOS 
+    // ourselves in cases where many clients get 500s for a while and then recover at the same time
+    bool pendingcs_serverBusySent = false;
 
     // pending HTTP requests
     pendinghttp_map pendinghttp;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1130,6 +1130,7 @@ void MegaClient::init()
     pendingsc.reset();
     pendingscUserAlerts.reset();
     mBlocked = false;
+    pendingcs_serverBusySent = false;
 
     btcs.reset();
     btsc.reset();
@@ -1166,7 +1167,6 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
     usealtdownport = false;
     usealtupport = false;
     retryessl = false;
-    workinglockcs = NULL;
     scpaused = false;
     asyncfopens = 0;
     achievements_enabled = false;
@@ -1308,7 +1308,6 @@ MegaClient::~MegaClient()
 
     delete pendingcs;
     delete badhostcs;
-    delete workinglockcs;
     delete sctable;
     delete tctable;
     delete dbaccess;
@@ -1973,9 +1972,11 @@ void MegaClient::exec()
             {
                 if (reqs.cmdspending())
                 {
+                    abortlockrequest();
                     pendingcs = new HttpReq();
                     pendingcs->protect = true;
                     pendingcs->logname = clientname + "cs ";
+                    pendingcs_serverBusySent = false;
 
                     bool suppressSID = true;
                     reqs.serverrequest(pendingcs->out, suppressSID, pendingcs->includesFetchingNodes);
@@ -2303,7 +2304,11 @@ void MegaClient::exec()
                 }
                 else if (workinglockcs->in == "0")
                 {
-                    sendevent(99425, "Timeout (server busy)", 0);
+                    if (!pendingcs_serverBusySent)
+                    {
+                        sendevent(99425, "Timeout (server busy)", 0);
+                        pendingcs_serverBusySent = true;
+                    }
                     pendingcs->lastdata = Waiter::ds;
                 }
                 else
@@ -2312,8 +2317,7 @@ void MegaClient::exec()
                     disconnecttimestamp = Waiter::ds + HttpIO::CONNECTTIMEOUT;
                 }
 
-                delete workinglockcs;
-                workinglockcs = NULL;
+                workinglockcs.reset();
                 requestLock = false;
             }
             else if (workinglockcs->status == REQ_FAILURE
@@ -2321,8 +2325,7 @@ void MegaClient::exec()
             {
                 LOG_warn << "Failed lock request. Retrying...";
                 btworkinglock.backoff();
-                delete workinglockcs;
-                workinglockcs = NULL;
+                workinglockcs.reset();
             }
         }
 
@@ -2938,7 +2941,8 @@ void MegaClient::exec()
         if (!workinglockcs && requestLock && btworkinglock.armed())
         {
             LOG_debug << "Sending lock request";
-            workinglockcs = new HttpReq();
+            workinglockcs.reset(new HttpReq());
+            workinglockcs->logname = clientname + "accountBusyCheck ";
             workinglockcs->posturl = APIURL;
             workinglockcs->posturl.append("cs?");
             workinglockcs->posturl.append(auth);
@@ -3990,8 +3994,7 @@ void MegaClient::catchup()
 
 void MegaClient::abortlockrequest()
 {
-    delete workinglockcs;
-    workinglockcs = NULL;
+    workinglockcs.reset();
     btworkinglock.reset();
     requestLock = false;
     disconnecttimestamp = NEVER;


### PR DESCRIPTION
Only queue the "Server busy" event once, until the current cs completes, otherwise we may DDOS
ourselves in cases where many clients get 500s for a while and then recover at the same time