### PR TITLE
Fix for MegaApiImpl::putnodes_result for a moved versioned node

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -13659,8 +13659,8 @@ void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<
 
     if (!e && t != USER_HANDLE)
     {
-        assert(!nn.empty() && nn.back().added && nn.back().mAddedHandle != UNDEF);
-        n = client->nodebyhandle(nn.back().mAddedHandle);
+        assert(!nn.empty() && nn.front().added && nn.front().mAddedHandle != UNDEF);
+        n = client->nodebyhandle(nn.front().mAddedHandle);
 
         if(n)
         {

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -1687,6 +1687,34 @@ TEST_F(SdkTest, SdkTestTransfers)
     ASSERT_STREQ(filename1.data(), n1->getName()) << "Uploaded file with wrong name (error: " << mApi[0].lastError << ")";
 
 
+    ASSERT_EQ(API_OK, doSetFileVersionsOption(0, false));  // false = not disabled
+
+    // Upload a file over an existing one to make a version
+    {
+        ofstream f(filename1);
+        f << "edited";
+    }
+
+    ASSERT_EQ(API_OK, doStartUpload(0, filename1.c_str(), rootnode));
+
+    // Upload a file over an existing one to make a version
+    {
+        ofstream f(filename1);
+        f << "edited2";
+    }
+
+    ASSERT_EQ(API_OK, doStartUpload(0, filename1.c_str(), rootnode));
+
+    // copy a node with versions to a new name (exercises the multi node putndoes_result)
+    MegaNode* nodeToCopy1 = megaApi[0]->getNodeByPath(("/" + filename1).c_str());
+    ASSERT_EQ(API_OK, doCopyNode(0, nodeToCopy1, rootnode, "some_other_name"));
+
+    // put original filename1 back
+    fs::remove(filename1);
+    createFile(filename1);
+    ASSERT_EQ(API_OK, doStartUpload(0, filename1.c_str(), rootnode));
+    n1 = megaApi[0]->getNodeByPath(("/" + filename1).c_str());
+
     // --- Get node by fingerprint (needs to be a file, not a folder) ---
 
     std::unique_ptr<char[]> fingerprint{megaApi[0]->getFingerprint(n1)};

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -156,11 +156,11 @@ public:
         string pwd;
         int lastError;
         int lastTransferError;
-        
+
         // flags to monitor the completion of requests/transfers
         bool requestFlags[MegaRequest::TOTAL_OF_REQUEST_TYPES];
         bool transferFlags[MegaTransfer::TYPE_LOCAL_HTTP_DOWNLOAD];
-        
+
         std::unique_ptr<MegaContactRequest> cr;
         std::unique_ptr<MegaTimeZoneDetails> tzDetails;
         std::unique_ptr<MegaAccountDetails> accountDetails;
@@ -286,6 +286,10 @@ public:
     template<typename ... requestArgs> int doRequestLogout(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->logout(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int doRequestLocalLogout(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->localLogout(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int doSetNodeDuration(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->setNodeDuration(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doStartUpload(unsigned apiIndex, requestArgs... args) { TransferTracker tt(megaApi[apiIndex].get()); megaApi[apiIndex]->startUpload(args..., &tt); return tt.waitForResult(); }
+    template<typename ... requestArgs> int doSetFileVersionsOption(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->setFileVersionsOption(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doMoveNode(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->moveNode(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doCopyNode(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->copyNode(args..., &rt); return rt.waitForResult(); }
 
     void createFile(string filename, bool largeFile = true);
     int64_t getFilesize(string filename);


### PR DESCRIPTION
The copy code copies the versions so there are multiple nodes in the array
and the main node is the first one, not the last one.
Almost all operations that use putnodes_result only affect one node.