### PR TITLE
Fix compilation for ENABLE_PERFORMANCE_LOGGER

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -11272,7 +11272,7 @@ void MegaClient::fetchnodes(bool nocache)
 
         // allow sc requests to start 
         scsn.setScsn(cachedscsn);
-        LOG_info << "Session loaded from local cache. SCSN: " << scsn;
+        LOG_info << "Session loaded from local cache. SCSN: " << scsn.text();
 
 #ifdef ENABLE_SYNC
         resumeResumableSyncs();


### PR DESCRIPTION
The `logValue()` is overloaded in the performance logger. In consequence, the compilation fails since it's not able to decide which
version of the method should use. By passing the `const char*`, the issue is solved.