### PR TITLE
SDK-1094. Remove name from heartbeat registration/update

### DIFF
--- a/contrib/tools/logs_beautifier.py
+++ b/contrib/tools/logs_beautifier.py
@@ -20,6 +20,23 @@ for l in open(sys.argv[1]):
                 try:
                     print json.dumps(json.loads(found), sort_keys=False, indent=4)
                 except:
+                    #try this other format:
+                    m = re.search('(.*)((sc|cs) (Received|Sending) [0-9]*:  *)(\{.*\}|\[.*\])  *(\[.*cpp.*\])*', l)
+                    if m and m is not None and len(m.groups()) > 4:
+                        header = found = m.group(1)
+                        sendrecv = m.group(2)
+                        found = m.group(5)
+                        fil = m.group(6)
+                        if header and sendrecv and found:
+                            print header,
+                            try:
+                                print json.dumps(json.loads(found), sort_keys=False, indent=4)
+                            except:
+                                print found
+                        else:
+                            print l,
+                    else:
+                        print l,
                     print found
             else:
                 print l,

--- a/contrib/tools/logs_beautifier.py
+++ b/contrib/tools/logs_beautifier.py
@@ -16,9 +16,9 @@ for l in open(sys.argv[1]):
             header = found = m.group(1)
             found = m.group(2)
             if header and found:
-                print header,
                 try:
-                    print json.dumps(json.loads(found), sort_keys=False, indent=4)
+                    contents = json.dumps(json.loads(found), sort_keys=False, indent=4)
+                    print header+contents
                 except:
                     #try this other format:
                     m = re.search('(.*)((sc|cs) (Received|Sending) [0-9]*:  *)(\{.*\}|\[.*\])  *(\[.*cpp.*\])*', l)
@@ -28,16 +28,15 @@ for l in open(sys.argv[1]):
                         found = m.group(5)
                         fil = m.group(6)
                         if header and sendrecv and found:
-                            print header,
                             try:
-                                print json.dumps(json.loads(found), sort_keys=False, indent=4)
+                                contents = json.dumps(json.loads(found), sort_keys=False, indent=4)
+                                print header+sendrecv+contents
                             except:
-                                print found
+                                print l
                         else:
                             print l,
                     else:
                         print l,
-                    print found
             else:
                 print l,
         else:

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -1316,7 +1316,7 @@ public:
     bool procresult(Result) override;
 
     // Register a new Sync
-    CommandBackupPut(MegaClient* client, BackupType type, handle nodeHandle, const std::string& localFolder, const std::string& deviceId, const std::string& backupName, int state, int subState, const std::string& extraData);
+    CommandBackupPut(MegaClient* client, BackupType type, handle nodeHandle, const std::string& localFolder, const std::string& deviceId, int state, int subState, const std::string& extraData);
 
     // Update a Backup
     // Params that keep the same value are passed with invalid value to avoid to send to the server
@@ -1325,11 +1325,10 @@ public:
     // - nodeHandle: UNDEF
     // - localFolder: nullptr
     // - deviceId: nullptr
-    // - backupName: nullptr
     // - state: -1
     // - subState: -1
     // - extraData: nullptr
-    CommandBackupPut(MegaClient* client, handle backupId, BackupType type, handle nodeHandle, const char* localFolder, const char* deviceId, const char* backupName, int state, int subState, const char* extraData);
+    CommandBackupPut(MegaClient* client, handle backupId, BackupType type, handle nodeHandle, const char* localFolder, const char* deviceId, int state, int subState, const char* extraData);
 
 private:
     bool mUpdate = false;

--- a/include/mega/heartbeats.h
+++ b/include/mega/heartbeats.h
@@ -249,7 +249,7 @@ private:
     void beatBackupInfo(const std::shared_ptr<HeartBeatBackupInfo> &hbs);
     void calculateStatus(HeartBeatBackupInfo *hbs);
 
-    std::shared_ptr<HeartBeatTransferProgressedInfo> getHeartBeatBackupInfoByTransfer(MegaTransfer *transfer);
+    std::shared_ptr<HeartBeatTransferProgressedInfo> getHeartBeatBackupInfoByTransfer(MegaApi *api, MegaTransfer *transfer);
 
 #ifdef ENABLE_SYNC
     // --- Members and methods for syncs. i.e: backups of type: TWO_WAY, UP_SYNC, DOWN_SYNC

