### PR TITLE
SDK-1273. Keep subtransfer resumption after exit/locallogout

### DIFF
--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -760,11 +760,16 @@ class MegaTransferPrivate : public MegaTransfer, public Cacheable
         long long getPlaceInQueue() const;
         void setPlaceInQueue(long long value);
 
+        void setDoNotStopSubTransfers(bool doNotStopSubTransfers);
+        bool getDoNotStopSubTransfers() const;
+
 protected:
         int type;
         int tag;
         int state;
         uint64_t priority;
+
+        bool mDoNotStopSubTransfers = false;
 
         struct
         {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -2850,6 +2850,16 @@ void MegaTransferPrivate::setPlaceInQueue(long long value)
     placeInQueue = value;
 }
 
+void MegaTransferPrivate::setDoNotStopSubTransfers(bool doNotStopSubTransfers)
+{
+    mDoNotStopSubTransfers = doNotStopSubTransfers;
+}
+
+bool MegaTransferPrivate::getDoNotStopSubTransfers() const
+{
+    return mDoNotStopSubTransfers;
+}
+
 void MegaTransferPrivate::setPath(const char* path)
 {
     if(this->path) delete [] this->path;
@@ -7568,6 +7578,9 @@ void MegaApiImpl::abortPendingActions(error preverror)
         {
             auto transfer = transferMap.begin()->second;
             transfer->setState(MegaTransfer::STATE_FAILED);
+
+            transfer->setDoNotStopSubTransfers(true); //so as not to remove subtransfer from cache
+
             // this call can be recursive and remove multiple, eg with MegaFolderUploadController
             fireOnTransferFinish(transfer, make_unique<MegaErrorPrivate>(preverror), committer);
         }
@@ -26645,6 +26658,7 @@ void MegaFolderDownloadController::cancel()
         subTransfer->setLastError(&megaError);
 
         bool found = false;
+        bool fireSubTransferFinish = false;
         file_list files = transfer->files;
         file_list::iterator iterator = files.begin();
         while (iterator != files.end())
@@ -26656,7 +26670,16 @@ void MegaFolderDownloadController::cancel()
                 found = true;
                 if (!file->syncxfer)
                 {
-                    client->stopxfer(file, committer);
+                    if (!this->transfer->getDoNotStopSubTransfers())
+                    {
+                        client->stopxfer(file, committer);
+                    }
+                    else
+                    {
+                        //firing onTransferFinished without stopping (to preserve cache)
+                        subTransfer->setState(MegaTransfer::STATE_FAILED);
+                        fireSubTransferFinish = true;
+                    }
                 }
                 else
                 {
@@ -26672,8 +26695,14 @@ void MegaFolderDownloadController::cancel()
             LOG_warn << "No file found for subtransfer: " << subTransfer->getFileName();
 
             subTransfer->setState(MegaTransfer::STATE_CANCELLED);
+            fireSubTransferFinish = true;
+        }
+
+        if (fireSubTransferFinish)
+        {
             megaApi->fireOnTransferFinish(subTransfer, make_unique<MegaErrorPrivate>(API_EINCOMPLETE), *committer);
         }
+
         cancelledSubTransfers++;
     }
 


### PR DESCRIPTION
avoid stopping subtransfers when aborting actions.
that entailed the removal of subtransfers from cache.
abortactions will now only cause a fireOnTransferFinish and its
consequent deletion of the MegaTransferPrivate object, keeping the cache
& temporary files untouched.