### PR TITLE
SDK-1190 - Create local nodes even if their parent doesn't exist in the cloud.

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1335,7 +1335,8 @@ public:
     void syncupdate();
 
     // create missing folders, copy/start uploading missing files
-    bool syncup(LocalNode*, dstime*);
+    bool syncup(LocalNode* l, dstime* nds, size_t& parentPending);
+    bool syncup(LocalNode* l, dstime* nds);
 
     // sync putnodes() completion
     void putnodes_sync_result(error, NewNode*, int);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -12891,7 +12891,7 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
 // if attached to an existing node
 // l and n are assumed to be folders and existing on both sides or scheduled
 // for creation
-bool MegaClient::syncup(LocalNode* l, dstime* nds)
+bool MegaClient::syncup(LocalNode* l, dstime* nds, size_t& parentPending)
 {
     bool insync = true;
 
@@ -12901,6 +12901,9 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
 
     // build array of sync-relevant (newest alias wins) remote children by name
     attr_map::iterator ait;
+
+    // Number of nodes waiting for their parent to be created.
+    size_t numPending = 0;
 
     if (l->node)
     {
@@ -13179,8 +13182,9 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                     }
 
                     // recurse into directories of equal name
-                    if (!syncup(ll, nds))
+                    if (!syncup(ll, nds, numPending))
                     {
+                        parentPending += numPending;
                         return false;
                     }
                     continue;
@@ -13371,7 +13375,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                 LOG_err << "LocalNode created and reported " << ll->name;
             }
         }
-        else
+        else if (ll->parent->node)
         {
             ll->created = true;
 
@@ -13384,25 +13388,43 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
             if (synccreate.size() >= MAX_NEWNODES)
             {
                 LOG_warn << "Stopping syncup due to MAX_NEWNODES";
+                parentPending += numPending;
                 return false;
             }
+        }
+        else
+        {
+            LOG_debug << "Skipping syncup of "
+                      << ll->name
+                      << " as its parent doesn't exist.";
+            ++numPending;
         }
 
         if (ll->type == FOLDERNODE)
         {
-            if (!syncup(ll, nds))
+            if (!syncup(ll, nds, numPending))
             {
+                parentPending += numPending;
                 return false;
             }
         }
     }
 
-    if (insync && l->node)
+    if (insync && l->node && numPending == 0)
     {
         l->treestate(TREESTATE_SYNCED);
     }
 
+    parentPending += numPending;
+
     return true;
+}
+
+bool MegaClient::syncup(LocalNode* l, dstime* nds)
+{
+    size_t numPending = 0;
+
+    return syncup(l, nds, numPending) && numPending == 0;
 }
 
 // execute updates stored in synccreate[]

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1267,11 +1267,13 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
     LOG_verbose << "Scanning: " << path << " in=" << initializing << " full=" << fullscan << " l=" << l;
     LocalPath* localpathNew = localname ? input_localpath : &tmppath;
 
-    // postpone moving nodes into nonexistent parents
-    if (parent && !parent->node)
+    if (parent)
     {
-        LOG_warn << "Parent doesn't exist yet: " << path;
-        return (LocalNode*)~0;
+        if (state != SYNC_INITIALSCAN && !parent->node)
+        {
+            LOG_warn << "Parent doesn't exist yet: " << path;
+            return (LocalNode*)~0;
+        }
     }
 
     // attempt to open/type this file


### PR DESCRIPTION
The purpose of this changeset is to allow local nodes to be created even when their parent does not exist in the cloud.

This is necessary in several situations, one of them coming from the feature/ignorefile branch. There, the local node tree contains all nodes, regardless of whether they are excluded or not. Excluded nodes are not pushed to the cloud and so it is possible that a given local node has a parent who does not exist in the cloud.

Without this changset, it is possible to trigger an infinite loop while performing the initial scan. That is, we would not be able to create a local node because its parent did not have a remote node, which we couldn't do because the parent is excluded.
