### PR TITLE
SDK-1267. Fix target for movements

### DIFF
--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19366,7 +19366,8 @@ void MegaApiImpl::sendPendingRequests()
                                 // continue to complete the copy-delete
                                 client->restag = request->getTag();
                                 vector<NewNode> emptyVec;
-                                putnodes_result(API_OK, NODE_HANDLE, emptyVec);
+                                targettype_t target = client->isForeignNode(newParent->nodehandle) ? USER_HANDLE : NODE_HANDLE;
+                                putnodes_result(API_OK, target, emptyVec);
                                 break;
                             }
 

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -19362,13 +19362,9 @@ void MegaApiImpl::sendPendingRequests()
                         {
                             if (node->isvalid && ovn->isvalid && *(FileFingerprint*)node == *(FileFingerprint*)ovn)
                             {
-                                e = API_OK; // there is already an identical node in the target folder
-                                // continue to complete the copy-delete
-                                client->restag = request->getTag();
-                                vector<NewNode> emptyVec;
-                                targettype_t target = client->isForeignNode(newParent->nodehandle) ? USER_HANDLE : NODE_HANDLE;
-                                putnodes_result(API_OK, target, emptyVec);
-                                break;
+                                request->setNodeHandle(UNDEF);
+                                e = client->unlink(node, false, request->getTag());
+                                break;  // request finishes now if error, otherwise on unlink_result
                             }
 
                             if (!client->versions_disabled)


### PR DESCRIPTION
When node is moved from cloud to inshare, and the file already exists at the target inshare's folder, the `putnodes_result()` is called directly from MegaApi, but the target is wrong. This commit considers the use case.