### PR TITLE
SDK-1215: Minor Filesystem Fixes

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -379,7 +379,7 @@ AppFilePut::~AppFilePut()
 
 void AppFilePut::displayname(string* dname)
 {
-    *dname = localname.toName(*transfer->client->fsaccess, client->fsaccess->getFilesystemType(localname));
+    *dname = localname.toName(*transfer->client->fsaccess, client->fsaccess->getlocalfstype(localname));
 }
 
 // transfer progress callback
@@ -682,7 +682,7 @@ AppFileGet::AppFileGet(Node* n, handle ch, byte* cfilekey, m_off_t csize, m_time
         name = *cfilename;
     }
 
-    localname = LocalPath::fromName(name, *client->fsaccess, client->fsaccess->getFilesystemType(LocalPath::fromPath(name, *client->fsaccess)));
+    localname = LocalPath::fromName(name, *client->fsaccess, client->fsaccess->getlocalfstype(LocalPath::fromPath(name, *client->fsaccess)));
     if (!targetfolder.empty())
     {
         string s = targetfolder;
@@ -702,7 +702,7 @@ AppFilePut::AppFilePut(const LocalPath& clocalname, handle ch, const char* ctarg
     targetuser = ctargetuser;
 
     // erase path component
-    auto fileSystemType = client->fsaccess->getFilesystemType(clocalname);
+    auto fileSystemType = client->fsaccess->getlocalfstype(clocalname);
 
     LocalPath p = clocalname;
     p.erase(0, p.lastpartlocal(*client->fsaccess));
@@ -2562,7 +2562,7 @@ bool recursiveCompare(Node* mn, fs::path p)
     }
 
     std::string path = p.u8string();
-    auto fileSystemType = client->fsaccess->getFilesystemType(LocalPath::fromPath(path, *client->fsaccess));
+    auto fileSystemType = client->fsaccess->getlocalfstype(LocalPath::fromPath(path, *client->fsaccess));
     multimap<string, Node*> ms;
     multimap<string, fs::path> ps;
     for (auto& m : mn->children)
@@ -8111,7 +8111,7 @@ void exec_metamac(autocomplete::ACState& s)
 
     auto ifAccess = client->fsaccess->newfileaccess();
     {
-        auto localPath = LocalPath::fromName(s.words[1].s, *client->fsaccess, client->fsaccess->getFilesystemType(LocalPath::fromPath(s.words[1].s, *client->fsaccess)));
+        auto localPath = LocalPath::fromName(s.words[1].s, *client->fsaccess, client->fsaccess->getlocalfstype(LocalPath::fromPath(s.words[1].s, *client->fsaccess)));
         if (!ifAccess->fopen(localPath, 1, 0))
         {
             cerr << "Failed to open: " << s.words[1].s << endl;

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -22,58 +22,26 @@
 #ifndef MEGA_FILESYSTEM_H
 #define MEGA_FILESYSTEM_H 1
 
-#if defined (__linux__) && !defined (__ANDROID__)
-#include <linux/magic.h>
-#endif
-
-#if defined (__linux__) || defined (__ANDROID__) // __ANDROID__ is always included in __linux__
-#include <sys/vfs.h>
-#elif defined  (__APPLE__) || defined (USE_IOS)
-#include <sys/mount.h>
-#include <sys/param.h>
-#elif defined(_WIN32) || defined(WINDOWS_PHONE)
-#include <winsock2.h>
-#include <Windows.h>
-#endif
-
 #include "types.h"
 #include "utils.h"
 #include "waiter.h"
 
-#if defined (__linux__) && !defined (__ANDROID__)
-// Define magic constants (for linux), in case they are not defined in headers
-#ifndef HFS_SUPER_MAGIC
-#define HFS_SUPER_MAGIC 0x4244
-#endif
-
-#ifndef NTFS_SB_MAGIC
-#define NTFS_SB_MAGIC   0x5346544e
-#endif
-
-#elif defined (__ANDROID__)
-// Define magic constants (for Android), in case they are not defined in headers
-#ifndef SDCARDFS_SUPER_MAGIC
-#define SDCARDFS_SUPER_MAGIC 0x5DCA2DF5
-#endif
-
-#ifndef FUSEBLK_SUPER_MAGIC
-#define FUSEBLK_SUPER_MAGIC  0x65735546
-#endif
-
-#ifndef FUSECTL_SUPER_MAGIC
-#define FUSECTL_SUPER_MAGIC  0x65735543
-#endif
-
-#ifndef F2FS_SUPER_MAGIC
-#define F2FS_SUPER_MAGIC 0xF2F52010
-#endif
-#endif
-
 namespace mega {
 
 // Enumeration for filesystem families
-enum FileSystemType {FS_UNKNOWN = -1, FS_APFS = 0, FS_HFS = 1, FS_EXT = 2, FS_FAT32 = 3,
-                     FS_EXFAT = 4, FS_NTFS = 5, FS_FUSE = 6, FS_SDCARDFS = 7, FS_F2FS = 8};
+enum FileSystemType
+{
+    FS_UNKNOWN = -1,
+    FS_APFS = 0,
+    FS_HFS = 1,
+    FS_EXT = 2,
+    FS_FAT32 = 3,
+    FS_EXFAT = 4,
+    FS_NTFS = 5,
+    FS_FUSE = 6,
+    FS_SDCARDFS = 7,
+    FS_F2FS = 8
+};
 
 // generic host filesystem node ID interface
 struct MEGA_API FsNodeId
@@ -445,9 +413,9 @@ struct MEGA_API FileSystemAccess : public EventTrigger
     bool islocalfscompatible(unsigned char, bool isEscape, FileSystemType = FS_UNKNOWN) const;
     void escapefsincompatible(string*, FileSystemType fileSystemType) const;
 
-    FileSystemType getFilesystemType(const LocalPath& dstPath) const;
     const char *fstypetostring(FileSystemType type) const;
-    FileSystemType getlocalfstype(const LocalPath& dstPath) const;
+    virtual bool getlocalfstype(const LocalPath& path, FileSystemType& type) const = 0;
+    FileSystemType getlocalfstype(const LocalPath& path) const;
     void unescapefsincompatible(string*,FileSystemType) const;
 
     // convert MEGA path (UTF-8) to local format

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -40,7 +40,8 @@ enum FileSystemType
     FS_NTFS = 5,
     FS_FUSE = 6,
     FS_SDCARDFS = 7,
-    FS_F2FS = 8
+    FS_F2FS = 8,
+    FS_XFS = 9
 };
 
 // generic host filesystem node ID interface

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -179,7 +179,7 @@ public:
     // Return a utf8 representation of the LocalPath, taking into account that the LocalPath
     // may contain escaped characters that are disallowed for the filesystem.
     // Those characters are converted back (unescaped).  fsaccess is used to do the conversion.
-    std::string toName(const FileSystemAccess& fsaccess, FileSystemType fsType = FS_UNKNOWN) const;
+    std::string toName(const FileSystemAccess& fsaccess, FileSystemType fsType) const;
 
     // Create a Localpath from a utf8 string where no character conversions or escaping is necessary.
     static LocalPath fromPath(const std::string& path, const FileSystemAccess& fsaccess);

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -63,6 +63,8 @@ struct MEGA_API PosixDirAccess : public DirAccess
 class MEGA_API PosixFileSystemAccess : public FileSystemAccess
 {
 public:
+    using FileSystemAccess::getlocalfstype;
+
     int notifyfd;
 
 #ifdef USE_INOTIFY
@@ -86,6 +88,8 @@ public:
     std::unique_ptr<FileAccess> newfileaccess(bool followSymLinks = true) override;
     DirAccess* newdiraccess() override;
     DirNotify* newdirnotify(LocalPath&, LocalPath&, Waiter*) override;
+
+    bool getlocalfstype(const LocalPath& path, FileSystemType& type) const override;
 
     void tmpnamelocal(LocalPath&) const override;
 

--- a/include/mega/win32/megafs.h
+++ b/include/mega/win32/megafs.h
@@ -50,7 +50,12 @@ struct MEGA_API WinDirNotify;
 class MEGA_API WinFileSystemAccess : public FileSystemAccess
 {
 public:
+    using FileSystemAccess::getlocalfstype;
+
     std::unique_ptr<FileAccess> newfileaccess(bool followSymLinks = true) override;
+    
+    bool getlocalfstype(const LocalPath& path, FileSystemType& type) const override;
+
     DirAccess* newdiraccess() override;
     DirNotify* newdirnotify(LocalPath&, LocalPath&, Waiter*) override;
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -77,119 +77,51 @@ const char *FileSystemAccess::fstypetostring(FileSystemType type) const
     return "UNKNOWN FS";
 }
 
-FileSystemType FileSystemAccess::getlocalfstype(const LocalPath& dstPath) const
+FileSystemType FileSystemAccess::getlocalfstype(const LocalPath& path) const
 {
-    if (dstPath.empty())
+    // Not enough information to determine path.
+    if (path.empty())
     {
         return FS_UNKNOWN;
     }
 
-#if defined (__linux__) && !defined (__ANDROID__)
-    // Filesystem detection for Linux
-    struct statfs fileStat;
-    if (!statfs(dstPath.editStringDirect()->c_str(), &fileStat))
-    {
-        switch (fileStat.f_type)
-        {
-            case EXT2_SUPER_MAGIC:
-                return FS_EXT;
-            case MSDOS_SUPER_MAGIC:
-                return FS_FAT32;
-            case HFS_SUPER_MAGIC:
-                return FS_HFS;
-            case NTFS_SB_MAGIC:
-                return FS_NTFS;
-            default:
-                return FS_UNKNOWN;
-        }
-    }
-#elif defined (__ANDROID__)
-    // Filesystem detection for Android
-    struct statfs fileStat;
-    if (!statfs(dstPath.editStringDirect()->c_str(), &fileStat))
-    {
-        switch (fileStat.f_type)
-        {
-            case EXT2_SUPER_MAGIC:
-                return FS_EXT;
-            case MSDOS_SUPER_MAGIC:
-                return FS_FAT32;
-            case HFS_SUPER_MAGIC:
-                return FS_HFS;
-            case NTFS_SB_MAGIC:
-                return FS_NTFS;
-            case SDCARDFS_SUPER_MAGIC:
-                return FS_SDCARDFS;
-            case FUSEBLK_SUPER_MAGIC:
-            case FUSECTL_SUPER_MAGIC:
-                return FS_FUSE;
-            case F2FS_SUPER_MAGIC:
-                return FS_F2FS;
-            default:
-                return FS_UNKNOWN;
-        }
-    }
-#elif defined  (__APPLE__) || defined (USE_IOS)
-    // Filesystem detection for Apple and iOS
-    struct statfs fileStat;
-    if (!statfs(dstPath.editStringDirect()->c_str(), &fileStat))
-    {
-        if (!strcmp(fileStat.f_fstypename, "apfs"))
-        {
-            return FS_APFS;
-        }
-        if (!strcmp(fileStat.f_fstypename, "hfs"))
-        {
-            return FS_HFS;
-        }
-        if (!strcmp(fileStat.f_fstypename, "ntfs"))
-        {
-            return FS_NTFS;
-        }
-        if (!strcmp(fileStat.f_fstypename, "msdos"))
-        {
-            return FS_FAT32;
-        }
-    }
-#elif defined(_WIN32) || defined(WINDOWS_PHONE)
-    // Filesystem detection for Windows
+    FileSystemType type;
 
-    auto tmpPath = dstPath;
-    tmpPath.editStringDirect()->append("", 1); // make sure of 2 byte terminator as LPCTWSTR (later we'll make it wstring for windows)
+    // Try and get the type from the path we were given.
+    if (getlocalfstype(path, type))
+    {
+        // Path exists.
+        return type;
+    }
 
-    std::wstring volMountPoint;
-    volMountPoint.resize(MAX_PATH);
-    DWORD mountLen = static_cast<DWORD>(volMountPoint.size());
-    if (!(GetVolumePathNameW((LPCWSTR)tmpPath.editStringDirect()->data(), &volMountPoint[0], mountLen)))
+    // Try and get the type based on our parent's path.
+    LocalPath parentPath(path);
+
+    // Remove trailing separator, if any.
+    parentPath.trimNonDriveTrailingSeparator(*this);
+
+    // Did the path consist solely of that separator?
+    if (parentPath.empty())
     {
         return FS_UNKNOWN;
     }
 
-    LPCWSTR auxMountPoint = volMountPoint.c_str();
-    WCHAR volumeName[MAX_PATH + 1] = { 0 };
-    WCHAR fileSystemName[MAX_PATH + 1] = { 0 };
-    DWORD serialNumber = 0;
-    DWORD maxComponentLen = 0;
-    DWORD fileSystemFlags = 0;
+    // Where does our name begin?
+    auto index = parentPath.getLeafnameByteIndex(*this);
 
-    if (GetVolumeInformationW(auxMountPoint, volumeName, sizeof(volumeName),
-                             &serialNumber, &maxComponentLen, &fileSystemFlags,
-                             fileSystemName, sizeof(fileSystemName)))
+    // We have a parent.
+    if (index)
     {
-        if (!wcscmp(fileSystemName, L"NTFS"))
+        // Remove the current leaf name.
+        parentPath.truncate(index);
+
+        // Try and get our parent's filesystem type.
+        if (getlocalfstype(parentPath, type))
         {
-            return FS_NTFS;
-        }
-        if (!wcscmp(fileSystemName, L"exFAT"))
-        {
-            return FS_EXFAT;
-        }
-        if (!wcscmp(fileSystemName, L"FAT32"))
-        {
-            return FS_FAT32;
+            return type;
         }
     }
-#endif
+
     return FS_UNKNOWN;
 }
 
@@ -202,21 +134,6 @@ bool FileSystemAccess::isControlChar(unsigned char c) const
 bool FileSystemAccess::islocalfscompatible(unsigned char c, bool, FileSystemType) const
 {
     return c >= ' ' && !strchr("\\/:?\"<>|*", c);
-}
-
-FileSystemType FileSystemAccess::getFilesystemType(const LocalPath& dstPath) const
-{
-    // first get "valid" path (no last leaf name, in case it is not in the FS?)
-    LocalPath validPath = dstPath;
-
-    if (!validPath.endsInSeparator(*this))
-    {
-        size_t leafIndex = validPath.getLeafnameByteIndex(*this);
-        if (leafIndex > 0)
-            validPath.truncate(leafIndex);
-    }
-
-    return getlocalfstype(validPath);
 }
 
 // replace characters that are not allowed in local fs names with a %xx escape sequence
@@ -249,7 +166,7 @@ void FileSystemAccess::escapefsincompatible(string* name, FileSystemType fileSys
             name->replace(i, 1, buf);
             LOG_debug << "Escape incompatible character for filesystem type "
                       << fstypetostring(fileSystemType)
-                      << ", replace '" << std::string(&incompatibleChar, 1) << "' by '" << buf << "'\n";
+                      << ", replace '" << incompatibleChar << "' by '" << buf << "'\n";
         }
         i += utf8seqsize;
     }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -70,6 +70,8 @@ const char *FileSystemAccess::fstypetostring(FileSystemType type) const
             return "SDCARDFS";
         case FS_F2FS:
             return "F2FS";
+        case FS_XFS:
+            return "XFS";
         case FS_UNKNOWN:    // fall through
             return "UNKNOWN FS";
     }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -2821,7 +2821,7 @@ void MegaTransferPrivate::setPath(const char* path)
 
     for (int i = int(strlen(path) - 1); i >= 0; i--)
     {
-        if (strchr(::mega::FileSystemAccess::getPathSeparator(), path[i]))
+        if (strchr(FileSystemAccess::getPathSeparator(), path[i]))
         {
             setFileName(&(path[i+1]));
             char *parentPath = MegaApi::strdup(path);
@@ -4771,7 +4771,7 @@ MegaFileGet::MegaFileGet(MegaClient *client, MegaNode *n, const LocalPath& dstPa
 {
     h = n->getHandle();
 
-    FileSystemType fsType = client->fsaccess->getFilesystemType(dstPath);
+    FileSystemType fsType = client->fsaccess->getlocalfstype(dstPath);
 
     LocalPath lpName = LocalPath::fromName(n->getName(), *client->fsaccess, fsType);
     name = lpName.toPath(*client->fsaccess);
@@ -8099,7 +8099,7 @@ void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *
 {
     if (fsType == FS_UNKNOWN && localPath)
     {
-        fsType = fsAccess->getFilesystemType(LocalPath::fromPath(localPath, *fsAccess));
+        fsType = fsAccess->getlocalfstype(LocalPath::fromPath(localPath, *fsAccess));
     }
 
     MegaTransferPrivate* transfer = new MegaTransferPrivate(MegaTransfer::TYPE_UPLOAD, listener);
@@ -8188,7 +8188,7 @@ void MegaApiImpl::startDownload(bool startFirst, MegaNode *node, const char* loc
 #endif
 
         int c = localPath[strlen(localPath)-1];
-        if (strchr(::mega::FileSystemAccess::getPathSeparator(), c))
+        if (strchr(FileSystemAccess::getPathSeparator(), c))
         {
             transfer->setParentPath(localPath);
         }
@@ -8302,7 +8302,7 @@ void MegaApiImpl::retryTransfer(MegaTransfer *transfer, MegaTransferListener *li
         MegaNode *parent = getNodeByHandle(t->getParentHandle());
         startUpload(t->shouldStartFirst(), t->getPath(), parent, t->getFileName(), t->getTime(), 0,
                           t->isBackupTransfer(), t->getAppData(), t->isSourceFileTemporary(), t->isStreamingTransfer(),
-                          client->fsaccess->getFilesystemType(LocalPath::fromPath(t->getPath(), *fsAccess)), listener);
+                          client->fsaccess->getlocalfstype(LocalPath::fromPath(t->getPath(), *fsAccess)), listener);
         delete parent;
     }
 }
@@ -8960,7 +8960,7 @@ char *MegaApiImpl::escapeFsIncompatible(const char *filename, const char *dstPat
     }
     string name = filename;
     string path = dstPath ? dstPath : "";
-    client->fsaccess->escapefsincompatible(&name, client->fsaccess->getFilesystemType(LocalPath::fromPath(path, *client->fsaccess)));
+    client->fsaccess->escapefsincompatible(&name, client->fsaccess->getlocalfstype(LocalPath::fromPath(path, *client->fsaccess)));
     return MegaApi::strdup(name.c_str());
 }
 
@@ -8972,7 +8972,7 @@ char *MegaApiImpl::unescapeFsIncompatible(const char *name, const char *path)
     }
     string filename = name;
     string localpath = path ? path : "";
-    client->fsaccess->unescapefsincompatible(&filename, client->fsaccess->getFilesystemType(LocalPath::fromPath(localpath, *client->fsaccess)));
+    client->fsaccess->unescapefsincompatible(&filename, client->fsaccess->getlocalfstype(LocalPath::fromPath(localpath, *client->fsaccess)));
     return MegaApi::strdup(filename.c_str());
 }
 
@@ -18350,7 +18350,7 @@ unsigned MegaApiImpl::sendPendingTransfers()
                         wLocalPath.appendWithSeparator(LocalPath::fromPath("", *fsAccess), true, fsAccess->localseparator);
                     }
 
-                    FileSystemType fsType = fsAccess->getFilesystemType(wLocalPath);
+                    FileSystemType fsType = fsAccess->getlocalfstype(wLocalPath);
 
                     MegaFileGet *f;
                     if (node)
@@ -24704,7 +24704,7 @@ void MegaFolderUploadController::onFolderAvailable(MegaHandle handle)
     da = client->fsaccess->newdiraccess();
     if (da->dopen(&localPath, NULL, false))
     {
-        FileSystemType fsType = client->fsaccess->getFilesystemType(localPath);
+        FileSystemType fsType = client->fsaccess->getlocalfstype(localPath);
 
         nodetype_t dirEntryType;
         while (da->dnext(localPath, localname, client->followsymlinks, &dirEntryType))
@@ -25496,7 +25496,7 @@ void MegaBackupController::onFolderAvailable(MegaHandle handle)
         da = client->fsaccess->newdiraccess();
         if (da->dopen(&localPath, NULL, false))
         {
-            FileSystemType fsType = client->fsaccess->getFilesystemType(localPath);
+            FileSystemType fsType = client->fsaccess->getlocalfstype(localPath);
 
             while (da->dnext(localPath, localname, client->followsymlinks))
             {
@@ -25979,7 +25979,7 @@ void MegaFolderDownloadController::start(MegaNode *node)
         path.appendWithSeparator(LocalPath::fromPath("", *client->fsaccess), true, client->fsaccess->localseparator);
     }
 
-    FileSystemType fsType = client->fsaccess->getFilesystemType(path);
+    FileSystemType fsType = client->fsaccess->getlocalfstype(path);
 
     if (!fileName)
     {
@@ -28792,7 +28792,7 @@ int MegaHTTPServer::onMessageComplete(http_parser *parser)
                 }
             }
 
-            FileSystemType fsType = httpctx->server->fsAccess->getFilesystemType(LocalPath::fromPath(httpctx->tmpFileName, *httpctx->server->fsAccess));
+            FileSystemType fsType = httpctx->server->fsAccess->getlocalfstype(LocalPath::fromPath(httpctx->tmpFileName, *httpctx->server->fsAccess));
 
             httpctx->megaApi->startUpload(httpctx->tmpFileName.c_str(), newParentNode, newname.c_str(), fsType, httpctx);
 
@@ -31530,7 +31530,7 @@ void MegaFTPDataServer::processReceivedData(MegaTCPContext *tcpctx, ssize_t nrea
                 LOG_debug << "Starting upload of file " << fds->newNameToUpload;
                 fds->controlftpctx->tmpFileName = ftpdatactx->tmpFileName;
 
-                FileSystemType fsType = fds->fsAccess->getFilesystemType(LocalPath::fromPath(ftpdatactx->tmpFileName, *fds->fsAccess));
+                FileSystemType fsType = fds->fsAccess->getlocalfstype(LocalPath::fromPath(ftpdatactx->tmpFileName, *fds->fsAccess));
 
                 ftpdatactx->megaApi->startUpload(ftpdatactx->tmpFileName.c_str(), newParentNode, fds->newNameToUpload.c_str(), fsType, fds->controlftpctx);
                 ftpdatactx->controlRespondedElsewhere = true;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -8792,8 +8792,7 @@ bool MegaApiImpl::isSyncable(const char *path, long long size)
             }
 
             size_t lastpart = localpath.lastpartlocal(*fsAccess);
-            name = localpath.subpathFrom(lastpart).toName(*fsAccess);
-            fsAccess->local2name(&name, sync->mFilesystemType);
+            name = localpath.subpathFrom(lastpart).toName(*fsAccess, sync->mFilesystemType);
             result = is_syncable(sync, name.c_str(), localpath);
             break;
         }
@@ -24713,7 +24712,7 @@ void MegaFolderUploadController::onFolderAvailable(MegaHandle handle)
             ScopedLengthRestore restoreLen(localPath);
             localPath.appendWithSeparator(localname, false, client->fsaccess->localseparator);
 
-            string name = localname.toName(*client->fsaccess);
+            string name = localname.toName(*client->fsaccess, fsType);
             if (dirEntryType == FILENODE)
             {
                 pendingTransfers++;
@@ -25509,7 +25508,7 @@ void MegaBackupController::onFolderAvailable(MegaHandle handle)
                 auto fa = client->fsaccess->newfileaccess();
                 if(fa->fopen(localPath, true, false))
                 {
-                    string name = localname.toName(*client->fsaccess);
+                    string name = localname.toName(*client->fsaccess, fsType);
                     if(fa->type == FILENODE)
                     {
                         pendingTransfers++;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -15226,8 +15226,10 @@ Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
     if (remoteNodes->empty())
         return nullptr;
 
-    std::string localName = localNode->localname.toName(*fsaccess);
-
+    std::string localName =
+      localNode->localname.toName(*fsaccess,
+                                  localNode->sync->mFilesystemType);
+    
     // Only compare metamac if the node doesn't already exist.
     node_vector::const_iterator remoteNode =
       std::find_if(remoteNodes->begin(),

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1183,7 +1183,7 @@ void LocalNode::setnameparent(LocalNode* newparent, LocalPath* newlocalpath, std
         {
             // set new name
             localname = newlocalpath->subpathFrom(p);
-            name = localname.toName(*sync->client->fsaccess);
+            name = localname.toName(*sync->client->fsaccess, sync->mFilesystemType);
 
             if (node)
             {
@@ -1821,7 +1821,7 @@ LocalNode* LocalNode::unserialize(Sync* sync, const string* d)
     l->localname = LocalPath(std::move(localname));
     l->slocalname.reset(shortname.empty() ? nullptr : new LocalPath(std::move(shortname)));
     l->slocalname_in_db = 0 != expansionflags[0];
-    l->name = l->localname.toName(*sync->client->fsaccess);
+    l->name = l->localname.toName(*sync->client->fsaccess, sync->mFilesystemType);
 
     memcpy(l->crc.data(), crc, sizeof crc);
     l->mtime = mtime;

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -71,6 +71,10 @@ extern JavaVM *MEGAjvm;
 #define F2FS_SUPER_MAGIC 0xF2F52010
 #endif /* ! F2FS_SUPER_MAGIC */
 
+#ifndef XFS_SUPER_MAGIC
+#define XFS_SUPER_MAGIC 0x58465342
+#endif /* ! XFS_SUPER_MAGIC */
+
 #endif /* __linux__ */
 
 #if defined(__APPLE__) || defined(USE_IOS)
@@ -1870,6 +1874,9 @@ bool PosixFileSystemAccess::getlocalfstype(const LocalPath& path, FileSystemType
             type = FS_SDCARDFS;
             break;
 #endif /* __ANDROID__ */
+        case XFS_SUPER_MAGIC:
+            type = FS_XFS;
+            break;
         default:
             type = FS_UNKNOWN;
             break;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -705,7 +705,7 @@ Sync::Sync(MegaClient* cclient, SyncConfig &config, const char* cdebris,
     fsstableids = dirnotify->fsstableids();
     LOG_info << "Filesystem IDs are stable: " << fsstableids;
 
-    mFilesystemType = client->fsaccess->getFilesystemType(crootpath);
+    mFilesystemType = client->fsaccess->getlocalfstype(crootpath);
 
     localroot->init(this, FOLDERNODE, NULL, crootpath, nullptr);  // the root node must have the absolute path.  We don't store shortname, to avoid accidentally using relative paths.
     localroot->setnode(remotenode);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -117,7 +117,8 @@ set<LocalPath> collectAllPathsInFolder(Sync& sync, MegaApp& app, FileSystemAcces
         localpath.appendWithSeparator(localname, false, fsaccess.localseparator);
 
         // check if this record is to be ignored
-        if (app.sync_syncable(&sync, localname.toName(fsaccess).c_str(), localpath))
+        const auto name = localname.toName(fsaccess, sync.mFilesystemType);
+        if (app.sync_syncable(&sync, name.c_str(), localpath))
         {
             // skip the sync's debris folder
             if (!localdebris.isContainingPathOf(localpath, fsaccess))
@@ -1126,7 +1127,7 @@ bool Sync::scan(LocalPath* localpath, FileAccess* fa)
         {
             while (da->dnext(*localpath, localname, client->followsymlinks))
             {
-                name = localname.toName(*client->fsaccess);
+                name = localname.toName(*client->fsaccess, mFilesystemType);
 
                 ScopedLengthRestore restoreLen(*localpath);
                 localpath->appendWithSeparator(localname, false, client->fsaccess->localseparator);

--- a/tests/unit/DefaultedFileSystemAccess.h
+++ b/tests/unit/DefaultedFileSystemAccess.h
@@ -27,6 +27,8 @@ namespace mt {
 class DefaultedFileSystemAccess : public mega::FileSystemAccess
 {
 public:
+    using FileSystemAccess::getlocalfstype;
+
     DefaultedFileSystemAccess(const std::string &separator = "/")
     {
         notifyerr = false;
@@ -40,6 +42,10 @@ public:
     mega::DirAccess* newdiraccess() override
     {
         throw NotImplemented{__func__};
+    }
+    bool getlocalfstype(const mega::LocalPath&, mega::FileSystemType& type) const override
+    {
+        return type = mega::FS_UNKNOWN, false;
     }
     void path2local(const std::string*, std::string*) const override
     {


### PR DESCRIPTION
The purpose of this ticket is to fix the following minor issues:

- The XFS filesystem is incorrectly detected as FS_UNKNOWN.
- The filesystem detected for a directory is that of its parent.
- LocalPath::toName(...)'s fsType parameter should be mandatory.