### PR TITLE
SDK-1221. Completion functions instead of share_result() and exportnode_result()

### DIFF
--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -162,9 +162,6 @@ struct DemoApp : public MegaApp
 
     void putnodes_result(const Error&, targettype_t, vector<NewNode>&) override;
 
-    void share_result(error) override;
-    void share_result(int, error) override;
-
     void setpcr_result(handle, error, opcactions_t) override;
     void updatepcr_result(error, ipcactions_t) override;
 
@@ -190,9 +187,6 @@ struct DemoApp : public MegaApp
 
     // sessionid is undef if all sessions except the current were killed
     void sessions_killed(handle sessionid, error e) override;
-
-    void exportnode_result(error) override;
-    void exportnode_result(handle, handle) override;
 
     void openfilelink_result(const Error&) override;
     void openfilelink_result(handle, const byte*, m_off_t, string*, string*, int) override;

--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -165,7 +165,7 @@ public:
     };
 
     virtual bool procresult(Result) = 0;
-    
+
     // json for the command is usually pre-generated but can be calculated just before sending, by overriding this function
     virtual const char* getJSON(MegaClient* client);
 
@@ -639,12 +639,14 @@ class MEGA_API CommandSetShare : public Command
     string msg;
     string personal_representation;
 
+    std::function<void(Error)> completion;
+
     bool procuserresult(MegaClient*);
 
 public:
     bool procresult(Result) override;
 
-    CommandSetShare(MegaClient*, Node*, User*, accesslevel_t, int, const char*, const char* = NULL);
+    CommandSetShare(MegaClient*, Node*, User*, accesslevel_t, int, const char*, const char*, int tag, std::function<void(Error)> f);
 };
 
 class MEGA_API CommandGetUserData : public Command
@@ -742,11 +744,12 @@ class MEGA_API CommandSetPH : public Command
 {
     handle h;
     m_time_t ets;
+    std::function<void(Error, handle, handle)> completion;
 
 public:
     bool procresult(Result) override;
 
-    CommandSetPH(MegaClient*, Node*, int, m_time_t);
+    CommandSetPH(MegaClient*, Node*, int, m_time_t, int ctag, std::function<void(Error, handle, handle)> f);
 };
 
 class MEGA_API CommandGetPH : public Command

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -125,8 +125,7 @@ struct MEGA_API MegaApp
     // node addition has failed
     virtual void putnodes_result(const Error&, targettype_t, vector<NewNode>&) { }
 
-    // share update result
-    virtual void share_result(error) { }
+    // share update changes (not the final callback though)
     virtual void share_result(int, error) { }
 
     // outgoing pending contact result
@@ -175,10 +174,6 @@ struct MEGA_API MegaApp
 #endif
 
     virtual void getuseremail_result(string *, error) { }
-
-    // file node export result
-    virtual void exportnode_result(error) { }
-    virtual void exportnode_result(handle, handle) { }
 
     // exported link access result
     virtual void openfilelink_result(const Error&) { }

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -572,15 +572,15 @@ public:
     error removecontact(const char*, visibility_t = HIDDEN);
 
     // add/remove/update outgoing share
-    void setshare(Node*, const char*, accesslevel_t, const char* = NULL);
+    void setshare(Node*, const char*, accesslevel_t, const char*, int tag, std::function<void(Error)> completion);
 
     // Add/delete/remind outgoing pending contact request
     void setpcr(const char*, opcactions_t, const char* = NULL, const char* = NULL, handle = UNDEF);
     void updatepcr(handle, ipcactions_t);
 
     // export node link or remove existing exported link for this node
-    error exportnode(Node*, int, m_time_t);
-    void getpubliclink(Node* n, int del, m_time_t ets); // auxiliar method to add req
+    error exportnode(Node*, int, m_time_t, int tag, std::function<void(Error, handle, handle)> completion);
+    void getpubliclink(Node* n, int del, m_time_t ets, int tag, std::function<void(Error, handle, handle)> completion); // auxiliar method to add req
 
     // add timer
     error addtimer(TimerWithBackoff *twb);

--- a/include/mega/pubkeyaction.h
+++ b/include/mega/pubkeyaction.h
@@ -46,10 +46,12 @@ class MEGA_API PubKeyActionCreateShare : public PubKeyAction
     accesslevel_t a;    // desired access level
     string selfemail;  // optional personal representation when sharing to a non-contact
 
+    std::function<void(Error)> completion;
+
 public:
     void proc(MegaClient*, User*);
 
-    PubKeyActionCreateShare(handle, accesslevel_t, int, const char* = NULL);
+    PubKeyActionCreateShare(handle, accesslevel_t, int, const char*, std::function<void(Error)> completion);
 };
 
 class MEGA_API PubKeyActionSendShareKey : public PubKeyAction

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2944,10 +2944,6 @@ protected:
         void fetchnodes_result(const Error&) override;
         void putnodes_result(const Error&, targettype_t, vector<NewNode>&) override;
 
-        // share update result
-        void share_result(error) override;
-        void share_result(int, error) override;
-
         // contact request results
         void setpcr_result(handle, error, opcactions_t) override;
         void updatepcr_result(error, ipcactions_t) override;
@@ -2991,10 +2987,6 @@ protected:
 #endif
 
         void getuseremail_result(string *, error) override;
-
-        // file node export result
-        void exportnode_result(error) override;
-        void exportnode_result(handle, handle) override;
 
         // exported link access result
         void openfilelink_result(const Error&) override;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -9781,8 +9781,10 @@ void MegaClient::rewriteforeignkeys(Node* n)
 
 // if user has a known public key, complete instantly
 // otherwise, queue and request public key if not already pending
