### PR TITLE
SNC-1786. Allow keeping syncs configuration when logging out

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -503,6 +503,9 @@ public:
     // A collection of sync configs backed by a database table
     std::unique_ptr<SyncConfigBag> syncConfigs;
 
+    // keep sync configuration after logout
+    bool mKeepSyncsAfterLogout = false;
+
 #endif
 
     // if set, symlinks will be followed except in recursive deletions
@@ -1787,6 +1790,8 @@ public:
 
     MegaClient(MegaApp*, Waiter*, HttpIO*, FileSystemAccess*, DbAccess*, GfxProc*, const char*, const char*, unsigned workerThreadCount);
     ~MegaClient();
+    bool getKeepSyncsAfterLogout() const;
+    void setKeepSyncsAfterLogout(bool keepSyncsAfterLogout);
 };
 } // namespace
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -883,6 +883,9 @@ public:
     // whether this sync should be resumed at startup
     bool isResumableAtStartup() const;
 
+    // wether this sync has errors (was inactive)
+    bool hasError() const;
+
     // returns the local path of the sync
     const std::string& getLocalPath() const;
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -355,6 +355,7 @@ enum SyncError {
     ACCOUNT_BLOCKED= 25,                    // Account blocked
     UNKNOWN_TEMPORARY_ERROR = 26,           // Unknown temporary error
     TOO_MANY_ACTION_PACKETS = 27,           // Too many changes in account, local state discarded
+    LOGGED_OUT = 28,                        // Logged out
 };
 
 static bool isSyncErrorPermanent(SyncError e)
@@ -362,6 +363,7 @@ static bool isSyncErrorPermanent(SyncError e)
     switch (e)
     {
     case NO_SYNC_ERROR:
+    case LOGGED_OUT: //syncs may be restored after relogging
     case UNKNOWN_TEMPORARY_ERROR:
     case STORAGE_OVERQUOTA:
     case BUSINESS_EXPIRED:

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -5044,6 +5044,7 @@ public:
         ACCOUNT_BLOCKED= 25, // Account blocked
         UNKNOWN_TEMPORARY_ERROR = 26, // unknown temporary error
         TOO_MANY_ACTION_PACKETS = 27, // Too many changes in account, local state discarded
+        LOGGED_OUT = 28, // Logged out
     };
 
     enum SyncAdded
@@ -5178,6 +5179,7 @@ public:
      *  - ACCOUNT_BLOCKED = 25: Account blocked
      *  - UNKNOWN_TEMPORARY_ERROR = 26: Unknown temporary error
      *  - TOO_MANY_ACTION_PACKETS = 27: Too many changes in account, local state discarded
+     *  - LOGGED_OUT = 28: Logged out
      *
      * @return Error of a synchronization
      */
@@ -13096,6 +13098,16 @@ class MegaApi
          * @param listener MegaRequestListener to track this request
          */
         void copyCachedStatus(int storageStatus, int blockStatus, int businessStatus, MegaRequestListener *listener = NULL);
