### PR TITLE
SDK-1192: Delete sync test files from previous runs

### DIFF
--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -96,6 +96,11 @@ int main (int argc, char *argv[])
         return 1;
     }
 
+    // delete old test folders, created during previous runs
+    TestFS testFS;
+    testFS.DeleteTestFolder();
+    testFS.DeleteTrashFolder();
+
     std::vector<char*> myargv1(argv, argv + argc);
     std::vector<char*> myargv2;
 

--- a/tests/integration/test.h
+++ b/tests/integration/test.h
@@ -1,7 +1,28 @@
 #pragma once
 #include <string>
+#include <thread>
+#include <vector>
 extern std::string USER_AGENT;
 extern bool gRunningInCI;
 extern bool gTestingInvalidArgs;
 extern bool gResumeSessions;
 enum { THREADS_PER_MEGACLIENT = 3 };
+
+
+class TestFS
+{
+public:
+    // these getters should return std::filesystem::path type, when C++17 will become mandatory
+    static const std::string& GetTestFolder();
+    static const std::string& GetTrashFolder();
+
+    void DeleteTestFolder() { DeleteFolder(GetTestFolder()); }
+    void DeleteTrashFolder() { DeleteFolder(GetTrashFolder()); }
+
+    ~TestFS();
+
+private:
+    void DeleteFolder(const std::string& folder);
+
+    std::vector<std::thread> m_cleaners;
+};


### PR DESCRIPTION
* Old files are being deleted before starting tests.


* The new `TestFS` class should probably be in separate h/cpp files, and that will require modifying the build files, but I'm afraid I'll miss something if I do that. Should I do that?
* Code could be simplified a bit if `std::filesystem` was always available.