### PR TITLE
SDK-1179: We logged "Disabling curl timeout" when reporting a timeout to curl

### DIFF
--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -653,7 +653,6 @@ void CurlHttpIO::processcurlevents(direction_t d)
 
     int dummy = 0;
     SockInfoMap *socketmap = &curlsockets[d];
-    m_time_t *timeout = &curltimeoutreset[d];
     bool *paused = &arerequestspaused[d];
 
     for (SockInfoMap::iterator it = socketmap->begin(); !(*paused) && it != socketmap->end();)
@@ -683,11 +682,10 @@ void CurlHttpIO::processcurlevents(direction_t d)
 #endif
     }
 
-    m_time_t value = *timeout;
-    if (value >= 0 && value <= Waiter::ds)
+    if (curltimeoutreset[d] >= 0 && curltimeoutreset[d] <= Waiter::ds)
     {
-        *timeout = -1;
-        LOG_debug << "Disabling cURL timeout";
+        curltimeoutreset[d] = -1;
+        LOG_debug << "Timeout from cURL reached for " << d << " at " << Waiter::ds;
         curl_multi_socket_action(curlm[d], CURL_SOCKET_TIMEOUT, 0, &dummy);
     }
 
@@ -2592,6 +2590,7 @@ int CurlHttpIO::upload_socket_callback(CURL *e, curl_socket_t s, int what, void 
 int CurlHttpIO::timer_callback(CURLM *, long timeout_ms, void *userp, direction_t d)
 {
     CurlHttpIO *httpio = (CurlHttpIO *)userp;
+    auto oldValue = httpio->curltimeoutreset[d];
     if (timeout_ms < 0)
     {
         httpio->curltimeoutreset[d] = -1;
@@ -2607,7 +2606,10 @@ int CurlHttpIO::timer_callback(CURLM *, long timeout_ms, void *userp, direction_
         httpio->curltimeoutreset[d] = Waiter::ds + timeoutds;
     }
 
-    LOG_debug << "Set cURL timeout[" << d << "] to " << httpio->curltimeoutreset[d] << " ms from " << timeout_ms;
+    if (oldValue != httpio->curltimeoutreset[d])
+    {
+        LOG_debug << "Set cURL timeout[" << d << "] to " << httpio->curltimeoutreset[d] << " from " << timeout_ms << "(ms) at ds: " << Waiter::ds;
+    }
     return 0;
 }
 

--- a/src/win32/waiter.cpp
+++ b/src/win32/waiter.cpp
@@ -25,26 +25,9 @@
 namespace mega {
 dstime Waiter::ds;
 
-#ifndef WINDOWS_PHONE
-PGTC pGTC;
-static ULONGLONG tickhigh;
-static DWORD prevt;
-#endif
-
 WinWaiter::WinWaiter()
 {
 #ifndef WINDOWS_PHONE
-    if (!pGTC) 
-    {
-        #pragma warning(suppress:4191)
-        pGTC = (PGTC)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetTickCount64");
-    }
-
-    if (!pGTC)
-    {
-        tickhigh = 0;
-        prevt = 0;
-    }
     externalEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 #else
     externalEvent = CreateEventEx(NULL, NULL, 0, EVENT_ALL_ACCESS);
@@ -61,28 +44,7 @@ WinWaiter::~WinWaiter()
 // FIXME: restore thread safety for applications using multiple MegaClient objects
 void Waiter::bumpds()
 {
-#ifdef WINDOWS_PHONE
 	ds = dstime(GetTickCount64() / 100);
-#else
-    if (pGTC)
-    {
-        ds = dstime(pGTC() / 100);
-    }
-    else
-    {
-        // emulate GetTickCount64() on XP
-        DWORD t = GetTickCount();
-
-        if (t < prevt)
-        {
-            tickhigh += 0x100000000;
-        }
-
-        prevt = t;
-
-        ds = dstime((t + tickhigh) / 100);
-    }
-#endif
 }
 
 // wait for events (socket, I/O completion, timeout + application events)


### PR DESCRIPTION
Instead of that, now logging "Timeout from cURL reached" just before we call cURL back to let it know.
Also logging which cURL instance - api, get, or put.
Also logging the Waiter::ds value so we can confirm it's not reporting early.
Also removed some XP-specific Waiter code which doesn't have GetTickCount64().