### PR TITLE
SDK-1202. Initial targeted syncdown()/syncup() support

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -168,6 +168,11 @@ public:
 
     bool checkError(Error &errorDetails, JSON &json);
 
+    void addToNodePendingCommands(handle h, MegaClient* client);
+    void addToNodePendingCommands(Node* n);
+    void removeFromNodePendingCommands(handle h, MegaClient* client);
+    void removeFromNodePendingCommands(Node* n);
+
     MEGA_DEFAULT_COPY_MOVE(Command)
 };
 
@@ -471,6 +476,7 @@ public:
 class MEGA_API CommandDelNode : public Command
 {
     handle h;
+    handle parent;
     std::function<void(handle, error)> mResultFunction;
 
 public:

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -499,7 +499,10 @@ public:
     // whether we allow the automatic resumption of syncs
     bool allowAutoResumeSyncs = true;
 
+    // manage syncdown flags inside the syncs
+    void setAllSyncsNeedSyncdown();
     bool anySyncNeedsTargetedSyncdown();
+    void setAllSyncsNeedSyncup();
 #endif
 
     // if set, symlinks will be followed except in recursive deletions
@@ -1283,11 +1286,6 @@ public:
     // app scanstate flag
     bool syncscanstate;
 
-    // scan required flag
-    bool syncdownrequired;
-
-    bool syncuprequired;
-
     // block local fs updates processing while locked ops are in progress
     bool syncfsopsfailed;
 
@@ -1339,13 +1337,13 @@ public:
     void syncupdate();
 
     // create missing folders, copy/start uploading missing files
-    bool syncup(LocalNode*, dstime*, bool targetedOnly);
+    bool syncup(LocalNode*, dstime*, bool scanWholeSubtree);
 
     // sync putnodes() completion
     void putnodes_sync_result(error, vector<NewNode>&);
 
     // start downloading/copy missing files, create missing directories
-    bool syncdown(LocalNode * const, LocalPath&, bool targetedOnly);
+    bool syncdown(LocalNode * const, LocalPath&, bool scanWholeSubtree);
 
     // move nodes to //bin/SyncDebris/yyyy-mm-dd/ or unlink directly
     void movetosyncdebris(Node*, bool);

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -498,6 +498,8 @@ public:
 
     // whether we allow the automatic resumption of syncs
     bool allowAutoResumeSyncs = true;
+
+    bool anySyncNeedsTargetedSyncdown();
 #endif
 
     // if set, symlinks will be followed except in recursive deletions
@@ -1337,13 +1339,13 @@ public:
     void syncupdate();
 
     // create missing folders, copy/start uploading missing files
-    bool syncup(LocalNode*, dstime*);
+    bool syncup(LocalNode*, dstime*, bool targetedOnly);
 
     // sync putnodes() completion
     void putnodes_sync_result(error, vector<NewNode>&);
 
     // start downloading/copy missing files, create missing directories
-    bool syncdown(LocalNode*, LocalPath&, bool);
+    bool syncdown(LocalNode * const, LocalPath&, bool targetedOnly);
 
     // move nodes to //bin/SyncDebris/yyyy-mm-dd/ or unlink directly
     void movetosyncdebris(Node*, bool);

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -123,7 +123,10 @@ struct CommandChain
 
     void push_back(Command* c)
     {
-        if (!chain) chain.reset(new std::list<Command*>);
+        if (!chain)
+        {
+            chain.reset(new std::list<Command*>);
+        }
         chain->push_back(c);
     }
 
@@ -377,9 +380,11 @@ struct MEGA_API LocalNode : public File
     // global sync reference
     handle syncid = mega::UNDEF;
 
-    enum { synctree_resolved = 0, 
-           synctree_descendantflagged = 1, 
-           synctree_scanhere = 2 };  // scan here also implies checking immdiate children for synctree_descendantflagged
+    enum : unsigned
+    {
+        SYNCTREE_RESOLVED = 0,
+        SYNCTREE_DESCENDANT_FLAGGED = 1,
+        SYNCTREE_SCAN_HERE = 2 };  // scan here also implies checking immdiate children for synctree_descendantflagged
 
     struct
     {
@@ -396,11 +401,10 @@ struct MEGA_API LocalNode : public File
         bool checked : 1;
 
         // needs another syncdown after pending changes
-        unsigned syncdownTargetedAction: 2;
+        unsigned syncdownTargetedAction : 2;
 
         // at least one child has needsAnotherSyncdown set
-        unsigned syncupTargetedAction: 2;
-
+        unsigned syncupTargetedAction : 2;
     };
 
     // set the syncupTargetedAction for this, and parents

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -403,10 +403,10 @@ struct MEGA_API LocalNode : public File
 
     };
 
