### PR TITLE
SDK-1180: Fix waiter notifications on MacOS

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -107,7 +107,7 @@ struct MEGA_API HttpReqCommandPutFA : public HttpReq, public Command
     void procresult();
 
     // progress information
-    virtual m_off_t transferred(MegaClient*);
+    virtual m_off_t transferred(MegaClient*) override;
 
     HttpReqCommandPutFA(MegaClient*, handle, fatype, std::unique_ptr<string> faData, bool);
 

--- a/include/mega/posix/megawaiter.h
+++ b/include/mega/posix/megawaiter.h
@@ -24,6 +24,7 @@
 
 #include "mega/waiter.h"
 #include <mutex>
+#include <atomic>
 
 namespace mega {
 struct PosixWaiter : public Waiter
@@ -45,8 +46,7 @@ struct PosixWaiter : public Waiter
 
 protected:
     int m_pipe[2];
-    std::mutex mMutex;
-    bool alreadyNotified = false;
+    std::atomic<int> mAtomicBytesSent { 0 };
 };
 } // namespace
 

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1706,8 +1706,8 @@ public:
     {
         const fs::path root = makeNewTestRoot(LOCAL_TEST_FOLDER);
 
-        client0 = std::make_unique<StandardClient>(root, "c0");
-        client1 = std::make_unique<StandardClient>(root, "c1");
+        client0 = ::mega::make_unique<StandardClient>(root, "c0");
+        client1 = ::mega::make_unique<StandardClient>(root, "c1");
 
         client0->logcb = true;
         client1->logcb = true;


### PR DESCRIPTION
The pipe() call was setting the read file descriptor to 3 on many calls
Possibly the first call on each thread
If the 3 file descriptor was closed, the next pipe() call would deliver 3 again
And ultimately one waiter could steal the notifies of another by reading the byte from the pipe
Which would leave that other waiter stalled.