### PR TITLE
Fix some compiler errors and warnings on Mac

### DIFF
--- a/include/mega/posix/meganet.h
+++ b/include/mega/posix/meganet.h
@@ -183,32 +183,32 @@ protected:
     m_time_t arestimeout;
 
 public:
-    void post(HttpReq*, const char* = 0, unsigned = 0);
-    void cancel(HttpReq*);
+    void post(HttpReq*, const char* = 0, unsigned = 0) override;
+    void cancel(HttpReq*) override;
 
-    m_off_t postpos(void*);
+    m_off_t postpos(void*) override;
 
-    bool doio(void);
+    bool doio(void) override;
     bool multidoio(CURLM *curlmhandle);
 
-    void addevents(Waiter*, int);
+    void addevents(Waiter*, int) override;
 
-    void setuseragent(string*);
+    void setuseragent(string*) override;
     void setproxy(Proxy*);
     void setdnsservers(const char*);
-    void disconnect();
+    void disconnect() override;
 
     // set max download speed
-    virtual bool setmaxdownloadspeed(m_off_t bpslimit);
+    virtual bool setmaxdownloadspeed(m_off_t bpslimit) override;
 
     // set max upload speed
-    virtual bool setmaxuploadspeed(m_off_t bpslimit);
+    virtual bool setmaxuploadspeed(m_off_t bpslimit) override;
 
     // get max download speed
-    virtual m_off_t getmaxdownloadspeed();
+    virtual m_off_t getmaxdownloadspeed() override;
 
     // get max upload speed
-    virtual m_off_t getmaxuploadspeed();
+    virtual m_off_t getmaxuploadspeed() override;
 
     CurlHttpIO();
     ~CurlHttpIO();

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -775,7 +775,6 @@ bool MegaFS::addCompletions(ACState& s)
                 pathprefix += folderName + "/";
                 if (folderName == ".")
                 {
-                    n = n;
                 }
                 else if (folderName == "..")
                 {

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -863,7 +863,7 @@ int PosixFileSystemAccess::checkevents(Waiter* w)
     // which we filter
     int pos, avail;
     int off;
-    int i, n, s;
+    int i, n;
     kfs_event* kfse;
     kfs_event_arg* kea;
     char buffer[131072];
@@ -872,10 +872,10 @@ int PosixFileSystemAccess::checkevents(Waiter* w)
     Sync* pathsync[2];
     sync_list::iterator it;
     fd_set rfds;
-    timeval tv = { 0 };
+    timeval tv = { 0, 0 };
     struct stat statbuf;
     static char rsrc[] = "/..namedfork/rsrc";
-    static unsigned int rsrcsize = sizeof(rsrc) - 1;
+    static size_t rsrcsize = sizeof(rsrc) - 1;
 
     for (;;)
     {
@@ -885,7 +885,7 @@ int PosixFileSystemAccess::checkevents(Waiter* w)
         // ensure nonblocking behaviour
         if (select(notifyfd + 1, &rfds, NULL, NULL, &tv) <= 0) break;
 
-        if ((avail = read(notifyfd, buffer, sizeof buffer)) < 0)
+        if ((avail = read(notifyfd, buffer, int(sizeof buffer))) < 0)
         {
             notifyerr = true;
             break;
@@ -929,15 +929,15 @@ int PosixFileSystemAccess::checkevents(Waiter* w)
             for (i = n; i--; )
             {
                 path = paths[i];
-                unsigned int psize = strlen(path);
+                size_t psize = strlen(path);
 
                 for (it = client->syncs.begin(); it != client->syncs.end(); it++)
                 {
                     std::string* ignore = (*it)->dirnotify->ignore.editStringDirect();
                     std::string* localname = (*it)->localroot->localname.editStringDirect();
 
-                    int rsize = (*it)->mFsEventsPath.size() ? (*it)->mFsEventsPath.size() : localname->size();
-                    int isize = ignore->size();
+                    size_t rsize = (*it)->mFsEventsPath.size() ? (*it)->mFsEventsPath.size() : localname->size();
+                    size_t isize = ignore->size();
 
                     if (psize >= rsize
                       && !memcmp((*it)->mFsEventsPath.size() ? (*it)->mFsEventsPath.c_str() : localname->c_str(), path, rsize)    // prefix match

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -223,7 +223,7 @@ std::string logTime()
     return ts;
 }
 
-std::map<int, std::string> gSessionIDs;
+std::map<size_t, std::string> gSessionIDs;
 
 void SdkTest::SetUp()
 {
@@ -235,7 +235,7 @@ void SdkTest::TearDown()
     out() << logTime() << "Test done, teardown starts" << endl;
     // do some cleanup
 
-    for (int i = 0; i < gSessionIDs.size(); ++i)
+    for (size_t i = 0; i < gSessionIDs.size(); ++i)
     {
         if (gResumeSessions && megaApi[i] && gSessionIDs[i].empty())
         {


### PR DESCRIPTION
Add override keyword where it was missing
10s syntax not available for C++11
Using size_t where it matches the return value from size() etc, and no subtraction is performed
Removed some unused lambda parameters that the compiler warned about.