### PR TITLE
Update to new ffmpeg api

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -7936,13 +7936,12 @@ bool CommandGetCountryCallingCodes::procresult(Result r)
 
     map<string, vector<string>> countryCallingCodes;
 
-    string countryCode;
-    vector<string> callingCodes;
-
     bool success = true;
     while (client->json.enterobject())
     {
         bool exit = false;
+        string countryCode;
+        vector<string> callingCodes;
         while (!exit)
         {
             switch (client->json.getnameid())

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -566,8 +566,11 @@ bool CommandDirectRead::procresult(Result r)
                     }
                     if (tempurls.size() == 1 || tempurls.size() == RAIDPARTS)
                     {
-                        drn->tempurls.swap(tempurls);
-                        e.setErrorCode(API_OK);
+                        if (drn)
+                        {
+                            drn->tempurls.swap(tempurls);
+                            e.setErrorCode(API_OK);
+                        }
                     }
                     else
                     {

--- a/src/gfx/freeimage.cpp
+++ b/src/gfx/freeimage.cpp
@@ -95,7 +95,7 @@ const char *GfxProcFreeImage::supportedformatsFfmpeg()
             ".qt.sls.tmf.trp.ts.ty.vc1.vob.vr.webm.wmv.";
 }
 
-bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int size)
+bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* /*fa*/, string* imagePath, int /*size*/)
 {
 #ifndef DEBUG
     av_log_set_level(AV_LOG_PANIC);
@@ -357,12 +357,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
                     w = FreeImage_GetWidth(dib);
                     h = FreeImage_GetHeight(dib);
 
-                    if (!w || !h)
-                    {
-                        return false;
-                    }
-
-                    return true;
+                    return w > 0 && h > 0;
                 }
            }
 
@@ -389,7 +384,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
 
 const char* GfxProcFreeImage::supportedformats()
 {
-    if (!sformats.size())
+    if (sformats.empty())
     {
         sformats+=".jpg.png.bmp.tif.tiff.jpeg.cut.dds.exr.g3.gif.hdr.ico.iff.ilbm"
            ".jbig.jng.jif.koala.pcd.mng.pcx.pbm.pgm.ppm.pfm.pict.pic.pct.pds.raw.3fr.ari"
@@ -483,18 +478,11 @@ bool GfxProcFreeImage::readbitmap(FileAccess* fa, string* localname, int size)
     w = FreeImage_GetWidth(dib);
     h = FreeImage_GetHeight(dib);
 
-    if (!w || !h)
-    {
 #ifdef _WIN32
             localname->resize(localname->size()-1);
 #endif
-        return false;
-    }
 
-#ifdef _WIN32
-            localname->resize(localname->size()-1);
-#endif
-    return true;
+    return w > 0 && h > 0;
 }
 
 bool GfxProcFreeImage::resizebitmap(int rw, int rh, string* jpegout)
@@ -556,7 +544,7 @@ bool GfxProcFreeImage::resizebitmap(int rw, int rh, string* jpegout)
         }
     }
 
-    return !!jpegout->size();
+    return !jpegout->empty();
 }
 
 void GfxProcFreeImage::freebitmap()

--- a/src/gfx/freeimage.cpp
+++ b/src/gfx/freeimage.cpp
@@ -114,7 +114,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
     if (avformat_open_input(&formatContext, imagePath->data(), NULL, NULL))
     {
         LOG_warn << "Error opening video: " << imagePath;
-        return NULL;
+        return false;
     }
 
     // Get stream information
