### PR TITLE
#SNC-1786. Allow copySyncDataToCache to receive sync error too

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -3082,6 +3082,7 @@ class MegaRequest
          * - MegaApi::exportNode - Returns true
          * - MegaApi::disableExport - Returns false
          * - MegaApi::inviteToChat - Returns the privilege level wanted for the user
+         * - MegaApi::copySyncDataToCache - Returns the sync error
          *
          * @return Access level related to the request
          */
@@ -13031,7 +13032,8 @@ class MegaApi
          * - MegaRequest::getName - Returns the name of the sync
          * - MegaRequest::getLink - Returns the path of the remote folder
          * - MegaRequest::getNumber - Returns the local filesystem fingreprint
-         * - MegaRequest::setNumDetails - Returns if sync is temporarily disabled
+         * - MegaRequest::getNumDetails - Returns the sync error (if any)
+         * - MegaRequest::getAccess - Returns if the sync is temporarily disabled
          * - MegaRequest::getFlag - if sync is enabled
 
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
@@ -13045,10 +13047,12 @@ class MegaApi
          * @param localfp Filesystem fingerprint
          * @param enabled If the sync is enabled by the user
          * @param temporaryDisabled If the sync is temporarily disabled
+         * @param syncError Sync error (if any)
          * @param listener MegaRequestListener to track this request
          */
         void copySyncDataToCache(const char *localFolder, const char *name, MegaHandle megaHandle, const char *remotePath,
-                                 long long localfp, bool enabled, bool temporaryDisabled, MegaRequestListener *listener = NULL);
+                                 long long localfp, bool enabled, bool temporaryDisabled, MegaSync::Error syncError = MegaSync::Error::NO_SYNC_ERROR,
+                                 MegaRequestListener *listener = NULL);
         /**
          * @brief Copy sync data to SDK cache.
          *
@@ -13063,7 +13067,8 @@ class MegaApi
          * - MegaRequest::getName - Returns the name of the sync
          * - MegaRequest::getLink - Returns the path of the remote folder
          * - MegaRequest::getNumber - Returns the local filesystem fingreprint
-         * - MegaRequest::setNumDetails - Returns if sync is temporarily disabled
+         * - MegaRequest::getNumDetails - Returns the sync error (if any)
+         * - MegaRequest::getAccess - Returns if the sync is temporarily disabled
          * - MegaRequest::getFlag - if sync is enabled
 
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
@@ -13076,10 +13081,12 @@ class MegaApi
          * @param localfp Filesystem fingerprint
          * @param enabled If the sync is enabled by the user
          * @param temporaryDisabled If the sync is temporarily disabled
+         * @param syncError Sync error (if any)
          * @param listener MegaRequestListener to track this request
          */
         void copySyncDataToCache(const char *localFolder, MegaHandle megaHandle, const char *remotePath,
-                                 long long localfp, bool enabled, bool temporaryDisabled, MegaRequestListener *listener = NULL);
+                                 long long localfp, bool enabled, bool temporaryDisabled, MegaSync::Error syncError = MegaSync::Error::NO_SYNC_ERROR,
+                                 MegaRequestListener *listener = NULL);
         /**
          * @brief Copy sync data to SDK cache.
          *

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2334,7 +2334,7 @@ class MegaApiImpl : public MegaApp
         void syncFolder(const char *localFolder, const char *name, MegaHandle megaHandle, MegaRegExp *regExp = NULL, MegaRequestListener* listener = NULL);
         void syncFolder(const char *localFolder, const char *name, MegaNode *megaFolder, MegaRegExp *regExp = NULL, MegaRequestListener* listener = NULL);
         void copySyncDataToCache(const char *localFolder, const char *name, MegaHandle megaHandle, const char *remotePath,
-                                          long long localfp, bool enabled, bool temporaryDisabled, MegaRequestListener *listener = NULL);
+                                          long long localfp, bool enabled, bool temporaryDisabled, MegaSync::Error syncError, MegaRequestListener *listener = NULL);
         void copyCachedStatus(int storageStatus, int blockStatus, int businessStatus, MegaRequestListener *listener = NULL);
         void removeSync(handle nodehandle, MegaRequestListener *listener=NULL);
         void removeSync(int syncTag, MegaRequestListener *listener=NULL);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3180,15 +3180,15 @@ void MegaApi::syncFolder(const char *localFolder, MegaHandle megaHandle, MegaReq
 }
 
 void MegaApi::copySyncDataToCache(const char *localFolder, const char *name, MegaHandle megaHandle, const char *remotePath,
-                                  long long localfp, bool enabled, bool temporaryDisabled, MegaRequestListener *listener)
+                                  long long localfp, bool enabled, bool temporaryDisabled, MegaSync::Error syncError, MegaRequestListener *listener)
 {
-    pImpl->copySyncDataToCache(localFolder, name, megaHandle, remotePath, localfp, enabled, temporaryDisabled, listener);
+    pImpl->copySyncDataToCache(localFolder, name, megaHandle, remotePath, localfp, enabled, temporaryDisabled, syncError, listener);
 }
 
 void MegaApi::copySyncDataToCache(const char *localFolder, MegaHandle megaHandle, const char *remotePath,
-                                  long long localfp, bool enabled, bool temporaryDisabled, MegaRequestListener *listener)
+                                  long long localfp, bool enabled, bool temporaryDisabled, MegaSync::Error syncError, MegaRequestListener *listener)
 {
-    pImpl->copySyncDataToCache(localFolder, nullptr, megaHandle, remotePath, localfp, enabled, temporaryDisabled, listener);
+    pImpl->copySyncDataToCache(localFolder, nullptr, megaHandle, remotePath, localfp, enabled, temporaryDisabled, syncError, listener);
 }
 
 void MegaApi::copyCachedStatus(int storageStatus, int blockStatus, int businessStatus, MegaRequestListener *listener)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -2724,7 +2724,7 @@ void MegaClient::exec()
                     for (it = syncs.begin(); it != syncs.end(); it++)
                     {
                         // make sure that the remote synced folder still exists
-                        if (!(*it)->localroot->node)
+                        if (!(*it)->localroot->node && (*it)->state != SYNC_FAILED)
                         {
                             LOG_err << "The remote root node doesn't exist";
                             (*it)->changestate(SYNC_FAILED, REMOTE_NODE_NOT_FOUND);
@@ -2916,7 +2916,10 @@ void MegaClient::exec()
                         if (!(*it)->localroot->node)
                         {
                             LOG_err << "The remote root node doesn't exist";
-                            (*it)->changestate(SYNC_FAILED, REMOTE_NODE_NOT_FOUND);
+                            if ((*it)->state != SYNC_FAILED )
+                            {
+                                (*it)->changestate(SYNC_FAILED, REMOTE_NODE_NOT_FOUND);
+                            }
                         }
                         else
                         {
@@ -12809,7 +12812,7 @@ error MegaClient::addsync(SyncConfig syncConfig, const char* debris, string* loc
     {
         if (fa->type == FOLDERNODE)
         {
-            LOG_debug << "Adding sync: " << syncConfig.getLocalPath() << " vs " << remotenode->displaypath();;
+            LOG_debug << "Adding sync: " << syncConfig.getLocalPath() << " vs " << remotenode->displaypath();
             int tag = syncConfig.getTag();
 
             // Note localpath is stored as utf8 in syncconfig as passed from the apps!


### PR DESCRIPTION
This is useful to be able to restore sync configurations from previous sessions, not only 
to pass app sync cache to sdk's cache

- also do not override sync error for remote not found when already
failed