-void MegaClient::setshare(Node* n, const char* user, accesslevel_t a, const char* personal_representation)
+void MegaClient::setshare(Node* n, const char* user, accesslevel_t a, const char* personal_representation, int tag, std::function<void(Error)> completion)
 {
+    assert(completion);
+
     size_t total = n->outshares ? n->outshares->size() : 0;
     total += n->pendingshares ? n->pendingshares->size() : 0;
     if (a == ACCESS_UNKNOWN && total == 1)
@@ -9792,7 +9794,7 @@ void MegaClient::setshare(Node* n, const char* user, accesslevel_t a, const char
         rewriteforeignkeys(n);
     }
 
-    queuepubkeyreq(user, ::mega::make_unique<PubKeyActionCreateShare>(n->nodehandle, a, reqtag, personal_representation));
+    queuepubkeyreq(user, ::mega::make_unique<PubKeyActionCreateShare>(n->nodehandle, a, tag, personal_representation, move(completion)));
 }
 
 // Add/delete/remind outgoing pending contact request
@@ -10974,7 +10976,7 @@ void MegaClient::querytransferquota(m_off_t size)
 }
 
 // export node link
-error MegaClient::exportnode(Node* n, int del, m_time_t ets)
+error MegaClient::exportnode(Node* n, int del, m_time_t ets, int tag, std::function<void(Error, handle, handle)> completion)
 {
     if (n->plink && !del && !n->plink->takendown
             && (ets == n->plink->ets) && !n->plink->isExpired())
@@ -10984,8 +10986,8 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
             LOG_warn << "Rejecting public link request when ODQ paywall";
             return API_EPAYWALL;
         }
-        restag = reqtag;
-        app->exportnode_result(n->nodehandle, n->plink->ph);
+        restag = tag;
+        completion(API_OK, n->nodehandle, n->plink->ph);
         return API_OK;
     }
 
@@ -10998,7 +11000,7 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
     switch (n->type)
     {
     case FILENODE:
-        getpubliclink(n, del, ets);
+        getpubliclink(n, del, ets, tag, move(completion));
         break;
 
     case FOLDERNODE:
@@ -11006,16 +11008,32 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
         {
             // deletion of outgoing share also deletes the link automatically
             // need to first remove the link and then the share
-            getpubliclink(n, del, ets);
-            setshare(n, NULL, ACCESS_UNKNOWN);
+            getpubliclink(n, del, ets, tag, nullptr);
+            setshare(n, NULL, ACCESS_UNKNOWN, nullptr, tag, [completion](Error e){
+                completion(e, UNDEF, UNDEF);
+            });
         }
         else
         {
             // exporting folder - need to create share first
-            setshare(n, NULL, RDONLY);
-            // getpubliclink() is called as _result() of the share
-        }
 
+            handle h = n->nodehandle;
+
+            setshare(n, NULL, RDONLY, nullptr, tag, [this, h, ets, tag, completion](Error e){
+                if (e)
+                {
+                    completion(e, UNDEF, UNDEF);
+                }
+                else if (Node* node = nodebyhandle(h))
+                {
+                    getpubliclink(node, false, ets, tag, completion);
+                }
+                else
+                {
+                    completion(API_ENOENT, UNDEF, UNDEF);
+                }
+            });
+        }
         break;
 
     default:
@@ -11025,9 +11043,9 @@ error MegaClient::exportnode(Node* n, int del, m_time_t ets)
     return API_OK;
 }
 
-void MegaClient::getpubliclink(Node* n, int del, m_time_t ets)
+void MegaClient::getpubliclink(Node* n, int del, m_time_t ets, int tag, std::function<void(Error, handle, handle)> f)
 {
-    reqs.add(new CommandSetPH(this, n, del, ets));
+    reqs.add(new CommandSetPH(this, n, del, ets, tag, move(f)));
 }
 
 // open exported file link

--- a/src/pubkeyaction.cpp
+++ b/src/pubkeyaction.cpp
@@ -92,7 +92,8 @@ void PubKeyActionCreateShare::proc(MegaClient* client, User* u)
     // node vanished: bail
     if (!(n = client->nodebyhandle(h)))
     {
-        return client->app->share_result(API_ENOENT);
+        completion(API_ENOENT);
+        return;
     }
 
     // do we already have a share key for this node?
@@ -108,16 +109,17 @@ void PubKeyActionCreateShare::proc(MegaClient* client, User* u)
 
     // we have all ingredients ready: the target user's public key, the share
     // key and all nodes to share
-    client->restag = tag;
-    client->reqs.add(new CommandSetShare(client, n, u, a, newshare, NULL, selfemail.c_str()));
+    client->reqs.add(new CommandSetShare(client, n, u, a, newshare, NULL, selfemail.c_str(), tag, move(completion)));
 }
 
 // share node sh with access level sa
-PubKeyActionCreateShare::PubKeyActionCreateShare(handle sh, accesslevel_t sa, int ctag, const char* personal_representation)
+PubKeyActionCreateShare::PubKeyActionCreateShare(handle sh, accesslevel_t sa, int ctag, const char* personal_representation, std::function<void(Error)> f)
 {
     h = sh;
     a = sa;
     tag = ctag;
+    completion = move(f);
+    assert(completion);
 
     if (personal_representation)
     {


### PR DESCRIPTION
Inspired by the need to fix the failing test case for getpubliclink().
This enables us to easily code the test cases for export/share/getpubliclink()
And also makes the chaining of commands very simple - export node needs to share and then getpubliclink().
But those are not always called in that order.   Matching up the response to the request
and then figuring out whether to chain another command was complex.
Now we can use lambdas to supply the actions to perform when a command completes, with no need to match up tags and request types.
This change can serve as an example for discussion as to whether we should adopt the method widely.
Also without needing to use overrides of MegaApp virtual functions, we can keep the requesting and response processing code close together.