### PR TITLE
SDK-1248 - Customize Sync algorithm for up-only Backup Syncs

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -124,14 +124,15 @@ struct NewSyncConfig
     SyncConfig::Type type = SyncConfig::Type::TYPE_TWOWAY;
     bool syncDeletions = true;
     bool forceOverwrite = false;
+    bool isExternal = false;
 
     static NewSyncConfig from(const SyncConfig& config)
     {
-        return NewSyncConfig{config.getType(), config.syncDeletions(), config.forceOverwrite()};
+        return NewSyncConfig{config.getType(), config.syncDeletions(), config.forceOverwrite(), config.isExternal()};
     }
 
-    NewSyncConfig(SyncConfig::Type t = SyncConfig::TYPE_TWOWAY, bool s = true, bool f = false)
-        : type(t), syncDeletions(s), forceOverwrite(f)
+    NewSyncConfig(SyncConfig::Type t = SyncConfig::TYPE_TWOWAY, bool s = true, bool f = false, bool x = false)
+        : type(t), syncDeletions(s), forceOverwrite(f), isExternal(x)
     {}
 };
 
@@ -153,6 +154,12 @@ static std::string syncConfigToString(const SyncConfig& config)
     {
         description = "TWOWAY";
     }
+    else if (config.getType() == SyncConfig::TYPE_BACKUP)
+    {
+        description = "BACKUP";
+        description += ", isExternal ";
+        description += config.isExternal() ? "ON" : "OFF";
+    }
     else if (config.getType() == SyncConfig::TYPE_UP)
     {
         description = "UP";
@@ -168,7 +175,7 @@ static std::string syncConfigToString(const SyncConfig& config)
 
 // creates a NewSyncConfig object from config options as strings.
 // returns a pair where `first` is success and `second` is the sync config.
-static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::string syncDel = {}, std::string overwrite = {})
+static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::string syncDel = {}, std::string overwrite = {}, std::string external = {})
 {
     static int syncTag = 13217;
     auto toLower = [](std::string& s)
@@ -179,6 +186,7 @@ static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::
     toLower(type);
     toLower(syncDel);
     toLower(overwrite);
+    toLower(external);
 
     SyncConfig::Type syncType;
     if (type == "up")
@@ -193,6 +201,10 @@ static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::
     {
         syncType = SyncConfig::TYPE_TWOWAY;
     }
+    else if (type == "backup")
+    {
+        syncType = SyncConfig::TYPE_BACKUP;
+    }
     else
     {
         return std::make_pair(false, SyncConfig(syncTag++, "", "", UNDEF, "", 0));
@@ -200,6 +212,7 @@ static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::
 
     bool syncDeletions = false;
     bool forceOverwrite = false;
+    bool isExternal = false;
 
     if (syncType != SyncConfig::TYPE_TWOWAY)
     {
@@ -228,13 +241,29 @@ static std::pair<bool, SyncConfig> syncConfigFromStrings(std::string type, std::
         {
             return std::make_pair(false, SyncConfig(syncTag++, "", "", UNDEF, "", 0));
         }
+
+        if (external == "on")
+        {
+            isExternal = true;
+        }
+        else if (external == "off")
+        {
+            isExternal = false;
+        }
+        else
+        {
+            return std::make_pair(false, SyncConfig(syncTag++, "", "", UNDEF, "", 0));
+        }
     }
 
-    return std::make_pair(true, SyncConfig(syncTag++, "", "", UNDEF, "", 0, {}, true, syncType, syncDeletions, forceOverwrite));
+    auto config = SyncConfig(syncTag++, "", "", UNDEF, "", 0, {}, true, syncType, syncDeletions, forceOverwrite);
+    config.isExternal(isExternal);
+
+    return std::make_pair(true, std::move(config));
 }
 
 // sync configuration used when creating a new sync
-static SyncConfig newSyncConfig = syncConfigFromStrings("twoway", "off", "off").second;
+static SyncConfig newSyncConfig = syncConfigFromStrings("twoway", "off", "off", "off").second;
 
 #endif
 
@@ -3050,7 +3079,7 @@ autocomplete::ACN autocompleteSyntax()
     p->Add(exec_du, sequence(text("du"), remoteFSPath(client, &cwd)));
 #ifdef ENABLE_SYNC
     p->Add(exec_sync, sequence(text("sync"), opt(either(sequence(localFSPath(), remoteFSPath(client, &cwd, "dst")), param("cancelslot")))));
-    p->Add(exec_syncconfig, sequence(text("syncconfig"), opt(sequence(param("type (TWOWAY/UP/DOWN)"), opt(sequence(param("syncDeletions (ON/OFF)"), param("forceOverwrite (ON/OFF)")))))));
+    p->Add(exec_syncconfig, sequence(text("syncconfig"), opt(sequence(param("type (TWOWAY/UP/DOWN/BACKUP)"), opt(sequence(param("syncDeletions (ON/OFF)"), param("forceOverwrite (ON/OFF)"), param("isExternal (ON/OFF)")))))));
 #endif
     p->Add(exec_export, sequence(text("export"), remoteFSPath(client, &cwd), opt(either(flag("-writable"), param("expiretime"), text("del")))));
     p->Add(exec_share, sequence(text("share"), opt(sequence(remoteFSPath(client, &cwd), opt(sequence(contactEmail(client), opt(either(text("r"), text("rw"), text("full"))), opt(param("origemail"))))))));
@@ -4441,11 +4470,12 @@ void exec_syncconfig(autocomplete::ACState& s)
     {
         cout << "Current sync config: " << syncConfigToString(newSyncConfig) << endl;
     }
-    else if (s.words.size() == 2 || s.words.size() == 4)
+    else if (s.words.size() == 2 || s.words.size() == 5)
     {
         auto pair = syncConfigFromStrings(s.words[1].s,
                 (s.words.size() > 2 ? s.words[2].s : "off"),
-                (s.words.size() > 3 ? s.words[3].s : "off"));
+                (s.words.size() > 3 ? s.words[3].s : "off"),
+                (s.words.size() > 4 ? s.words[4].s : "off"));
 
         if (pair.first)
         {

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -422,6 +422,8 @@ public:
 
     DirNotify(const LocalPath&, const LocalPath&);
     virtual ~DirNotify() {}
+
+    bool empty();
 };
 
 // generic host filesystem access interface

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -214,6 +214,19 @@ public:
 
 std::ostream& operator<<(std::ostream &os, const SCSN &scsn);
 
+class SyncdownContext
+{
+public:
+    SyncdownContext()
+      : mActionsPerformed(false)
+      , mRubbish(false)
+    {
+    }
+
+    bool mActionsPerformed;
+    bool mRubbish;
+}; // SyncdownContext
+
 class MEGA_API MegaClient
 {
 public:
@@ -1487,6 +1500,7 @@ public:
     void putnodes_sync_result(error, vector<NewNode>&);
 
     // start downloading/copy missing files, create missing directories
+    bool syncdown(LocalNode*, LocalPath&, SyncdownContext& cxt);
     bool syncdown(LocalNode*, LocalPath&, bool);
 
     // move nodes to //bin/SyncDebris/yyyy-mm-dd/ or unlink directly

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -219,12 +219,10 @@ class SyncdownContext
 public:
     SyncdownContext()
       : mActionsPerformed(false)
-      , mRubbish(false)
     {
     }
 
     bool mActionsPerformed;
-    bool mRubbish;
 }; // SyncdownContext
 
 class MEGA_API MegaClient
@@ -1501,7 +1499,7 @@ public:
 
     // start downloading/copy missing files, create missing directories
     bool syncdown(LocalNode*, LocalPath&, SyncdownContext& cxt);
-    bool syncdown(LocalNode*, LocalPath&, bool);
+    bool syncdown(LocalNode*, LocalPath&);
 
     // move nodes to //bin/SyncDebris/yyyy-mm-dd/ or unlink directly
     void movetosyncdebris(Node*, bool);

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -264,6 +264,10 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     Node(MegaClient*, vector<Node*>*, handle, handle, nodetype_t, m_off_t, handle, const char*, m_time_t);
     ~Node();
 
+#ifdef ENABLE_SYNC
+    void detach(const bool recreate = false);
+#endif // ENABLE_SYNC
+
 private:
     // full folder/file key, symmetrically or asymmetrically encrypted
     // node crypto keys (raw or cooked -
@@ -400,6 +404,8 @@ struct MEGA_API LocalNode : public File
     static LocalNode* unserialize( Sync* sync, const string* sData );
 
     ~LocalNode();
+
+    void detach(const bool recreate = false);
 };
 
 template <> inline NewNode*& crossref_other_ptr_ref<LocalNode, NewNode>(LocalNode* p) { return p->newnode.ptr; }

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -203,11 +203,28 @@ public:
     static const int FILE_UPDATE_MAX_DELAY_SECS;
     static const dstime RECENT_VERSION_INTERVAL_SECS;
 
-protected :
+    // Change state to (DISABLED, BACKUP_MODIFIED).
+    // Always returns false.
+    bool backupModified();
+
+    // Whether this is a backup sync.
+    bool isBackup() const;
+
+    // Whether this is a backup sync and it is mirroring.
+    bool isMirroring() const;
+
+    // Whether this is a backup sync and it is monitoring.
+    bool isMonitoring() const;
+
+    // Move the sync into the monitoring state.
+    void monitor();
+
+protected:
     bool readstatecache();
 
 private:
     std::string mLocalPath;
+    SyncBackupState mBackupState;
 };
 } // namespace
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -334,6 +334,17 @@ typedef enum {
     SYNC_ACTIVE
 } syncstate_t;
 
