### PR TITLE
Revert "SDK-1227. Add `w` param to `gpsa` to get `url`"

### DIFF
--- a/bindings/java/nz/mega/sdk/MegaApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaApiJava.java
@@ -2090,9 +2090,8 @@ public class MegaApiJava {
      * - MegaRequest::getName - Returns the title of the PSA
      * - MegaRequest::getText - Returns the text of the PSA
      * - MegaRequest::getFile - Returns the URL of the image of the PSA
-     * - MegaRequest::getPassword - Returns the text for the positive button (or an empty string)
-     * - MegaRequest::getLink - Returns the link for the positive button (or an empty string)
-     * - MegaRequest::getEmail - Returns the url that app need to open with in-app browser
+     * - MegaRequest::getPassword - Returns the text for the possitive button (or an empty string)
+     * - MegaRequest::getLink - Returns the link for the possitive button (or an empty string)
      *
      * If there isn't any new PSA to show, onRequestFinish will be called with the error
      * code MegaError::API_ENOENT
@@ -2100,7 +2099,7 @@ public class MegaApiJava {
      * @param listener MegaRequestListener to track this request
      * @see MegaApi::setPSA
      */
-    public void getPSA(MegaRequestListenerInterface listener){
+    void getPSA(MegaRequestListenerInterface listener){
         megaApi.getPSA(createDelegateRequestListener(listener));
     }
 
@@ -2127,7 +2126,7 @@ public class MegaApiJava {
      *
      * @see MegaApi::setPSA
      */
-    public void getPSA(){
+    void getPSA(){
         megaApi.getPSA();
     }
 
@@ -2145,7 +2144,7 @@ public class MegaApiJava {
      *
      * @see MegaApi::getPSA
      */
-    public void setPSA(int id, MegaRequestListenerInterface listener){
+    void setPSA(int id, MegaRequestListenerInterface listener){
         megaApi.setPSA(id, createDelegateRequestListener(listener));
     }
 
@@ -2162,7 +2161,7 @@ public class MegaApiJava {
      *
      * @see MegaApi::getPSA
      */
-    public void setPSA(int id){
+    void setPSA(int id){
         megaApi.setPSA(id);
     }
 

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -391,7 +391,7 @@ struct MEGA_API MegaApp
     virtual void keepmealive_result (error) { }
 
     // get the current PSA
-    virtual void getpsa_result (error, int, string*, string*, string*, string*, string*, string*) { }
+    virtual void getpsa_result (error, int, string*, string*, string*, string*, string*) { }
 
     // result of the user alert acknowledge request
     virtual void acknowledgeuseralerts_result(error) { }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -9375,7 +9375,6 @@ class MegaApi
          * - MegaRequest::getFile - Returns the URL of the image of the PSA
          * - MegaRequest::getPassword - Returns the text for the possitive button (or an empty string)
          * - MegaRequest::getLink - Returns the link for the possitive button (or an empty string)
-         * - MegaRequest::getEmail - Returns the URL (or an empty string)
          *
          * If there isn't any new PSA to show, onRequestFinish will be called with the error
          * code MegaError::API_ENOENT.

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2956,7 +2956,7 @@ protected:
         void getcountrycallingcodes_result(error, map<string, vector<string>>*) override;
 
         // get the current PSA
-        void getpsa_result (error, int, string*, string*, string*, string*, string*, string*) override;
+        void getpsa_result (error, int, string*, string*, string*, string*, string*) override;
 
         // account creation
         void sendsignuplink_result(error) override;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -7668,7 +7668,6 @@ bool CommandMultiFactorAuthDisable::procresult(Result r)
 CommandGetPSA::CommandGetPSA(MegaClient *client)
 {
     cmd("gpsa");
-    arg("w", 1);
 
     tag = client->reqtag;
 }
@@ -7677,14 +7676,14 @@ bool CommandGetPSA::procresult(Result r)
 {
     if (r.wasErrorOrOK())
     {
-        client->app->getpsa_result(r.errorOrOK(), 0, NULL, NULL, NULL, NULL, NULL, NULL);
+        client->app->getpsa_result(r.errorOrOK(), 0, NULL, NULL, NULL, NULL, NULL);
         return true;
     }
 
     int id = 0;
     string temp;
     string title, text, imagename, imagepath;
-    string buttonlink, buttontext, url;
+    string buttonlink, buttontext;
 
     for (;;)
     {
@@ -7707,9 +7706,6 @@ bool CommandGetPSA::procresult(Result r)
             case 'l':
                 client->json.storeobject(&buttonlink);
                 break;
-            case MAKENAMEID3('u', 'r', 'l'):
-                client->json.storeobject(&url);
-                break;
             case 'b':
                 client->json.storeobject(&temp);
                 Base64::atob(temp, buttontext);
@@ -7720,13 +7716,13 @@ bool CommandGetPSA::procresult(Result r)
             case EOO:
                 imagepath.append(imagename);
                 imagepath.append(".png");
-                client->app->getpsa_result(API_OK, id, &title, &text, &imagepath, &buttontext, &buttonlink, &url);
+                client->app->getpsa_result(API_OK, id, &title, &text, &imagepath, &buttontext, &buttonlink);
                 return true;
             default:
                 if (!client->json.storeobject())
                 {
                     LOG_err << "Failed to parse get PSA response";
-                    client->app->getpsa_result(API_EINTERNAL, 0, NULL, NULL, NULL, NULL, NULL, NULL);
+                    client->app->getpsa_result(API_EINTERNAL, 0, NULL, NULL, NULL, NULL, NULL);
                     return false;
                 }
                 break;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -15631,7 +15631,7 @@ void MegaApiImpl::keepmealive_result(error e)
     fireOnRequestFinish(request, make_unique<MegaErrorPrivate>(e));
 }
 
-void MegaApiImpl::getpsa_result(error e, int id, string *title, string *text, string *image, string *buttontext, string *buttonlink, std::string *url)
+void MegaApiImpl::getpsa_result(error e, int id, string *title, string *text, string *image, string *buttontext, string *buttonlink)
 {
     if (requestMap.find(client->restag) == requestMap.end())
     {
@@ -15652,7 +15652,6 @@ void MegaApiImpl::getpsa_result(error e, int id, string *title, string *text, st
         request->setFile(image->c_str());
         request->setPassword(buttontext->c_str());
         request->setLink(buttonlink->c_str());
-        request->setEmail(url->c_str());
     }
 
     fireOnRequestFinish(request, make_unique<MegaErrorPrivate>(e));


### PR DESCRIPTION
Reverts meganz/sdk#2258

The feature is not ready in API, so the branch should had not been merged yet in order to avoid interferences with PSA usage in production. 