--- a/include/mega/heartbeats.h
+++ b/include/mega/heartbeats.h
@@ -159,15 +159,13 @@ private:
 class MegaBackupInfo
 {
 public:
-    MegaBackupInfo(BackupType type, string localFolder, string mName, handle megaHandle, int state, int substate, string extra, handle backupId = UNDEF);
+    MegaBackupInfo(BackupType type, string localFolder, handle megaHandle, int state, int substate, string extra, handle backupId = UNDEF);
 
     BackupType type() const;
 
     handle backupId() const;
 
     string localFolder() const;
-
-    string name() const;
 
     handle megaHandle() const;
 
@@ -183,7 +181,6 @@ protected:
     BackupType mType;
     handle mBackupId;
     string mLocalFolder;
-    string mName;
     handle mMegaHandle;
     int mState;
     int mSubState;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1804,6 +1804,8 @@ public:
 
     std::string getDeviceid() const;
 
+    std::string getDeviceidHash() const;
+
 #ifdef ENABLE_SYNC
     void resetSyncConfigs();
     bool getKeepSyncsAfterLogout() const;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -8194,12 +8194,18 @@ bool CommandBackupPut::procresult(Result r)
 {
     assert(r.wasStrictlyError() || r.hasJsonItem());
     handle backupId = UNDEF;
-    Error e = r.errorOrOK();
+    Error e = API_OK;
+
     if (r.hasJsonItem())
     {
         backupId = client->json.gethandle(MegaClient::USERHANDLE);
         e = API_OK;
     }
+    else
+    {
+        e = r.errorOrOK();
+    }
+
     if (mUpdate)
     {
         client->app->backupupdate_result(e, backupId);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1718,15 +1718,10 @@ CommandLogin::CommandLogin(MegaClient* client, const char* email, const byte *em
         arg("sn", (byte*)&client->cachedscsn, sizeof client->cachedscsn);
     }
 
-    string id = client->getDeviceid();
-
-    if (id.size())
+    string deviceIdHash = client->getDeviceidHash();
+    if (!deviceIdHash.empty())
     {
-        string hash;
-        HashSHA256 hasher;
-        hasher.add((const byte*)id.data(), unsigned(id.size()));
-        hasher.get(&hash);
-        arg("si", (const byte*)hash.data(), int(hash.size()));
+        arg("si", deviceIdHash.c_str());
     }
 
     tag = client->reqtag;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -8124,7 +8124,7 @@ bool CommandFolderLinkInfo::procresult(Result r)
 }
 
 // to register a new backup
-CommandBackupPut::CommandBackupPut(MegaClient *client, BackupType type, handle nodeHandle, const string& localFolder, const std::string &deviceId, const string& backupName, int state, int subState, const string& extraData)
+CommandBackupPut::CommandBackupPut(MegaClient *client, BackupType type, handle nodeHandle, const string& localFolder, const std::string &deviceId, int state, int subState, const string& extraData)
 {
     assert(type != BackupType::INVALID);
 
@@ -8134,7 +8134,6 @@ CommandBackupPut::CommandBackupPut(MegaClient *client, BackupType type, handle n
     arg("h", (byte*)&nodeHandle, MegaClient::NODEHANDLE);
     arg("l", localFolder.c_str());
     arg("d", deviceId.c_str());
-    arg("n", backupName.c_str());
     arg("s", state);
     arg("ss", subState);
 
@@ -8146,7 +8145,7 @@ CommandBackupPut::CommandBackupPut(MegaClient *client, BackupType type, handle n
 }
 
 // to update an already registered backup
-CommandBackupPut::CommandBackupPut(MegaClient* client, handle backupId, BackupType type, handle nodeHandle, const char* localFolder, const char *deviceId, const char* backupName, int state, int subState, const char* extraData)
+CommandBackupPut::CommandBackupPut(MegaClient* client, handle backupId, BackupType type, handle nodeHandle, const char* localFolder, const char *deviceId, int state, int subState, const char* extraData)
 {
     cmd("sp");
 
@@ -8170,11 +8169,6 @@ CommandBackupPut::CommandBackupPut(MegaClient* client, handle backupId, BackupTy
     if (deviceId)
     {
         arg("d", deviceId);
-    }
-
-    if (backupName)
-    {
-        arg("n", backupName);
     }
 
     if (state > 0)

--- a/src/heartbeats.cpp
+++ b/src/heartbeats.cpp
@@ -600,10 +600,10 @@ void MegaBackupMonitor::onPauseStateChanged(MegaApi *api)
     //loop on active syncs to update
     for (auto &sync : mClient->syncs)
     {
-        auto megaSync = api->getSyncByTag(sync->tag);
+        std::unique_ptr<MegaSync> megaSync{ api->getSyncByTag(sync->tag) };
         if (megaSync)
         {
-            updateOrRegisterSync(megaSync);
+            updateOrRegisterSync(megaSync.get());
         }
     }
 }
@@ -622,7 +622,7 @@ void MegaBackupMonitor::onSyncDeleted(MegaApi *api, MegaSync *sync)
 }
 #endif
 
-std::shared_ptr<HeartBeatTransferProgressedInfo> MegaBackupMonitor::getHeartBeatBackupInfoByTransfer(MegaTransfer *transfer)
+std::shared_ptr<HeartBeatTransferProgressedInfo> MegaBackupMonitor::getHeartBeatBackupInfoByTransfer(MegaApi *api, MegaTransfer *transfer)
 {
 #ifdef ENABLE_SYNC
     if (transfer->isSyncTransfer())
@@ -661,8 +661,16 @@ std::shared_ptr<HeartBeatTransferProgressedInfo> MegaBackupMonitor::getHeartBeat
             }
             else
             {
-                //create new HeartBeatSyncInfo
-                return mHeartBeatedSyncs.insert(std::make_pair(syncTag, std::make_shared<HeartBeatSyncInfo>(syncTag, UNDEF))).first->second;
+                std::unique_ptr<MegaSync> sync{api->getSyncByTag(syncTag)};
+                if (sync) //only if sync tag exists (to avoid handling transfer removed after sync removal)
+                {
+                    //create new HeartBeatSyncInfo
+                    return mHeartBeatedSyncs.insert(std::make_pair(syncTag, std::make_shared<HeartBeatSyncInfo>(syncTag, UNDEF))).first->second;
+                }
+                else
+                {
+                    LOG_debug << "Getting HeartBeatBackupInfo associated to transfer for non existing sync. No need to create one";
+                }
             }
         }
     }
@@ -672,7 +680,7 @@ std::shared_ptr<HeartBeatTransferProgressedInfo> MegaBackupMonitor::getHeartBeat
 
 void MegaBackupMonitor::onTransferStart(MegaApi *api, MegaTransfer *transfer)
 {
-    auto hbs = getHeartBeatBackupInfoByTransfer(transfer);
+    auto hbs = getHeartBeatBackupInfoByTransfer(api, transfer);
     if (hbs)
     {
         if (transfer->getType() == MegaTransfer::TYPE_UPLOAD)
@@ -689,7 +697,7 @@ void MegaBackupMonitor::onTransferStart(MegaApi *api, MegaTransfer *transfer)
 
 void MegaBackupMonitor::onTransferUpdate(MegaApi *api, MegaTransfer *transfer)
 {
-    auto hbs = getHeartBeatBackupInfoByTransfer(transfer);
+    auto hbs = getHeartBeatBackupInfoByTransfer(api, transfer);
     if (hbs)
     {
         hbs->updateTransferInfo(transfer);
@@ -698,7 +706,7 @@ void MegaBackupMonitor::onTransferUpdate(MegaApi *api, MegaTransfer *transfer)
 
 void MegaBackupMonitor::onTransferFinish(MegaApi *api, MegaTransfer *transfer, MegaError *error)
 {
-    auto hbs = getHeartBeatBackupInfoByTransfer(transfer);
+    auto hbs = getHeartBeatBackupInfoByTransfer(api, transfer);
     if (hbs)
     {
         if (transfer->getType() == MegaTransfer::TYPE_UPLOAD)

--- a/src/heartbeats.cpp
+++ b/src/heartbeats.cpp
@@ -298,11 +298,10 @@ void HeartBeatSyncInfo::updateStatus(MegaClient *client)
 
 ////////////// BackupInfo ////////////////
 
-MegaBackupInfo::MegaBackupInfo(BackupType type, string localFolder, string name, handle megaHandle, int state, int substate, std::string extra, handle backupId)
+MegaBackupInfo::MegaBackupInfo(BackupType type, string localFolder, handle megaHandle, int state, int substate, std::string extra, handle backupId)
     : mType(type)
     , mBackupId(backupId)
     , mLocalFolder(localFolder)
-    , mName(name)
     , mMegaHandle(megaHandle)
     , mState(state)
     , mSubState(substate)
@@ -324,11 +323,6 @@ handle MegaBackupInfo::backupId() const
 string MegaBackupInfo::localFolder() const
 {
     return mLocalFolder;
-}
-
-string MegaBackupInfo::name() const
-{
-    return mName;
 }
 
 handle MegaBackupInfo::megaHandle() const
@@ -358,7 +352,7 @@ void MegaBackupInfo::setBackupId(const handle &backupId)
 
 #ifdef ENABLE_SYNC
 MegaBackupInfoSync::MegaBackupInfoSync(MegaClient *client, const MegaSync &sync, handle backupid)
-    : MegaBackupInfo(getSyncType(client, sync), sync.getLocalFolder(), sync.getName(), sync.getMegaHandle()
+    : MegaBackupInfo(getSyncType(client, sync), sync.getLocalFolder(), sync.getMegaHandle()
                  , getSyncState(client, sync), getSyncSubstatus(sync), getSyncExtraData(sync), backupid)
 {
 
@@ -524,11 +518,10 @@ void MegaBackupMonitor::updateBackupInfo(const MegaBackupInfo &info)
 {
     string localFolderEncrypted(mClient->cypherTLVTextWithMasterKey("lf", info.localFolder()) );
     string deviceIDEncrypted(mClient->cypherTLVTextWithMasterKey("de", mClient->getDeviceid()) );
-    string nameEncrypted(mClient->cypherTLVTextWithMasterKey("na", info.name()) );
 
     mClient->reqs.add(new CommandBackupPut(mClient, info.backupId(), info.type(), info.megaHandle(),
                                            localFolderEncrypted.c_str(),
-                                           deviceIDEncrypted.c_str(), nameEncrypted.c_str(),
+                                           deviceIDEncrypted.c_str(),
                                            info.state(), info.subState(), info.extra().c_str()
                                            ));
 }
@@ -538,11 +531,10 @@ void MegaBackupMonitor::registerBackupInfo(const MegaBackupInfo &info)
 {
     string localFolderEncrypted(mClient->cypherTLVTextWithMasterKey("lf", info.localFolder()) );
     string deviceIDEncrypted(mClient->cypherTLVTextWithMasterKey("de", mClient->getDeviceid()) );
-    string nameEncrypted(mClient->cypherTLVTextWithMasterKey("na", info.name()) );
 
     mClient->reqs.add(new CommandBackupPut(mClient, info.type(), info.megaHandle(),
                                            localFolderEncrypted.c_str(),
-                                           deviceIDEncrypted.c_str(), nameEncrypted.c_str(),
+                                           deviceIDEncrypted.c_str(),
                                            info.state(), info.subState(), info.extra().c_str()
                                            ));
 }

--- a/src/heartbeats.cpp
+++ b/src/heartbeats.cpp
@@ -517,22 +517,11 @@ void MegaBackupMonitor::digestPutResult(handle backupId)
 void MegaBackupMonitor::updateBackupInfo(const MegaBackupInfo &info)
 {
     string localFolderEncrypted(mClient->cypherTLVTextWithMasterKey("lf", info.localFolder()) );
-
-    string deviceIDEncrypted;
-    string id = mClient->getDeviceid();
-    if (id.size())
-    {
-        string hash;
-        HashSHA256 hasher;
-        hasher.add((const byte*)id.data(), unsigned(id.size()));
-        hasher.get(&hash);
-        Base64::btoa(hash, deviceIDEncrypted);
-    }
-
+    string deviceIdHash = mClient->getDeviceidHash();
 
     mClient->reqs.add(new CommandBackupPut(mClient, info.backupId(), info.type(), info.megaHandle(),
                                            localFolderEncrypted.c_str(),
-                                           deviceIDEncrypted.c_str(),
+                                           deviceIdHash.c_str(),
                                            info.state(), info.subState(), info.extra().c_str()
                                            ));
 }
@@ -541,21 +530,11 @@ void MegaBackupMonitor::updateBackupInfo(const MegaBackupInfo &info)
 void MegaBackupMonitor::registerBackupInfo(const MegaBackupInfo &info)
 {
     string localFolderEncrypted(mClient->cypherTLVTextWithMasterKey("lf", info.localFolder()) );
-
-    string deviceIDEncrypted;
-    string id = mClient->getDeviceid();
-    if (id.size())
-    {
-        string hash;
-        HashSHA256 hasher;
-        hasher.add((const byte*)id.data(), unsigned(id.size()));
-        hasher.get(&hash);
-        Base64::btoa(hash, deviceIDEncrypted);
-    }
+    string deviceIdHash = mClient->getDeviceidHash();
 
     mClient->reqs.add(new CommandBackupPut(mClient, info.type(), info.megaHandle(),
                                            localFolderEncrypted.c_str(),
-                                           deviceIDEncrypted.c_str(),
+                                           deviceIdHash.c_str(),
                                            info.state(), info.subState(), info.extra().c_str()
                                            ));
 }

--- a/src/heartbeats.cpp
+++ b/src/heartbeats.cpp
@@ -517,7 +517,18 @@ void MegaBackupMonitor::digestPutResult(handle backupId)
 void MegaBackupMonitor::updateBackupInfo(const MegaBackupInfo &info)
 {
     string localFolderEncrypted(mClient->cypherTLVTextWithMasterKey("lf", info.localFolder()) );
-    string deviceIDEncrypted(mClient->cypherTLVTextWithMasterKey("de", mClient->getDeviceid()) );
+
+    string deviceIDEncrypted;
+    string id = mClient->getDeviceid();
+    if (id.size())
+    {
+        string hash;
+        HashSHA256 hasher;
+        hasher.add((const byte*)id.data(), unsigned(id.size()));
+        hasher.get(&hash);
+        Base64::btoa(hash, deviceIDEncrypted);
+    }
+
 
     mClient->reqs.add(new CommandBackupPut(mClient, info.backupId(), info.type(), info.megaHandle(),
                                            localFolderEncrypted.c_str(),
@@ -530,7 +541,17 @@ void MegaBackupMonitor::updateBackupInfo(const MegaBackupInfo &info)
 void MegaBackupMonitor::registerBackupInfo(const MegaBackupInfo &info)
 {
     string localFolderEncrypted(mClient->cypherTLVTextWithMasterKey("lf", info.localFolder()) );
-    string deviceIDEncrypted(mClient->cypherTLVTextWithMasterKey("de", mClient->getDeviceid()) );
+
+    string deviceIDEncrypted;
+    string id = mClient->getDeviceid();
+    if (id.size())
+    {
+        string hash;
+        HashSHA256 hasher;
+        hasher.add((const byte*)id.data(), unsigned(id.size()));
+        hasher.get(&hash);
+        Base64::btoa(hash, deviceIDEncrypted);
+    }
 
     mClient->reqs.add(new CommandBackupPut(mClient, info.type(), info.megaHandle(),
                                            localFolderEncrypted.c_str(),

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -1026,6 +1026,21 @@ std::string MegaClient::getDeviceid() const
     return MegaClient::statsid;
 }
 
+std::string MegaClient::getDeviceidHash() const
+{
+    string deviceIdHash;
+    string id = getDeviceid();
+    if (id.size())
+    {
+        string hash;
+        HashSHA256 hasher;
+        hasher.add((const byte*)id.data(), unsigned(id.size()));
+        hasher.get(&hash);
+        Base64::btoa(hash, deviceIdHash);
+    }
+    return deviceIdHash;
+}
+
 // set warn level
 void MegaClient::warn(const char* msg)
 {


### PR DESCRIPTION
It also address the following:
- Update python beautifier
- Adjust format of `device-id` for `sp` command
- Avoid handling transfer removed after sync removal 