+
+        /**
+         * @brief Enable keeping sync configuration after logout
+         *
+         * By default, sync configurations are removed upon logout. Enabling this will
+         * keep configurations so that new sessions will restore syncs configured previously.
+         *
+         * @param enable True to keep sync configurations after logout.
+         */
+        void setKeepSyncsAfterLogout(bool enable);
 
 #ifdef USE_PCRE
         /**

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2336,6 +2336,7 @@ class MegaApiImpl : public MegaApp
         void copySyncDataToCache(const char *localFolder, const char *name, MegaHandle megaHandle, const char *remotePath,
                                           long long localfp, bool enabled, bool temporaryDisabled, MegaRequestListener *listener = NULL);
         void copyCachedStatus(int storageStatus, int blockStatus, int businessStatus, MegaRequestListener *listener = NULL);
+        void setKeepSyncsAfterLogout(bool enable);
         void removeSync(handle nodehandle, MegaRequestListener *listener=NULL);
         void removeSync(int syncTag, MegaRequestListener *listener=NULL);
         void disableSync(handle nodehandle, MegaRequestListener *listener=NULL);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -3195,6 +3195,12 @@ void MegaApi::copyCachedStatus(int storageStatus, int blockStatus, int businessS
 {
     pImpl->copyCachedStatus(storageStatus, blockStatus, businessStatus, listener);
 }
+
+void MegaApi::setKeepSyncsAfterLogout(bool enable)
+{
+    pImpl->setKeepSyncsAfterLogout(enable);
+}
+
 #ifdef USE_PCRE
 void MegaApi::syncFolder(const char *localFolder, MegaNode *megaFolder, MegaRegExp *regExp, MegaRequestListener *listener)
 {
@@ -5651,6 +5657,8 @@ const char* MegaSync::getMegaSyncErrorCode(int errorCode)
         return "Your account is blocked";
     case MegaSync::Error::UNKNOWN_TEMPORARY_ERROR:
         return "Unknown temporary error";
+    case MegaSync::Error::LOGGED_OUT:
+        return "Session closed";
     case MegaSync::Error::TOO_MANY_ACTION_PACKETS:
         return "Too many changes in account, local state invalid";
     default:

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8525,6 +8525,11 @@ void MegaApiImpl::copyCachedStatus(int storageStatus, int blockStatus, int busin
     waiter->notify();
 }
 
+void MegaApiImpl::setKeepSyncsAfterLogout(bool enable)
+{
+    client->setKeepSyncsAfterLogout(enable);
+}
+
 void MegaApiImpl::removeSync(handle nodehandle, MegaRequestListener* listener)
 {
     MegaRequestPrivate *request = new MegaRequestPrivate(MegaRequest::TYPE_REMOVE_SYNC, listener);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -13147,7 +13147,8 @@ void MegaApiImpl::sync_auto_resume_result(const SyncConfig &config, const syncst
     sync->setError(syncError);
 
     bool failedToResume = config.isResumableAtStartup() && !sync->isActive(); //the sync could not be resumed
-    bool wasEnabled = config.getEnabled();
+    bool attemptedReenabling = config.isResumableAtStartup() && config.hasError();
+
 
     auto existingpair = syncMap.find(config.getTag());
     if (existingpair !=  syncMap.end())
@@ -13160,7 +13161,7 @@ void MegaApiImpl::sync_auto_resume_result(const SyncConfig &config, const syncst
     }
     syncMap[config.getTag()] = sync;
 
-    if (!wasEnabled && config.isResumableAtStartup()) //attempted to re-enable
+    if (attemptedReenabling && config.isResumableAtStartup()) //attempted to re-enable
     {
         fireOnSyncAdded(sync, failedToResume ? MegaSync::REENABLED_FAILED : MegaSync::FROM_CACHE_REENABLED);
     }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4102,8 +4102,18 @@ void MegaClient::locallogout(bool removecaches)
 {
     mAsyncQueue.clearDiscardable();
 
-    //disableSyncs in a temporarily state: so that they will be resumed when relogin
-    disableSyncs(LOGGED_OUT);
+    if (mKeepSyncsAfterLogout)
+    {
+        //disableSyncs in a temporarily state: so that they will be resumed when relogin
+        disableSyncs(LOGGED_OUT);
+    }
+    else
+    {
+        for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
+        {
+            delsync(*it);
+        }
+    }
 
     if (removecaches)
     {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1212,6 +1212,7 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
     syncadding = 0;
     currsyncid = 0;
     totalLocalNodes = 0;
+    mKeepSyncsAfterLogout = false;
 #endif
 
     pendingcs = NULL;
@@ -4101,6 +4102,9 @@ void MegaClient::locallogout(bool removecaches)
 {
     mAsyncQueue.clearDiscardable();
 
+    //disableSyncs in a temporarily state: so that they will be resumed when relogin
+    disableSyncs(LOGGED_OUT);
+
     if (removecaches)
     {
         removeCaches();
@@ -4276,7 +4280,7 @@ void MegaClient::removeCaches()
             (*it)->statecachetable = NULL;
         }
     }
-    if (syncConfigs)
+    if (syncConfigs && !mKeepSyncsAfterLogout)
     {
         syncConfigs->clear();
     }
@@ -12509,6 +12513,16 @@ void MegaClient::preadabort(Node* n, m_off_t offset, m_off_t count)
 void MegaClient::preadabort(handle ph, m_off_t offset, m_off_t count)
 {
     abortreads(ph, false, offset, count);
+}
+
+bool MegaClient::getKeepSyncsAfterLogout() const
+{
+    return mKeepSyncsAfterLogout;
+}
+
+void MegaClient::setKeepSyncsAfterLogout(bool keepSyncsAfterLogout)
+{
+    mKeepSyncsAfterLogout = keepSyncsAfterLogout;
 }
 
 void MegaClient::abortreads(handle h, bool p, m_off_t offset, m_off_t count)

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -4102,21 +4102,21 @@ void MegaClient::locallogout(bool removecaches)
 {
     mAsyncQueue.clearDiscardable();
 
-    if (mKeepSyncsAfterLogout)
-    {
-        //disableSyncs in a temporarily state: so that they will be resumed when relogin
-        disableSyncs(LOGGED_OUT);
-    }
-    else
-    {
-        for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
-        {
-            delsync(*it);
-        }
-    }
-
     if (removecaches)
     {
+        if (mKeepSyncsAfterLogout)
+        {
+            //disableSyncs in a temporarily state: so that they will be resumed when relogin
+            disableSyncs(LOGGED_OUT);
+        }
+        else
+        {
+            for (sync_list::iterator it = syncs.begin(); it != syncs.end(); it++)
+            {
+                delsync(*it);
+            }
+        }
+
         removeCaches();
     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2253,6 +2253,7 @@ bool SyncConfig::isResumable() const
 bool SyncConfig::isResumableAtStartup() const
 {
     return mEnabled && (!isAnError(mError)
+                        || mError == LOGGED_OUT
                         || mError == UNKNOWN_TEMPORARY_ERROR
                         || mError == FOREIGN_TARGET_OVERSTORAGE); //temporary errors that don't have an asociated restore functionality
 }
@@ -2266,7 +2267,6 @@ const std::string& SyncConfig::getName() const
 {
     return mName;
 }
-
 
 handle SyncConfig::getRemoteNode() const
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2258,6 +2258,11 @@ bool SyncConfig::isResumableAtStartup() const
                         || mError == FOREIGN_TARGET_OVERSTORAGE); //temporary errors that don't have an asociated restore functionality
 }
 
+bool SyncConfig::hasError() const
+{
+    return isAnError(mError);
+}
+
 const std::string& SyncConfig::getLocalPath() const
 {
     return mLocalPath;


### PR DESCRIPTION
- Also, set syncs as temporarily disabled with a new ERROR code, so that
apps are notified of the "disabilitation" and when restoring them after
a new log in, they receive onSyncAdded with FROM_CACHE_REENABLED