### PR TITLE
SDK-1208. Adjustments for reducing sent data in sphb for syncs

### DIFF
--- a/include/mega/command.h
+++ b/include/mega/command.h
@@ -1349,7 +1349,7 @@ class MEGA_API CommandBackupPutHeartBeat : public Command
 public:
     bool procresult(Result) override;
 
-    CommandBackupPutHeartBeat(MegaClient* client, handle backupId, uint8_t status, uint8_t progress, uint32_t uploads, uint32_t downloads, m_time_t ts, handle lastNode);
+    CommandBackupPutHeartBeat(MegaClient* client, handle backupId, uint8_t status, int8_t progress, uint32_t uploads, uint32_t downloads, m_time_t ts, handle lastNode);
 };
 
 class MEGA_API CommandGetBanners : public Command

--- a/include/mega/heartbeats.h
+++ b/include/mega/heartbeats.h
@@ -49,6 +49,7 @@ public:
     virtual int status() const;
 
     virtual double progress() const;
+    virtual void invalidateProgress();
 
     virtual uint32_t pendingUps() const;
 
@@ -79,14 +80,16 @@ protected:
 
     int mStatus = 0;
     double mProgress = 0;
+    bool mProgressInvalid = true;
+
 
     uint32_t mPendingUps = 0;
     uint32_t mPendingDowns = 0;
 
     mega::MegaHandle mLastItemUpdated = INVALID_HANDLE; // handle of node most recently updated
 
-    m_time_t mLastAction = 0;   //timestamps of the last action
-    m_time_t mLastBeat = 0;     //timestamps of the last beat
+    m_time_t mLastAction = -1;   //timestamps of the last action
+    m_time_t mLastBeat = -1;     //timestamps of the last beat
 
     Command *mRunningCommand = nullptr;
 
@@ -239,8 +242,6 @@ private:
 
     mega::MegaClient *mClient = nullptr;
     std::deque<std::function<void(handle)>> mPendingBackupPutCallbacks; // Callbacks to be executed when backupId received after a registering "sp"
-
-    m_time_t mLastBeat = 0;
 
     void updateBackupInfo(const MegaBackupInfo &info);
     void registerBackupInfo(const MegaBackupInfo &info);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -8184,7 +8184,7 @@ bool CommandBackupPut::procresult(Result r)
     return r.wasStrictlyError() || r.hasJsonItem();
 }
 
-CommandBackupPutHeartBeat::CommandBackupPutHeartBeat(MegaClient* client, handle backupId, uint8_t status, uint8_t progress, uint32_t uploads, uint32_t downloads, m_time_t ts, handle lastNode)
+CommandBackupPutHeartBeat::CommandBackupPutHeartBeat(MegaClient* client, handle backupId, uint8_t status, int8_t progress, uint32_t uploads, uint32_t downloads, m_time_t ts, handle lastNode)
 {
     cmd("sphb");
 

--- a/src/heartbeats.cpp
+++ b/src/heartbeats.cpp
@@ -55,6 +55,11 @@ double HeartBeatBackupInfo::progress() const
     return mProgress;
 }
 
+void HeartBeatBackupInfo::invalidateProgress()
+{
+    mProgressInvalid = true;
+}
+
 uint32_t HeartBeatBackupInfo::pendingUps() const
 {
     return mPendingUps;
@@ -118,6 +123,7 @@ void HeartBeatBackupInfo::setStatus(const int &status)
 
 void HeartBeatBackupInfo::setProgress(const double &progress)
 {
+    mProgressInvalid = false;
     mProgress = progress;
     updateLastActionTime();
 }
@@ -228,6 +234,7 @@ void HeartBeatTransferProgressedInfo::clearFinshedTransfers()
 
 void HeartBeatTransferProgressedInfo::setTransferredBytes(long long value)
 {
+    mProgressInvalid = false;
     if (mTransferredBytes != value)
     {
         mTransferredBytes = value;
@@ -237,6 +244,7 @@ void HeartBeatTransferProgressedInfo::setTransferredBytes(long long value)
 
 void HeartBeatTransferProgressedInfo::setTotalBytes(long long value)
 {
+    mProgressInvalid = false;
     if (mTotalBytes != value)
     {
         mTotalBytes = value;
@@ -246,7 +254,7 @@ void HeartBeatTransferProgressedInfo::setTotalBytes(long long value)
 
 double HeartBeatTransferProgressedInfo::progress() const
 {
-    return std::max(0., std::min(1., static_cast<double>(mTransferredBytes) / static_cast<double>(mTotalBytes)));
+    return mProgressInvalid ? -1.0 : std::max(0., std::min(1., static_cast<double>(mTransferredBytes) / static_cast<double>(mTotalBytes)));
 }
 
 #ifdef ENABLE_SYNC
@@ -752,9 +760,16 @@ void MegaBackupMonitor::beatBackupInfo(const std::shared_ptr<HeartBeatBackupInfo
 
         hbs->setLastBeat(m_time(nullptr));
 
-        auto newCommand = new CommandBackupPutHeartBeat(mClient, hbs->backupId(), hbs->status(),
-                          static_cast<uint8_t>(std::lround(hbs->progress()*100.0)), hbs->pendingUps(), hbs->pendingDowns(),
+        int8_t progress = (hbs->progress() < 0) ? -1 : static_cast<int8_t>(std::lround(hbs->progress()*100.0));
+
+        auto newCommand = new CommandBackupPutHeartBeat(mClient, hbs->backupId(),  static_cast<uint8_t>(hbs->status()),
+                          progress, hbs->pendingUps(), hbs->pendingDowns(),
                           hbs->lastAction(), hbs->lastItemUpdated());
+        if (hbs->status() == HeartBeatSyncInfo::Status::UPTODATE && progress >= 100)
+        {
+            hbs->invalidateProgress(); // we invalidate progress, so as not to keep on reporting 100% progress after reached up to date
+            // note: new transfer updates will modify the progress and make it valid again
+        }
 
         auto runningCommand = hbs->runningCommand();
 


### PR DESCRIPTION
- changed progress parameter from unsigned to signed (there was a
comparison with -1 that made no sense for unsigned)
- initialize last actions timestamps to -1, to avoid sending in hpbs
when unset
- removed unused mLastBeat in MegaBackupMonitor
- have invalidProgress variable to not sending unless set, and
invalidate it after sending progress 100 for UPTODATE syncs