### PR TITLE
SDK-1223. Hotfix over 3.7.4. Crash when obtaining CRCfix crash when obtaining CRC

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -661,10 +661,14 @@ void EncryptByChunks::updateCRC(byte* data, unsigned size, unsigned offset)
 {
     uint32_t *intc = (uint32_t *)crc;
 
-    int ol = offset % CRCSIZE;
+    unsigned ol = offset % CRCSIZE;
     if (ol)
     {
-        int ll = CRCSIZE - ol;
+        unsigned ll = CRCSIZE - ol;
+        if (ll > size) //last chunks could be smaller than CRCSIZE!
+        {
+            ll = size;
+        }
         size -= ll;
         while (ll--)
         {


### PR DESCRIPTION
 for files with size N*SEGSIZE+o with o < CRCSIZE