### PR TITLE
Release/v3.7.3c

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -661,10 +661,14 @@ void EncryptByChunks::updateCRC(byte* data, unsigned size, unsigned offset)
 {
     uint32_t *intc = (uint32_t *)crc;
 
-    int ol = offset % CRCSIZE;
+    unsigned ol = offset % CRCSIZE;
     if (ol)
     {
-        int ll = CRCSIZE - ol;
+        unsigned ll = CRCSIZE - ol;
+        if (ll > size) //last chunks could be smaller than CRCSIZE!
+        {
+            ll = size;
+        }
         size -= ll;
         while (ll--)
         {


### PR DESCRIPTION
Bug fixes:
- SDK-1223. Fix crash when obtaining CRC for files with size N*SEGSIZE+o with o < CRCSIZE

Target app/s:
- megasync 4.3.5