-    // set the syncupPartialAction for this, and parents
+    // set the syncupTargetedAction for this, and parents
     void needsFutureSyncup();
 
-    // set the syncupPartialAction for this, and parents
+    // set the syncdownTargetedAction for this, and parents
     void needsFutureSyncdown();
 
     // current subtree sync state: current and displayed

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -114,9 +114,9 @@ private:
 };
 
 struct CommandChain
-{   
+{
     // convenience functions, hides the unique_ptr aspect, removes it when empty
-    bool empty() 
+    bool empty()
     {
         return !chain || chain->empty();
     }
@@ -403,7 +403,7 @@ struct MEGA_API LocalNode : public File
         // needs another syncdown after pending changes
         unsigned syncdownTargetedAction : 2;
 
-        // at least one child has needsAnotherSyncdown set
+        // needs another syncup after pending changes
         unsigned syncupTargetedAction : 2;
     };
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -41,6 +41,32 @@ void Command::cancel()
     canceled = true;
 }
 
+void Command::addToNodePendingCommands(handle h, MegaClient* client)
+{
+    if (auto node = client->nodebyhandle(h))
+    {
+        addToNodePendingCommands(node);
+    }
+}
+
+void Command::addToNodePendingCommands(Node* node)
+{
+    node->mPendingChanges.push_back(this);
+}
+
+void Command::removeFromNodePendingCommands(handle h, MegaClient* client)
+{
+    if (auto node = client->nodebyhandle(h))
+    {
+        removeFromNodePendingCommands(node);
+    }
+}
+
+void Command::removeFromNodePendingCommands(Node* node)
+{
+    node->mPendingChanges.erase(this);
+}
+
 // returns completed command JSON string
 const char* Command::getstring() const
 {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1321,7 +1321,7 @@ bool CommandPutNodes::procresult(Result r)
                 // A node has been added by a regular (non sync) putnodes
                 // inside a synced folder, so force a syncdown to detect
                 // and sync the changes.
-                client->syncdownrequired = true;
+                client->setAllSyncsNeedSyncdown();
             }
         }
 #endif

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1011,7 +1011,7 @@ bool CommandSetAttr::procresult(Result r)
     if (Node* n = client->nodebyhandle(h))
     {
         // in case the name of the file/folder changed
-        if (n && n->parent && n->parent->localnode)
+        if (n->parent && n->parent->localnode)
         {
             n->parent->localnode->needsFutureSyncdown();
         }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -22128,7 +22128,7 @@ void MegaApiImpl::update()
     LOG_debug << "PendingCS? " << (client->pendingcs != NULL);
     LOG_debug << "PendingFA? " << client->activefa.size() << " active, " << client->queuedfa.size() << " queued";
     LOG_debug << "FLAGS: " << client->syncactivity
-              << " " << client->syncdownrequired << " " << client->syncdownretry
+              << " " << client->anySyncNeedsTargetedSyncdown() << " " << client->syncdownretry
               << " " << client->syncfslockretry << " " << client->syncfsopsfailed
               << " " << client->syncnagleretry << " " << client->syncscanfailed
               << " " << client->syncops << " " << client->syncscanstate

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -13159,10 +13159,6 @@ void MegaApiImpl::rename_result(handle h, error e)
     MegaRequestPrivate* request = requestMap.at(client->restag);
     if(!request || (request->getType() != MegaRequest::TYPE_MOVE)) return;
 
-#ifdef ENABLE_SYNC
-    client->syncdownrequired = true;
-#endif
-
     request->setNodeHandle(h);
     fireOnRequestFinish(request, make_unique<MegaErrorPrivate>(e));
 }
