### PR TITLE
Prevent incorrect speeds being reported during network glitches

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -235,7 +235,7 @@ Proxy *HttpIO::getautoproxy()
     if (ieProxyConfig.lpszAutoConfigUrl)
     {
         GlobalFree(ieProxyConfig.lpszAutoConfigUrl);
-    }    
+    }
 #endif
 
 #if defined(__APPLE__) && !(TARGET_OS_IPHONE)
@@ -382,7 +382,7 @@ void HttpReq::dns(MegaClient *client)
         httpio->cancel(this);
         init();
     }
-    
+
     httpio = client->httpio;
     bufpos = 0;
     outpos = 0;
@@ -391,7 +391,7 @@ void HttpReq::dns(MegaClient *client)
     method = METHOD_NONE;
     contentlength = -1;
     lastdata = Waiter::ds;
-    
+
     httpio->post(this);
 }
 
@@ -480,7 +480,7 @@ void HttpReq::put(void* data, unsigned len, bool purge)
 
         in.append((char*)data, len);
     }
-    
+
     bufpos += len;
 }
 
@@ -508,17 +508,17 @@ bool HttpReq::http_buf_t::isNull()
 }
 
 byte* HttpReq::http_buf_t::datastart()
-{ 
-    return buf + start; 
+{
+    return buf + start;
 }
 
-size_t HttpReq::http_buf_t::datalen() 
-{ 
-    return end - start; 
+size_t HttpReq::http_buf_t::datalen()
+{
+    return end - start;
 }
 
 
-// give up ownership of the buffer for client to use.  
+// give up ownership of the buffer for client to use.
 struct HttpReq::http_buf_t* HttpReq::release_buf()
 {
     HttpReq::http_buf_t* result = new HttpReq::http_buf_t(buf, inpurge, (size_t)bufpos);
@@ -802,6 +802,7 @@ dstime SpeedController::requestElapsedDs()
 
 m_off_t SpeedController::calculateSpeed(long long numBytes)
 {
+    assert(numBytes >= 0);
     dstime currentTime = Waiter::ds;
     if (numBytes <= 0 && mLastCalcTime == currentTime)
     {
@@ -827,7 +828,7 @@ m_off_t SpeedController::calculateSpeed(long long numBytes)
     mCircularCurrentSum += numBytes;
 
     m_off_t speed = (mCircularCurrentSum * 10) / SPEED_MEAN_MAX_INTERVAL_DS;
-    
+
     if (numBytes)
     {
         if (!mMeanSpeedStart)
@@ -837,7 +838,7 @@ m_off_t SpeedController::calculateSpeed(long long numBytes)
         mMeanSpeed = delta ? (mMeanSpeedSum * 10 / delta) : mMeanSpeedSum;
     }
     mLastCalcTime = currentTime;
-    
+
     return speed;
 }
 

--- a/src/posix/net.cpp
+++ b/src/posix/net.cpp
@@ -74,7 +74,7 @@ bool SockInfo::checkEvent(bool& read, bool& write)
     }
 
     read = 0 != (FD_READ & wne.lNetworkEvents);
-    write = 0 != (FD_WRITE & wne.lNetworkEvents);  
+    write = 0 != (FD_WRITE & wne.lNetworkEvents);
 
     // Even though the writeable network event occurred, double check there is no space available in the write buffer
     // Otherwise curl can report a spurious timeout error
@@ -88,7 +88,7 @@ bool SockInfo::checkEvent(bool& read, bool& write)
         // where curl wrote to the socket, but not enough to cause it to become unwriteable for now.
         // So, we need to signal curl to write again if it has more data to write, if the socket can take
         // more data.  This trick with WSASend for 0 bytes enables that - if it fails with would-block
-        // then we can stop asking curl to write to the socket, and start waiting on the handle to 
+        // then we can stop asking curl to write to the socket, and start waiting on the handle to
         // know when to try again.
         // If curl has finished writing to the socket, it will call us back to change the mode to read only.
 
@@ -116,7 +116,7 @@ void SockInfo::closeEvent(bool adjustSocket)
     if (adjustSocket)
     {
 #ifdef DEBUG
-        int result = 
+        int result =
 #endif
         WSAEventSelect(fd, NULL, 0); // cancel association by specifying lNetworkEvents = 0
         assert(result == 0);
@@ -545,7 +545,7 @@ void CurlHttpIO::addaresevents(Waiter *waiter)
     for (auto& mapPair : prevAressockets)
     {
         // We pass false for c-ares becase we can't be sure if c-ares closed the socket or not
-        // If it's not using the socket, the event should not be triggered, and even if it is 
+        // If it's not using the socket, the event should not be triggered, and even if it is
         // then we just do one extra loop.
         mapPair.second.closeEvent(false);
     }
@@ -611,7 +611,7 @@ void CurlHttpIO::closearesevents()
 #if defined(_WIN32)
     for (auto& mapPair : aressockets)
     {
-        mapPair.second.closeEvent();
+        mapPair.second.closeEvent(false);
     }
 #endif
     aressockets.clear();
@@ -1072,7 +1072,7 @@ void CurlHttpIO::proxy_ready_callback(void* arg, int status, int, hostent* host)
         if (httpio->proxyhost == httpctx->hostname && httpctx->hostip.size())
         {
             std::ostringstream oss;
-            
+
             oss << httpctx->hostip << ":" << httpio->proxyport;
             httpio->proxyip = oss.str();
 
@@ -1414,7 +1414,7 @@ void CurlHttpIO::send_request(CurlHttpContext* httpctx)
         httpio->statechange = true;
         return;
     }
-    
+
     CURL* curl;
     if ((curl = curl_easy_init()))
     {
@@ -1761,7 +1761,7 @@ void CurlHttpIO::post(HttpReq* req, const char* data, unsigned len)
     httpctx->isCachedIp = false;
     httpctx->ares_pending = 0;
     httpctx->d = (req->type == REQ_JSON || req->method == METHOD_NONE) ? API : ((data ? len : req->out->size()) ? PUT : GET);
-    req->httpiohandle = (void*)httpctx;    
+    req->httpiohandle = (void*)httpctx;
 
     bool validrequest = true;
     if ((proxyurl.size() && !proxyhost.size()) // malformed proxy string
@@ -2165,7 +2165,7 @@ bool CurlHttpIO::multidoio(CURLM *curlmhandle)
                         }
                         req->httpstatus = 200;
                     }
-                    
+
                     if (req->binary)
                     {
                         LOG_debug << "[received " << (req->buf ? req->bufpos : (int)req->in.size()) << " bytes of raw data]";
@@ -2411,7 +2411,7 @@ size_t CurlHttpIO::read_data(void* ptr, size_t size, size_t nmemb, void* source)
             httpio->partialdata[PUT] += nread;
         }
     }
-    
+
     memcpy(ptr, buf, nread);
     req->outpos += nread;
     //LOG_debug << req->logname << "Supplying " << nread << " bytes to cURL to send";
@@ -2589,7 +2589,7 @@ int CurlHttpIO::socket_callback(CURL *, curl_socket_t s, int what, void *userp, 
         {
             LOG_debug << "Setting curl socket " << s << " to " << what;
         }
-        
+
         auto& info = it->second;
         info.fd = s;
         info.mode = what;

--- a/src/transferslot.cpp
+++ b/src/transferslot.cpp
@@ -32,7 +32,7 @@
 
 namespace mega {
 
-TransferSlotFileAccess::TransferSlotFileAccess(std::unique_ptr<FileAccess>&& p, Transfer* t) 
+TransferSlotFileAccess::TransferSlotFileAccess(std::unique_ptr<FileAccess>&& p, Transfer* t)
     : transfer(t)
 {
     reset(std::move(p));
@@ -84,7 +84,7 @@ TransferSlot::TransferSlot(Transfer* ctransfer)
 
     failure = false;
     retrying = false;
-    
+
     fileattrsmutable = 0;
 
     connections = 0;
@@ -218,7 +218,7 @@ TransferSlot::~TransferSlot()
 
                     case REQ_DECRYPTING:
                         LOG_info << "Waiting for block decryption";
-                        std::mutex finalizedMutex; 
+                        std::mutex finalizedMutex;
                         std::unique_lock<std::mutex> guard(finalizedMutex);
                         auto outputPiece = transferbuf.getAsyncOutputBufferPointer(i);
                         outputPiece->finalizedCV.wait(guard, [&](){ return outputPiece->finalized; });
@@ -413,7 +413,7 @@ bool TransferSlot::testForSlowRaidConnection(unsigned connectionNum, bool& incre
                     }
                 }
             }
-        
+
             averageOtherRate /=  otherCount ? otherCount : 1;
             m_off_t thisRate = mReqSpeeds[connectionNum].lastRequestSpeed();
 
@@ -421,8 +421,8 @@ bool TransferSlot::testForSlowRaidConnection(unsigned connectionNum, bool& incre
                     && averageOtherRate > 50 * 1024 // avg is more than 50KB/s
                     && thisRate < 1024 * 1024)      // this is less than 1MB/s
             {
-                LOG_warn << "Raid connection " << connectionNum 
-                         << " is much slower than its peers, with speed " << thisRate 
+                LOG_warn << "Raid connection " << connectionNum
+                         << " is much slower than its peers, with speed " << thisRate
                          << " while they are managing " << averageOtherRate;
 
                 mRaidChannelSwapsForSlowness += 1;
@@ -507,7 +507,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                 LOG_debug << "Connection " << slowestStartConnection << " is the slowest to reply, using the other 5.";
                 reqs[slowestStartConnection].reset();
                 transferbuf.resetPart(slowestStartConnection);
-                i = connections; 
+                i = connections;
                 continue;
             }
 
@@ -589,7 +589,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                         if (reqs[i]->in.size())
                         {
                             if (reqs[i]->in.size() == NewNode::UPLOADTOKENLEN)
-                            {                                        
+                            {
                                 LOG_debug << "Upload token received";
                                 if (!transfer->ultoken)
                                 {
@@ -773,7 +773,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                     {
                         // this must return the same piece we just decrypted, since we have not asked the transferbuf to discard it yet.
                         auto outputPiece = transferbuf.getAsyncOutputBufferPointer(i);
-                        
+
                         if (fa->asyncavailable())
                         {
                             if (asyncIO[i])
@@ -853,7 +853,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
                                 client->mAsyncQueue.push([req, transferkey, ctriv, finaltempurl, pos, npos](SymmCipher& sc)
                                     {
                                         sc.setkey(transferkey.data());
-                                        req->prepare(finaltempurl.c_str(), &sc, ctriv, pos, npos); 
+                                        req->prepare(finaltempurl.c_str(), &sc, ctriv, pos, npos);
                                         req->status = REQ_PREPARED;
                                     }, true);   // discardable - if the transfer or client are being destroyed, we won't be sending that data.
                             }
@@ -951,7 +951,7 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
 
                         return transfer->failed(API_EOVERQUOTA, committer, backoff);
                     }
-                    else if (reqs[i]->httpstatus == 429)  
+                    else if (reqs[i]->httpstatus == 429)
                     {
                         // too many requests - back off a bit (may be added serverside at some point.  Added here 202020623)
                         backoff = 5;
@@ -1162,12 +1162,12 @@ void TransferSlot::doio(MegaClient* client, DBTableTransactionCommitter& committ
         p += transferbuf.progress();
     }
     p += transfer->progresscompleted;
-    
+
     if (p != progressreported || (Waiter::ds - lastprogressreport) > PROGRESSTIMEOUT)
     {
         if (p != progressreported)
         {
-            m_off_t diff = p - progressreported;
+            m_off_t diff = std::max<m_off_t>(0, p - progressreported);
             speed = speedController.calculateSpeed(diff);
             meanSpeed = speedController.getMeanSpeed();
             if (transfer->type == PUT)


### PR DESCRIPTION
We should never have a negative number of bytes being sent or received since the last update.