### PR TITLE
SDK-1228. Send `smslc` separately

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -8006,6 +8006,7 @@ CommandGetCountryCallingCodes::CommandGetCountryCallingCodes(MegaClient* client)
 {
     cmd("smslc");
 
+    batchSeparately = true;
     tag = client->reqtag;
 }
 


### PR DESCRIPTION
...to avoid a -16 when account is blocked.