@@ -122,7 +122,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
     {
         LOG_warn << "Stream info not found: " << imagePath;
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     // Find first video stream type
@@ -142,7 +142,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
     {
         LOG_warn << "Video stream not found: " << imagePath;
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     // Get codec context to determine video frame dimensions
@@ -153,14 +153,14 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
     {
         LOG_warn << "Invalid video dimensions: " << width << ", " << height;
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     if (codecContext.pix_fmt == AV_PIX_FMT_NONE)
     {
         LOG_warn << "Invalid pixel format: " << codecContext.pix_fmt;
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     AVPixelFormat sourcePixelFormat = codecContext.pix_fmt;
@@ -172,7 +172,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
     {
         LOG_warn << "SWS Context not found: " << sourcePixelFormat;
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     // Find decoder for video stream
@@ -183,7 +183,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
         LOG_warn << "Codec not found: " << codecId;
         sws_freeContext(swsContext);
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     // Force seeking to key frames
@@ -200,7 +200,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
         LOG_warn << "Error opening codec: " << codecId;
         sws_freeContext(swsContext);
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     //Allocate video frames
@@ -219,7 +219,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
         }
         sws_freeContext(swsContext);
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     targetFrame->format = targetPixelFormat;
@@ -233,7 +233,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
         avcodec_close(&codecContext);
         sws_freeContext(swsContext);
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     // Calculation of seeking point. We need to rescale time units (seconds) to AVStream.time_base units to perform the seeking
@@ -263,7 +263,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
         avcodec_close(&codecContext);
         sws_freeContext(swsContext);
         avformat_close_input(&formatContext);
-        return NULL;
+        return false;
     }
 
     AVPacket packet;
@@ -294,7 +294,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
                     av_frame_free(&targetFrame);
                     sws_freeContext(swsContext);
                     avformat_close_input(&formatContext);
-                    return NULL;
+                    return false;
                 }
 
                 scalingResult = sws_scale(swsContext, videoFrame->data, videoFrame->linesize,
@@ -319,7 +319,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
                         sws_freeContext(swsContext);
                         avformat_close_input(&formatContext);
                         free (fmemory.data);
-                        return NULL;
+                        return false;
                     }
 
                     //int pitch = imagesize/height;
@@ -375,7 +375,7 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
     av_frame_free(&targetFrame);
     sws_freeContext(swsContext);
     avformat_close_input(&formatContext);
-    return NULL;
+    return false;
 }
 
 #endif

--- a/src/gfx/freeimage.cpp
+++ b/src/gfx/freeimage.cpp
@@ -163,25 +163,12 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
         return false;
     }
 
-    AVPixelFormat sourcePixelFormat = codecContext.pix_fmt;
-    AVPixelFormat targetPixelFormat = AV_PIX_FMT_BGR24; //raw data expected by freeimage is in this format
-    SwsContext* swsContext = sws_getContext(width, height, sourcePixelFormat,
-                                            width, height, targetPixelFormat,
-                                            SWS_FAST_BILINEAR, NULL, NULL, NULL);
-    if (!swsContext)
-    {
-        LOG_warn << "SWS Context not found: " << sourcePixelFormat;
-        avformat_close_input(&formatContext);
-        return false;
-    }
-
     // Find decoder for video stream
     AVCodecID codecId = codecContext.codec_id;
     AVCodec* decoder = avcodec_find_decoder(codecId);
     if (!decoder)
     {
         LOG_warn << "Codec not found: " << codecId;
-        sws_freeContext(swsContext);
         avformat_close_input(&formatContext);
         return false;
     }
@@ -192,6 +179,18 @@ bool GfxProcFreeImage::readbitmapFfmpeg(FileAccess* fa, string* imagePath, int s
     if (decoder->capabilities & CAP_TRUNCATED)
     {
         codecContext.flags |= CAP_TRUNCATED;
+    }
+
+    AVPixelFormat sourcePixelFormat = codecContext.pix_fmt;
+    AVPixelFormat targetPixelFormat = AV_PIX_FMT_BGR24; //raw data expected by freeimage is in this format
+    SwsContext* swsContext = sws_getContext(width, height, sourcePixelFormat,
+                                            width, height, targetPixelFormat,
+                                            SWS_FAST_BILINEAR, NULL, NULL, NULL);
+    if (!swsContext)
+    {
+        LOG_warn << "SWS Context not found: " << sourcePixelFormat;
+        avformat_close_input(&formatContext);
+        return false;
     }
 
     // Open codec


### PR DESCRIPTION
This is a patch that updates to the new ffmpeg API to avoid a bunch of "deprecated" functions warnings.

Also fixes some nullptr deref and use after move.