+typedef enum
+{
+    // Sync is not operating in a backup capacity.
+    SYNC_BACKUP_NONE = 0,
+    // Sync is mirroring the local source.
+    SYNC_BACKUP_MIRROR = 1,
+    // Sync is monitoring (and propagating) local changes.
+    SYNC_BACKUP_MONITOR = 2
+}
+SyncBackupState;
+
 enum SyncError {
     NO_SYNC_ERROR = 0,
     UNKNOWN_ERROR = 1,

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -973,6 +973,10 @@ public:
     handle getBackupId() const;
     void setBackupId(const handle &backupId);
 
+    // Whether this sync is backed by an external device.
+    void isExternal(bool isExternal);
+    bool isExternal() const;
+
 private:
 
     // Unique identifier. any other field can change (even remote handle),
@@ -981,6 +985,9 @@ private:
 
     // enabled/disabled by the user
     bool mEnabled = true;
+
+    // sync stored on external device.
+    bool mExternal = false;
 
     // the local path of the sync
     std::string mLocalPath;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -364,6 +364,7 @@ enum SyncError {
     UNKNOWN_TEMPORARY_ERROR = 26,           // Unknown temporary error
     TOO_MANY_ACTION_PACKETS = 27,           // Too many changes in account, local state discarded
     LOGGED_OUT = 28,                        // Logged out
+    BACKUP_MODIFIED = 29                    // Backup has been externally modified.
 };
 
 inline bool isSyncErrorPermanent(SyncError e)

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -876,6 +876,7 @@ public:
         TYPE_UP = 0x01, // sync up from local to remote
         TYPE_DOWN = 0x02, // sync down from remote to local
         TYPE_TWOWAY = TYPE_UP | TYPE_DOWN, // Two-way sync
+        TYPE_BACKUP = 0x04
     };
 
     SyncConfig(int tag,

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -598,7 +598,7 @@ public:
         return mNotifications.empty();
     }
 
