### PR TITLE
SDK-1199. Provide a way for apps to call setrlimit

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -16941,8 +16941,11 @@ class MegaApi
      * can make that call and set appropriate limits.
      *
      * @param newNumFileLimit The new limit of file and socket handles for the whole app.
+     *
+     * @return True when there were no errors setting the new limit (even when clipped to the maximum
+     * allowed value). It returns false when setting a new limit failed.
      */
-    void platformSetRLimitNumFile(int newNumFileLimit);
+    bool platformSetRLimitNumFile(int newNumFileLimit) const;
 
  private:
         MegaApiImpl *pImpl;

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2138,7 +2138,7 @@ class MegaApiImpl : public MegaApp
 
         void setLoggingName(const char* loggingName);
 
-        void platformSetRLimitNumFile(int newNumFileLimit) const;
+        bool platformSetRLimitNumFile(int newNumFileLimit) const;
 
         void createFolder(const char* name, MegaNode *parent, MegaRequestListener *listener = NULL);
         bool createLocalFolder(const char *path);

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -4110,9 +4110,9 @@ MegaApiLock* MegaApi::getMegaApiLock(bool lockNow)
     return new MegaApiLock(pImpl, lockNow);
 }
 
-void MegaApi::platformSetRLimitNumFile(int newNumFileLimit)
+bool MegaApi::platformSetRLimitNumFile(int newNumFileLimit) const
 {
-    pImpl->platformSetRLimitNumFile(newNumFileLimit);
+    return pImpl->platformSetRLimitNumFile(newNumFileLimit);
 }
 
 void MegaApi::sendSMSVerificationCode(const char* phoneNumber, MegaRequestListener *listener, bool reverifying_whitelisted)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7490,7 +7490,7 @@ bool MegaApiImpl::hasToForceUpload(const Node &node, const MegaTransferPrivate &
     return canForceUpload && (isMedia || isPdf) && !(hasPreview && hasThumbnail);
 }
 
-void MegaApiImpl::platformSetRLimitNumFile(int newNumFileLimit) const
+bool MegaApiImpl::platformSetRLimitNumFile(int newNumFileLimit) const
 {
 #ifndef WIN32
     struct rlimit rl{0,0};
@@ -7498,6 +7498,7 @@ void MegaApiImpl::platformSetRLimitNumFile(int newNumFileLimit) const
     {
         auto e = errno;
         LOG_err << "Error calling getrlimit: " << e;
+        return false;
     }
     else
     {
@@ -7514,10 +7515,13 @@ void MegaApiImpl::platformSetRLimitNumFile(int newNumFileLimit) const
         {
             auto e = errno;
             LOG_err << "Error calling setrlimit: " << e;
+            return false;
         }
     }
+    return true;
 #else
     LOG_err << "Code for calling setrlimit is not available yet (or not relevant) on this platform";
+    return false;
 #endif
 }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -7503,6 +7503,13 @@ void MegaApiImpl::platformSetRLimitNumFile(int newNumFileLimit) const
     {
         LOG_info << "rlimit for NOFILE before change is: " << rl.rlim_cur << ", " << rl.rlim_max;
         rl.rlim_cur = rlim_t(newNumFileLimit);
+
+        if (rl.rlim_cur > rl.rlim_max)
+        {
+            LOG_info << "Requested rlimit (" << rl.rlim_cur << ") will be replaced by maximum allowed value (" << rl.rlim_max << ")";
+            rl.rlim_cur = rl.rlim_max;
+        }
+
         if (0 < setrlimit(RLIMIT_NOFILE, &rl))
         {
             auto e = errno;


### PR DESCRIPTION
The defaults on some platforms are too low for uploading or downloading many files at once, as the SDK may do on request.   Let's allow the app to choose an overall limit that suits the SDK and whatever else the app may be doing.