### PR TITLE
WIP: SNC-1840. Investigate whether we can know about Metered Connections on windows

### DIFF
--- a/src/raid.cpp
+++ b/src/raid.cpp
@@ -250,6 +250,30 @@ bool RaidBufferManager::isRaidConnectionProgressBlocked(unsigned connectionNum) 
 }
 
 
+class ConnectionInfo
+{
+public:
+    // Return true if system-wide cost restrictions are enabled.
+    bool isSystemRestricted() const;
+
+    // Start listening for system-wide cost change events.
+    // f, user function to be executed when a cost change has occured. Its argument will
+    //    be `true` when the system has become restricted, and `false` when unrestricted.
+    //
+    // Return true if there were no errors, and if it was not already called earlier.
+    bool bindSystemEvents(std::function<void(bool)> f);
+
+    // Stop listening for cost change events.
+    //
+    // Return true if there were no errors stopping it (i.e. listening for events was succesfully started).
+    bool unbindSystemEvents();
+
+    // Return true if there are cost restrictions for the given url
+    // This is a bonus feature, it reuses isSystemRestricted(), and adds only little extra code.
+    bool isDestinationRestricted(const std::string& url) const;
+};
+
+
 const std::string& RaidBufferManager::tempURL(unsigned connectionNum)
 {
     if (isRaid())

--- a/src/raid.cpp
+++ b/src/raid.cpp
@@ -791,11 +791,37 @@ bool ConnectionInfo::initCom()
 
 
 
+
+
+
+
+ConnectionInfo ci;
+
+
 const std::string& RaidBufferManager::tempURL(unsigned connectionNum)
 {
     if (isRaid())
     {
         assert(connectionNum < tempurls.size());
+
+        auto f = [](bool restricted) { LOG_info << "CONN_COST, S-W event: system-wide restricted is now: " << restricted; };
+
+        ci.bindSystemEvents(f);
+
+        // quickly unbind, to make sure it works fine even if the thread does not have a message queue yet
+        ci.unbindSystemEvents();
+
+        // bind again, to really test cost changes
+        ci.bindSystemEvents(f);
+
+        const string& url = tempurls[connectionNum];
+        bool restrictedDest = ci.isDestinationRestricted(url);
+        bool restrictedSys = ci.isSystemRestricted();
+
+        LOG_info << "CONN_COST: url:\n\t" << url;
+        LOG_info << "CONN_COST: url restricted: " << restrictedDest;
+        LOG_info << "CONN_COST: system-wide restricted: " << restrictedSys;
+
         return tempurls[connectionNum];
     }
     else if (!tempurls.empty())


### PR DESCRIPTION
This PR is only meant for review, and finding out what should still be changed (functionally, names, etc.).
Eventually, the new code should be moved to a different location -- this needs to be determined.


Steps to test catching dynamic cost/restriction changes, on Windows:
* Start MegaSync and start a download;
* in Windows (10), open `Settings`, go to `Wi-Fi` settings, click on the currently connected network, scroll down to `Metered connection`. Turn that on and off a few times.
* Open the log file, and search for `CONN_COST, S-W event: system-wide restricted is now: `