### PR TITLE
SDK-1253. Upper size limit not working properly when copying files

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13657,6 +13657,26 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds, size_t& parentPending)
             continue;
         }
 
+        // Make sure the local node is actually included.
+        {
+            LocalPath localPath = ll->getLocalPath();
+
+            if (!app->sync_syncable(ll->sync, localname.c_str(), localPath))
+            {
+                // As a precaution against remote changes.
+                if (ll->node)
+                {
+                    ll->node->localnode = nullptr;
+                    ll->node->tag = ll->sync->tag;
+                    ll->node = nullptr;
+
+                    ll->sync->statecacheadd(ll);
+                }
+
+                continue;
+            }
+        }
+
         rit = nchildren.find(&localname);
 
         bool isSymLink = false;


### PR DESCRIPTION
syncup now checks while pairing that a given node is actually included.

This is necessary as it's possible for a local node to be created for a file when it should otherwise not be.

An example of how this can occur is when we copy a large file into a synced directory with a filesize filter applied.
The SDK becomes aware of the file while the copy is in progress and as such, filters based on the file's current (growing) size.

One fix that was considered was to make the system wait until the file's size had stabilized before checking whether it passed any size filters. This, however, was deemed too expensive given how often we scan files.

The current design has the expectation that excluded nodes never exist in memory.
This is why syncup, previously, did not check whether a given node passed configured filters.

Nodes excluded in this way will remain in memory until the user restarts the application.