### PR TITLE
SDK-1224. When a node is moved to the trash, remove outshares

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -469,6 +469,9 @@ public:
     // move node to new parent folder
     error rename(Node*, Node*, syncdel_t = SYNCDEL_NONE, handle = UNDEF, const char *newName = nullptr);
 
+    // Queue commands (if needed) to remvoe any outshares (or pending outshares) below the specified node
+    void removeOutSharesFromSubtree(Node* n);
+
     // start/stop/pause file transfer
     bool startxfer(direction_t, File*, DBTableTransactionCommitter&, bool skipdupes = false, bool startfirst = false, bool donotpersist = false);
     void stopxfer(File* f, DBTableTransactionCommitter* committer);

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -40,7 +40,7 @@ bool MegaClient::disablepkp = false;
 
 // root URL for API access
 // TODO: restore this before merging - needed for now for jenkins runs
-string MegaClient::APIURL = "https://lu1.api.mega.co.nz:444/";
+string MegaClient::APIURL = "https://bt1.api.mega.co.nz:444/";
 
 // root URL for GeLB requests
 string MegaClient::GELBURL = "https://gelb.karere.mega.nz/";


### PR DESCRIPTION
For that node, and any descendant.  Also pending outshares.