-    bool size()
+    size_t size()
     {
         std::lock_guard<std::mutex> g(m);
         return mNotifications.size();

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -295,6 +295,19 @@ int DirNotify::getFailed(string& reason)
 }
 
 
+bool DirNotify::empty()
+{
+    for (auto& q : notifyq)
+    {
+        if (!q.empty())
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // notify base LocalNode + relative path/filename
 void DirNotify::notify(notifyqueue q, LocalNode* l, LocalPath&& path, bool immediate)
 {

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -3003,7 +3003,7 @@ void MegaClient::exec()
                             if (sync->state == SYNC_ACTIVE || sync->state == SYNC_INITIALSCAN)
                             {
                                 LOG_debug << "Running syncdown on demand";
-                                if (!syncdown(sync->localroot.get(), localpath, true))
+                                if (!syncdown(sync->localroot.get(), localpath))
                                 {
                                     // a local filesystem item was locked - schedule periodic retry
                                     // and force a full rescan afterwards as the local item may
@@ -13273,12 +13273,11 @@ void MegaClient::addchild(remotenode_map* nchildren, string* name, Node* n, list
 // * attempt to execute renames, moves and deletions (deletions require the
 // rubbish flag to be set)
 // returns false if any local fs op failed transiently
-bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
+bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath)
 {
     SyncdownContext cxt;
 
     cxt.mActionsPerformed = false;
-    cxt.mRubbish = rubbish;
 
     if (!syncdown(l, localpath, cxt))
     {
@@ -13461,7 +13460,7 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, SyncdownContext& c
 
             lit++;
         }
-        else if (cxt.mRubbish && ll->deleted)    // no corresponding remote node: delete local item
+        else if (ll->deleted)    // no corresponding remote node: delete local item
         {
             if (ll->type == FILENODE)
             {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -211,6 +211,18 @@ Node::~Node()
 #endif
 }
 
+#ifdef ENABLE_SYNC
+
+void Node::detach(const bool recreate)
+{
+    if (localnode)
+    {
+        localnode->detach(recreate);
+    }
+}
+
+#endif // ENABLE_SYNC
+
 void Node::setkeyfromjson(const char* k)
 {
     if (keyApplied()) --client->mAppliedKeyNodeCount;
@@ -1640,6 +1652,19 @@ LocalNode::~LocalNode()
     }
 
     slocalname.reset();
+}
+
+void LocalNode::detach(const bool recreate)
+{
+    // Never detach the sync root.
+    if (parent && node)
+    {
+        node->localnode = nullptr;
+        node->tag = sync->tag;
+        node = nullptr;
+
+        created &= !recreate;
+    }
 }
 
 LocalPath LocalNode::getLocalPath() const

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -666,15 +666,9 @@ Sync::Sync(MegaClient* cclient, SyncConfig &config, const char* cdebris,
     mLocalPath = config.getLocalPath();
     LocalPath crootpath = LocalPath::fromPath(mLocalPath, *client->fsaccess);
 
-    //// dgw: TODO: Use SyncConfig when available.
-    //bool isBackup = false;
-
-    //isBackup |= mLocalPath.find("cls0") != mLocalPath.npos;
-    //isBackup |= mLocalPath.find("synca") != mLocalPath.npos;
-
     mBackupState = config.getType() == SyncConfig::TYPE_BACKUP  
-               ? SYNC_BACKUP_MIRROR
-               : SYNC_BACKUP_NONE;
+                   ? SYNC_BACKUP_MIRROR
+                   : SYNC_BACKUP_NONE;
 
     if (cdebris)
     {

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -666,14 +666,14 @@ Sync::Sync(MegaClient* cclient, SyncConfig &config, const char* cdebris,
     mLocalPath = config.getLocalPath();
     LocalPath crootpath = LocalPath::fromPath(mLocalPath, *client->fsaccess);
 
-    // dgw: TODO: Use SyncConfig when available.
-    bool isBackup = false;
+    //// dgw: TODO: Use SyncConfig when available.
+    //bool isBackup = false;
 
-    isBackup |= mLocalPath.find("cls0") != mLocalPath.npos;
-    isBackup |= mLocalPath.find("synca") != mLocalPath.npos;
+    //isBackup |= mLocalPath.find("cls0") != mLocalPath.npos;
+    //isBackup |= mLocalPath.find("synca") != mLocalPath.npos;
 
-    mBackupState =
-      isBackup ? SYNC_BACKUP_MIRROR
+    mBackupState = config.getType() == SyncConfig::TYPE_BACKUP  
+               ? SYNC_BACKUP_MIRROR
                : SYNC_BACKUP_NONE;
 
     if (cdebris)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2249,6 +2249,7 @@ SyncConfig::SyncConfig(int tag,
                        const SyncError error, mega::handle hearBeatID)
     : mTag{tag}
     , mEnabled{enabled}
+    , mExternal{false}
     , mLocalPath{std::move(localPath)}
     , mName{std::move(name)}
     , mRemoteNode{remoteNode}
@@ -2290,11 +2291,21 @@ bool SyncConfig::isEnabled(syncstate_t state, SyncError syncError)
 
 bool SyncConfig::isResumable() const
 {
+    if (mExternal && mSyncType == TYPE_BACKUP)
+    {
+        return false;
+    }
+
     return mEnabled && !isSyncErrorPermanent(mError);
 }
 
 bool SyncConfig::isResumableAtStartup() const
 {
+    if (mExternal && mSyncType == TYPE_BACKUP)
+    {
+        return false;
+    }
+
     return mEnabled && (!isAnError(mError)
                         || mError == LOGGED_OUT
                         || mError == UNKNOWN_TEMPORARY_ERROR
@@ -2408,6 +2419,16 @@ handle SyncConfig::getBackupId() const
 void SyncConfig::setBackupId(const handle &backupId)
 {
     mBackupId = backupId;
+}
+
+void SyncConfig::isExternal(bool isExternal)
+{
+    mExternal = isExternal;
+}
+
+bool SyncConfig::isExternal() const
+{
+    return mExternal;
 }
 
 // This should be a const-method but can't be due to the broken Cacheable interface.

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -5311,7 +5311,7 @@ TEST(Sync, TwoWay_Highlevel_Symmetries)
     static string singleNamedTest = ""; // to investigate just one sync case, put its name here, otherwise we loop.
 
     
-    for (int syncType = TwoWaySyncSymmetryCase::type_numTypes; --syncType; )
+    for (int syncType = TwoWaySyncSymmetryCase::type_numTypes; syncType--; )
     {
         //if (syncType != TwoWaySyncSymmetryCase::type_backupSync) continue;
 


### PR DESCRIPTION
This ticket adds basic support for backup syncing.

The major changes are:

Syncdown has been altered such that remote changes are not applied locally. Instead, remote change are "undone" such that the remote matches what appears on the local disk.

The sync has a new member, mBackupState, that records whether the sync is operating in a backup capacity and if so, what state it is in. Three states are defined: NONE, MIRROR and MONITOR.

NONE specifies that the sync is not a backup sync.

MIRROR specifies that this is a backup sync and that it has not yet completed its first full sync down. The idea here is that the first sync down is special and serves to bring the remote backup target into alignment with the local disk. Once the SDK is satisfied that this is the case, the sync moves into the MONITOR state.

Remote changes in the MIRROR state do not signal an error. Instead, they are effectively undone. Remote deletions, for instance, will not cause the linked local node to be deleted. The local nodes that would've been deleted are re-uploaded instead.

MONITOR specifies that this is a backup sync and that the first full syncdown has completed. That is, the SDK is satisfied that the remote target mirrors the local disk and that all it has to do from here on out, is to propagate local changes to the cloud.

Remote changes detected in this state will cause the SDK to disable the sync with the BACKUP_MODIFIED error. This is to prevent multiple applications from modifying the remote backup.

BACKUP_MODIFIED is currently considered a 'permanent error.'

The rationale for this is simple: We don't want the SDK to resume the sync and possibly erase user data until we know for sure that's what they want us to do.