@@ -13176,10 +13172,6 @@ void MegaApiImpl::unlink_result(handle h, error e)
     {
         return;
     }
-
-#ifdef ENABLE_SYNC
-    client->syncdownrequired = true;
-#endif
 
     if (request->getType() != MegaRequest::TYPE_MOVE)
     {
@@ -13421,10 +13413,6 @@ void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<
                     (request->getType() != MegaRequest::TYPE_CREATE_ACCOUNT) &&
                     (request->getType() != MegaRequest::TYPE_RESTORE) &&
                     (request->getType() != MegaRequest::TYPE_COMPLETE_BACKGROUND_UPLOAD))) return;
-
-#ifdef ENABLE_SYNC
-    client->syncdownrequired = true;
-#endif
 
     if (request->getType() == MegaRequest::TYPE_COMPLETE_BACKGROUND_UPLOAD)
     {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1360,7 +1360,9 @@ bool MegaClient::anySyncNeedsTargetedSyncdown()
 {
     for (Sync* sync : syncs)
     {
-        if (sync->localroot->syncdownTargetedAction != LocalNode::synctree_resolved)
+        if (sync->state != SYNC_CANCELED &&
+            sync->state != SYNC_FAILED &&
+            sync->localroot->syncdownTargetedAction != LocalNode::synctree_resolved)
         {
             return true;
         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13987,6 +13987,11 @@ void MegaClient::delsync(Sync* sync, bool deletecache)
         sync->statecachetable = NULL;
     }
 
+    if (deletecache && syncConfigs)
+    {
+        syncConfigs->remove(sync->getConfig().getLocalPath());
+    }
+
     syncactivity = true;
 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1346,35 +1346,6 @@ void MegaClient::setKeepSyncsAfterLogout(bool keepSyncsAfterLogout)
 {
     mKeepSyncsAfterLogout = keepSyncsAfterLogout;
 }
-#endif
-
-std::string MegaClient::getPublicLink(bool newLinkFormat, nodetype_t type, handle ph, const char *key)
-{
-    string strlink = "https://mega.nz/";
-    string nodeType;
-    if (newLinkFormat)
-    {
-        nodeType = (type == FOLDERNODE ?  "folder/" : "file/");
-    }
-    else
-    {
-        nodeType = (type == FOLDERNODE ? "#F!" : "#!");
-    }
-
-    strlink += nodeType;
-
-    Base64Str<MegaClient::NODEHANDLE> base64ph(ph);
-    strlink += base64ph;
-    strlink += (newLinkFormat ? "#" : "");
-
-    if (key)
-    {
-        strlink += (newLinkFormat ? "" : "!");
-        strlink += key;
-    }
-
-    return strlink;
-}
 
 bool MegaClient::anySyncNeedsTargetedSyncdown()
 {
@@ -1404,6 +1375,35 @@ void MegaClient::setAllSyncsNeedSyncup()
     {
         sync->localroot->syncupTargetedAction = LocalNode::synctree_scanhere;
     }
+}
+#endif  // ENABLE_SYNC
+
+std::string MegaClient::getPublicLink(bool newLinkFormat, nodetype_t type, handle ph, const char *key)
+{
+    string strlink = "https://mega.nz/";
+    string nodeType;
+    if (newLinkFormat)
+    {
+        nodeType = (type == FOLDERNODE ?  "folder/" : "file/");
+    }
+    else
+    {
+        nodeType = (type == FOLDERNODE ? "#F!" : "#!");
+    }
+
+    strlink += nodeType;
+
+    Base64Str<MegaClient::NODEHANDLE> base64ph(ph);
+    strlink += base64ph;
+    strlink += (newLinkFormat ? "#" : "");
+
+    if (key)
+    {
+        strlink += (newLinkFormat ? "" : "!");
+        strlink += key;
+    }
+
+    return strlink;
 }
 
 // nonblocking state machine executing all operations currently in progress

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13317,7 +13317,7 @@ bool MegaClient::syncdown(LocalNode * const l, LocalPath& localpath, bool scanWh
                 // recurse into directories of equal name
                 if (!syncdown(ll, localpath, scanWholeSubtree))
                 {
-                    l->syncdownTargetedAction = std::max<int>(originalTargetedAction, LocalNode::SYNCTREE_DESCENDANT_FLAGGED);
+                    l->syncdownTargetedAction = std::max<unsigned>(originalTargetedAction, LocalNode::SYNCTREE_DESCENDANT_FLAGGED);
                     success = false;
                 }
 
@@ -14092,13 +14092,6 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds, size_t& parentPending, bool s
 
     return true;
 }
-
-//bool MegaClient::syncup(LocalNode* l, dstime* nds, bool scanWholeSubtree)
-//{
-//    size_t numPending = 0;
-//
-//    return syncup(l, nds, numPending) && numPending == 0;
-//}
 
 // execute updates stored in synccreate[]
 // must not be invoked while the previous creation operation is still in progress
@@ -15211,7 +15204,7 @@ Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
         return nullptr;
 
     std::string localName = localNode->localname.toName(*fsaccess);
-    
+
     // Only compare metamac if the node doesn't already exist.
     node_vector::const_iterator remoteNode =
       std::find_if(remoteNodes->begin(),

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13507,7 +13507,7 @@ bool MegaClient::syncdown(LocalNode * const l, LocalPath& localpath, bool scanWh
                             {
                                 LOG_debug << "Syncdown not finished";
                             }
-                            l->syncdownTargetedAction = std::max<int>(originalTargetedAction, LocalNode::SYNCTREE_DESCENDANT_FLAGGED);
+                            l->syncdownTargetedAction = std::max<unsigned>(originalTargetedAction, LocalNode::SYNCTREE_DESCENDANT_FLAGGED);
                             success = false;
                         }
                     }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1279,7 +1279,7 @@ void LocalNode::setnameparent(LocalNode* newparent, LocalPath* newlocalpath, std
         {
             // complete the copy/delete operation
             dstime nds = NEVER;
-            sync->client->syncup(parent, &nds, false);
+            sync->client->syncup(parent, &nds, true);
 
             // check if nodes can be immediately created
             bool immediatecreation = (int) sync->client->synccreate.size() == nc;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1325,8 +1325,8 @@ LocalNode::LocalNode()
 , created{false}
 , reported{false}
 , checked{false}
-, syncdownTargetedAction(synctree_resolved)
-, syncupTargetedAction(synctree_resolved)
+, syncdownTargetedAction(SYNCTREE_RESOLVED)
+, syncupTargetedAction(SYNCTREE_RESOLVED)
 {}
 
 // initialize fresh LocalNode object - must be called exactly once
@@ -1339,8 +1339,8 @@ void LocalNode::init(Sync* csync, nodetype_t ctype, LocalNode* cparent, LocalPat
     deleted = false;
     created = false;
     reported = false;
-    syncdownTargetedAction = synctree_resolved;
-    syncupTargetedAction = synctree_resolved;
+    syncdownTargetedAction = SYNCTREE_RESOLVED;
+    syncupTargetedAction = SYNCTREE_RESOLVED;
     syncxfer = true;
     newnode.reset();
     parent_dbid = 0;
@@ -1384,21 +1384,27 @@ void LocalNode::init(Sync* csync, nodetype_t ctype, LocalNode* cparent, LocalPat
 
 void LocalNode::needsFutureSyncup()
 {
-    syncupTargetedAction = syncupTargetedAction < synctree_scanhere ? synctree_scanhere : syncupTargetedAction;
+    syncupTargetedAction = syncupTargetedAction < SYNCTREE_SCAN_HERE ? SYNCTREE_SCAN_HERE : syncupTargetedAction;
     for (auto p = parent; p != NULL; p = p->parent)
     {
-        if (p->syncupTargetedAction >= synctree_descendantflagged) break;
-        p->syncupTargetedAction = synctree_descendantflagged;
+        if (p->syncupTargetedAction >= SYNCTREE_DESCENDANT_FLAGGED)
+        {
+            break;
+        }
+        p->syncupTargetedAction = SYNCTREE_DESCENDANT_FLAGGED;
     }
 }
 
 void LocalNode::needsFutureSyncdown()
 {
-    syncdownTargetedAction = syncdownTargetedAction < synctree_scanhere ? synctree_scanhere : syncdownTargetedAction;
+    syncdownTargetedAction = syncdownTargetedAction < SYNCTREE_SCAN_HERE ? SYNCTREE_SCAN_HERE : syncdownTargetedAction;
     for (auto p = parent; p != NULL; p = p->parent)
     {
-        if (p->syncdownTargetedAction >= synctree_descendantflagged) break;
-        p->syncdownTargetedAction = synctree_descendantflagged;
+        if (p->syncdownTargetedAction >= SYNCTREE_DESCENDANT_FLAGGED)
+        {
+            break;
+        }
+        p->syncdownTargetedAction = SYNCTREE_DESCENDANT_FLAGGED;
     }
 }
 

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -524,7 +524,7 @@ void Transfer::failed(const Error& e, DBTableTransactionCommitter& committer, ds
                 && e != API_EOVERQUOTA
                 && e != API_EPAYWALL)
             {
-                client->syncdownrequired = true;
+                client->setAllSyncsNeedSyncdown();
             }
 #endif
             client->app->file_removed(*it, e);
@@ -931,7 +931,7 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
 #ifdef ENABLE_SYNC
                             if (f->syncxfer)
                             {
-                                client->syncdownrequired = true;
+                                client->setAllSyncsNeedSyncdown();
                             }
 #endif
                             client->app->file_removed(f, API_EWRITE);
@@ -1038,7 +1038,7 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
 #ifdef ENABLE_SYNC
                 if (f->syncxfer)
                 {
-                    client->syncdownrequired = true;
+                    client->setAllSyncsNeedSyncdown();
                 }
 #endif
                 it++; // the next line will remove the current item and invalidate that iterator

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -4586,9 +4586,8 @@ TEST_F(SdkTest, SdkSimpleCommands)
     err = synchronousGetMiscFlags(0);
     ASSERT_EQ(MegaError::API_OK, err) << "Get misc flags failed (error: " << err << ")";
 
-    // getUserEmail() test
+    // leave a valid session, so it works as expected in --RESUMESESSIONS mode
     ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
-
 }
 
 TEST_F(SdkTest, SdkGetCountryCallingCodes)

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -842,10 +842,14 @@ void SdkTest::getAccountsForTest(unsigned howMany)
     }
 
     // wait for logins to complete:
+    bool anyLoginFailed = false;
     for (unsigned index = 0; index < howMany; ++index)
     {
-        ASSERT_EQ(API_OK, trackers[index]->waitForResult()) << " Failed to establish a login/session for accout " << index;
+        auto loginResult = trackers[index]->waitForResult();
+        EXPECT_EQ(API_OK, loginResult) << " Failed to establish a login/session for accout " << index;
+        if (loginResult != API_OK) anyLoginFailed = true;
     }
+    ASSERT_FALSE(anyLoginFailed);
 
     // perform parallel fetchnodes for each
     for (unsigned index = 0; index < howMany; ++index)
@@ -855,10 +859,14 @@ void SdkTest::getAccountsForTest(unsigned howMany)
     }
 
     // wait for fetchnodes to complete:
+    bool anyFetchnodesFailed = false;
     for (unsigned index = 0; index < howMany; ++index)
     {
-        ASSERT_EQ(API_OK, trackers[index]->waitForResult()) << " Failed to fetchnodes for accout " << index;
+        auto fetchnodesResult = trackers[index]->waitForResult();
+        EXPECT_EQ(API_OK, fetchnodesResult) << " Failed to fetchnodes for accout " << index;
+        anyFetchnodesFailed = anyFetchnodesFailed || (fetchnodesResult != API_OK);
     }
+    ASSERT_FALSE(anyFetchnodesFailed);
 
     // In case the last test exited without cleaning up (eg, debugging etc)
     out() << logTime() << "Cleaning up account 0" << endl;
@@ -1080,7 +1088,7 @@ void SdkTest::getUserAttribute(MegaUser *u, int type, int timeout, int apiIndex)
  */
 TEST_F(SdkTest, DISABLED_SdkTestCreateAccount)
 {
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     string email1 = "user@domain.com";
     string pwd = "pwd";
@@ -1132,7 +1140,7 @@ bool veryclose(double a, double b)
 TEST_F(SdkTest, SdkTestNodeAttributes)
 {
     LOG_info << "___TEST Node attributes___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     std::unique_ptr<MegaNode> rootnode{megaApi[0]->getRootNode()};
 
@@ -1355,7 +1363,7 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
 TEST_F(SdkTest, SdkTestExerciseOtherCommands)
 {
     LOG_info << "___TEST SdkTestExerciseOtherCommands___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     /*bool HttpReqCommandPutFA::procresult(Result r)
     bool CommandGetFA::procresult(Result r)
@@ -1452,7 +1460,7 @@ TEST_F(SdkTest, SdkTestExerciseOtherCommands)
 TEST_F(SdkTest, SdkTestResumeSession)
 {
     LOG_info << "___TEST Resume session___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     unique_ptr<char[]> session(dumpSession());
 
@@ -1481,7 +1489,7 @@ TEST_F(SdkTest, SdkTestResumeSession)
 TEST_F(SdkTest, SdkTestNodeOperations)
 {
     LOG_info <<  "___TEST Node operations___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // --- Create a new folder ---
 
@@ -1615,7 +1623,7 @@ TEST_F(SdkTest, SdkTestNodeOperations)
 TEST_F(SdkTest, SdkTestTransfers)
 {
     LOG_info << "___TEST Transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     LOG_info << cwd();
 
@@ -1781,7 +1789,7 @@ TEST_F(SdkTest, SdkTestTransfers)
 TEST_F(SdkTest, SdkTestContacts)
 {
     LOG_info << "___TEST Contacts___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
 
     // --- Check my email and the email of the contact ---
@@ -2138,7 +2146,7 @@ bool SdkTest::checkAlert(int apiIndex, const string& title, handle h, int n)
 TEST_F(SdkTest, SdkTestShares)
 {
     LOG_info << "___TEST Shares___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     MegaShareList *sl;
     MegaShare *s;
@@ -2442,7 +2450,7 @@ TEST_F(SdkTest, SdkTestShares)
 TEST_F(SdkTest, SdkTestShareKeys)
 {
     LOG_info << "___TEST ShareKeys___";
-    getAccountsForTest(3);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(3));
 
     // Three user scenario, with nested shares and new nodes created that need keys to be shared to the other users.
     // User A creates folder and shares it with user B
@@ -2536,7 +2544,7 @@ LocalPath fspathToLocal(const fs::path& p, FSACCESS_CLASS& fsa)
 
 TEST_F(SdkTest, SdkTestFolderIteration)
 {
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     for (int testcombination = 0; testcombination < 2; testcombination++)
     {
@@ -2818,7 +2826,7 @@ bool cmp(const autocomplete::CompletionState& c, std::vector<std::string>& s)
 
 TEST_F(SdkTest, SdkTestConsoleAutocomplete)
 {
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
     using namespace autocomplete;
 
     {
@@ -3448,7 +3456,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
 TEST_F(SdkTest, SdkTestChat)
 {
     LOG_info << "___TEST Chat___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // --- Send a new contact request ---
 
@@ -3592,7 +3600,7 @@ public:
 TEST_F(SdkTest, SdkTestFingerprint)
 {
     LOG_info << "___TEST fingerprint stream/file___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     int filesizes[] = { 10, 100, 1000, 10000, 100000, 10000000 };
     string expected[] = {
@@ -3799,7 +3807,7 @@ namespace mega
 TEST_F(SdkTest, SdkTestCloudraidTransfers)
 {
     LOG_info << "___TEST Cloudraid transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -3937,7 +3945,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
 TEST_F(SdkTest, SdkTestCloudraidTransferWithConnectionFailures)
 {
     LOG_info << "___TEST Cloudraid transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -3992,7 +4000,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransferWithConnectionFailures)
 TEST_F(SdkTest, SdkTestCloudraidTransferWithSingleChannelTimeouts)
 {
     LOG_info << "___TEST Cloudraid transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -4044,7 +4052,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransferWithSingleChannelTimeouts)
 TEST_F(SdkTest, SdkTestOverquotaNonCloudraid)
 {
     LOG_info << "___TEST SdkTestOverquotaNonCloudraid";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -4117,7 +4125,7 @@ TEST_F(SdkTest, SdkTestOverquotaNonCloudraid)
 TEST_F(SdkTest, SdkTestOverquotaCloudraid)
 {
     LOG_info << "___TEST SdkTestOverquotaCloudraid";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -4281,7 +4289,7 @@ CheckStreamedFile_MegaTransferListener* StreamRaidFilePart(MegaApi* megaApi, m_o
 TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
 {
     LOG_info << "___TEST SdkCloudraidStreamingSoakTest";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
 #ifdef MEGASDK_DEBUG_TEST_HOOKS_ENABLED
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
@@ -4436,7 +4444,7 @@ TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
 TEST_F(SdkTest, SdkRecentsTest)
 {
     LOG_info << "___TEST SdkRecentsTest___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     MegaNode *rootnode = megaApi[0]->getRootNode();
 
@@ -4499,7 +4507,7 @@ TEST_F(SdkTest, SdkRecentsTest)
 TEST_F(SdkTest, SdkMediaUploadRequestURL)
 {
     LOG_info << "___TEST MediaUploadRequestURL___";
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
 
     // Create a "media upload" instance
     int apiIndex = 0;
@@ -4518,7 +4526,7 @@ TEST_F(SdkTest, SdkMediaUploadRequestURL)
 
 TEST_F(SdkTest, SdkSimpleCommands)
 {
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     LOG_info << "___TEST SimpleCommands___";
 
     // fetchTimeZone() test
@@ -4526,13 +4534,7 @@ TEST_F(SdkTest, SdkSimpleCommands)
     ASSERT_EQ(MegaError::API_OK, err) << "Fetch time zone failed (error: " << err << ")";
     ASSERT_TRUE(mApi[0].tzDetails && mApi[0].tzDetails->getNumTimeZones()) << "Invalid Time Zone details"; // some simple validation
 
-    // getMiscFlags() -- not logged in
-    logout(0);
-    err = synchronousGetMiscFlags(0);
-    ASSERT_EQ(MegaError::API_OK, err) << "Get misc flags failed (error: " << err << ")";
-
     // getUserEmail() test
-    getAccountsForTest(1);
     std::unique_ptr<MegaUser> user(megaApi[0]->getMyUser());
     ASSERT_TRUE(!!user); // some simple validation
 
@@ -4565,13 +4567,22 @@ TEST_F(SdkTest, SdkSimpleCommands)
     }
 
     err = synchronousKillSession(0, INVALID_HANDLE);
-    ASSERT_EQ(MegaError::API_ESID, err) << "Kill session for unknown seesions shoud fail with API_ESID (error: " << err << ")";
+    ASSERT_EQ(MegaError::API_ESID, err) << "Kill session for unknown sessions shoud fail with API_ESID (error: " << err << ")";
+
+    // getMiscFlags() -- not logged in
+    logout(0);
+    err = synchronousGetMiscFlags(0);
+    ASSERT_EQ(MegaError::API_OK, err) << "Get misc flags failed (error: " << err << ")";
+
+    // getUserEmail() test
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
+
 }
 
 TEST_F(SdkTest, SdkGetCountryCallingCodes)
 {
     LOG_info << "___TEST SdkGetCountryCallingCodes___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     getCountryCallingCodes();
     ASSERT_NE(nullptr, stringListMap);
@@ -4590,7 +4601,7 @@ TEST_F(SdkTest, SdkGetCountryCallingCodes)
 TEST_F(SdkTest, SdkGetRegisteredContacts)
 {
     LOG_info << "___TEST SdkGetRegisteredContacts___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     const std::string js1 = "+0000000010";
     const std::string js2 = "+0000000011";
@@ -4632,7 +4643,7 @@ TEST_F(SdkTest, SdkGetRegisteredContacts)
 TEST_F(SdkTest, DISABLED_invalidFileNames)
 {
     LOG_info << "___TEST invalidFileNames___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     FSACCESS_CLASS fsa;
     auto aux = LocalPath::fromPath(fs::current_path().u8string(), fsa);
@@ -4819,7 +4830,7 @@ TEST_F(SdkTest, DISABLED_invalidFileNames)
 TEST_F(SdkTest, RecursiveUploadWithLogout)
 {
     LOG_info << "___TEST RecursiveUploadWithLogout___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // this one used to cause a double-delete
 
@@ -4850,7 +4861,7 @@ TEST_F(SdkTest, RecursiveUploadWithLogout)
 TEST_F(SdkTest, DISABLED_RecursiveDownloadWithLogout)
 {
     LOG_info << "___TEST RecursiveDownloadWithLogout";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // this one used to cause a double-delete
 
@@ -4894,7 +4905,7 @@ TEST_F(SdkTest, DISABLED_RecursiveDownloadWithLogout)
 TEST_F(SdkTest, SyncResumptionAfterFetchNodes)
 {
     LOG_info << "___TEST SyncResumptionAfterFetchNodes___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // This test has several issues:
     // 1. Remote nodes may not be committed to the sctable database in time for fetchnodes which
@@ -5082,7 +5093,7 @@ TEST_F(SdkTest, SyncResumptionAfterFetchNodes)
     removeSync(sync4Path);
 
     // wait for the sync removals to actually take place
-    std::this_thread::sleep_for(std::chrono::seconds{20});
+    std::this_thread::sleep_for(std::chrono::seconds{5});
 
     cleanUp();
 }

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1507,7 +1507,7 @@ void waitonsyncs(chrono::seconds d = std::chrono::seconds(4), StandardClient* c1
     auto totalTimeoutStart = chrono::steady_clock::now();
     auto start = chrono::steady_clock::now();
     std::vector<StandardClient*> v{ c1, c2, c3, c4 };
-    bool onelastsyncdown = true;
+//    bool onelastsyncdown = true;
     for (;;)
     {
         bool any_add_del = false;
@@ -1548,12 +1548,12 @@ void waitonsyncs(chrono::seconds d = std::chrono::seconds(4), StandardClient* c1
             start = chrono::steady_clock::now();
         }
 
-        if (onelastsyncdown && (chrono::steady_clock::now() - start + d/2) > d)
-        {
-            // synced folders that were removed remotely don't have the corresponding local folder removed unless we prompt an extra syncdown.  // todo:  do we need to fix
-            for (auto vn : v) if (vn) vn->client.syncdownrequired = true;
-            onelastsyncdown = false;
-        }
+        //if (onelastsyncdown && (chrono::steady_clock::now() - start + d/2) > d)
+        //{
+        //    // synced folders that were removed remotely don't have the corresponding local folder removed unless we prompt an extra syncdown.  // todo:  do we need to fix
+        //    for (auto vn : v) if (vn) vn->client.syncdownrequired = true;
+        //    onelastsyncdown = false;
+        //}
 
         for (auto vn : v) if (vn)
         {

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -2049,7 +2049,6 @@ void waitonsyncs(chrono::seconds d = std::chrono::seconds(4), StandardClient* c1
     auto totalTimeoutStart = chrono::steady_clock::now();
     auto start = chrono::steady_clock::now();
     std::vector<StandardClient*> v{ c1, c2, c3, c4 };
-//    bool onelastsyncdown = true;
     for (;;)
     {
         bool any_add_del = false;
@@ -2089,13 +2088,6 @@ void waitonsyncs(chrono::seconds d = std::chrono::seconds(4), StandardClient* c1
         {
             start = chrono::steady_clock::now();
         }
-
-        //if (onelastsyncdown && (chrono::steady_clock::now() - start + d/2) > d)
-        //{
-        //    // synced folders that were removed remotely don't have the corresponding local folder removed unless we prompt an extra syncdown.  // todo:  do we need to fix
-        //    for (auto vn : v) if (vn) vn->client.syncdownrequired = true;
-        //    onelastsyncdown = false;
-        //}
 
         for (auto vn : v) if (vn)
         {


### PR DESCRIPTION
Add the ability to mark a LocalNode for targeted syncup or syncdown.  
Defer making a syncup/syncdown decision about a node if there are already commands being sent to the server affecting that node (this will be very important for Speculative Instant Completion Removal)
Moved some intermediate layer flag setting back to the sync core where it should have been.
