### PR TITLE
SDK-1269. Notify when API sends the node to the rubbish bin

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -1179,7 +1179,7 @@ void DemoApp::fetchnodes_result(const Error& e)
     }
 }
 
-void DemoApp::putnodes_result(const Error& e, targettype_t t, vector<NewNode>& nn)
+void DemoApp::putnodes_result(const Error& e, targettype_t t, vector<NewNode>& nn, bool targetOverride)
 {
     if (t == USER_HANDLE)
     {
@@ -1207,6 +1207,11 @@ void DemoApp::putnodes_result(const Error& e, targettype_t t, vector<NewNode>& n
     if (e)
     {
         cout << "Node addition failed (" << errorstring(e) << ")" << endl;
+    }
+
+    if (targetOverride)
+    {
+        cout << "Target folder has changed!" << endl;
     }
 
     auto i = gOnPutNodeTag.find(client->restag);

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -160,7 +160,7 @@ struct DemoApp : public MegaApp
 
     void fetchnodes_result(const Error&) override;
 
-    void putnodes_result(const Error&, targettype_t, vector<NewNode>&) override;
+    void putnodes_result(const Error&, targettype_t, vector<NewNode>&, bool targetOverride) override;
 
     void share_result(error) override;
     void share_result(int, error) override;

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -123,7 +123,7 @@ struct MEGA_API MegaApp
     virtual void key_modified(handle, attr_t) { }
 
     // node addition has failed
-    virtual void putnodes_result(const Error&, targettype_t, vector<NewNode>&) { }
+    virtual void putnodes_result(const Error&, targettype_t, vector<NewNode>&, bool targetOverride = false) { }
 
     // share update result
     virtual void share_result(error) { }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -4240,6 +4240,16 @@ class MegaTransfer
          * @return Notification number
          */
         virtual long long getNotificationNumber() const;
+
+        /**
+         * @brief Returns whether the target folder of the transfer was overriden by the API server
+         *
+         * It may happen that the target folder fo a transfer is deleted by the time the node
+         * is going to be added. Hence, the API will create the node in the rubbish bin.
+         *
+         * @return True if target folder was overriden (apps can check the final parent)
+         */
+        virtual bool getTargetOverride() const;
 };
 
 /**
@@ -9811,6 +9821,7 @@ class MegaApi
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
          * - MegaRequest::getNodeHandle - Handle of the new folder
+         * - MegaRequest::getFlag - True if target folder (\c parent) was overriden
          *
          * If the MEGA account is a business account and it's status is expired, onRequestFinish will
          * be called with the error code MegaError::API_EBUSINESSPASTDUE.
@@ -9855,6 +9866,10 @@ class MegaApi
          * - MegaRequest::getParentHandle - Returns the handle of the new parent for the node
          * - MegaRequest::getName - Returns the name for the new node
          *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getFlag - True if target folder (\c newParent) was overriden
+         *
          * If the MEGA account is a business account and it's status is expired, onRequestFinish will
          * be called with the error code MegaError::API_EBUSINESSPASTDUE.
          *
@@ -9877,6 +9892,11 @@ class MegaApi
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
          * - MegaRequest::getNodeHandle - Handle of the new node
+         * - MegaRequest::getFlag - True if target folder (\c newParent) was overriden
+         *
+         * @note In case the target folder was overriden, the MegaRequest::getParentHandle still keeps
+         * the handle of the original target folder. You can check the final parent by checking the
+         * value returned by MegaNode::getParentHandle
          *
          * If the status of the business account is expired, onRequestFinish will be called with the error
          * code MegaError::API_EBUSINESSPASTDUE.
@@ -10127,6 +10147,7 @@ class MegaApi
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
          * - MegaRequest::getNodeHandle - Handle of the new node in the account
+         * - MegaRequest::getFlag - True if target folder (\c parent) was overriden
          *
          * If the MEGA account is a business account and it's status is expired, onRequestFinish will
          * be called with the error code MegaError::API_EBUSINESSPASTDUE.
@@ -16532,6 +16553,7 @@ class MegaApi
          * Valid data in the MegaRequest object received in onRequestFinish when the error code
          * is MegaError::API_OK:
          * - MegaRequest::getNodeHandle - Returns the handle of the uploaded node
+         * - MegaRequest::getFlag - True if target folder (\c parent) was overriden
          *
          * @param state The MegaBackgroundMediaUpload object tracking this upload
          * @param utf8Name The leaf name of the file, utf-8 encoded

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -705,6 +705,7 @@ class MegaTransferPrivate : public MegaTransfer, public Cacheable
         void setFolderTransferTag(int tag);
         void setNotificationNumber(long long notificationNumber);
         void setListener(MegaTransferListener *listener);
+        void setTargetOverride(bool targetOverride);
 
         int getType() const override;
         const char * getTransferString() const override;
@@ -751,6 +752,7 @@ class MegaTransferPrivate : public MegaTransfer, public Cacheable
         virtual void setPriority(unsigned long long p);
         unsigned long long getPriority() const override;
         long long getNotificationNumber() const override;
+        bool getTargetOverride() const override;
 
         bool serialize(string*) override;
         static MegaTransferPrivate* unserialize(string*);
@@ -805,6 +807,7 @@ protected:
         int folderTransferTag;
         const char* appData;
         unique_ptr<MegaRecursiveOperation> recursiveOperation;
+        bool mTargetOverride;
 };
 
 class MegaTransferDataPrivate : public MegaTransferData
@@ -3004,7 +3007,7 @@ protected:
         void key_modified(handle, attr_t) override;
 
         void fetchnodes_result(const Error&) override;
-        void putnodes_result(const Error&, targettype_t, vector<NewNode>&) override;
+        void putnodes_result(const Error&, targettype_t, vector<NewNode>&, bool targetOverride) override;
 
         // share update result
         void share_result(error) override;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1274,10 +1274,15 @@ bool CommandPutNodes::procresult(Result r)
 
     client->sendkeyrewrites();
 
+    // when the target has been removed, the API automatically adds the new node/s
+    // into the rubbish bin
+    Node *tempNode = !nn.empty() ? client->nodebyhandle(nn.front().mAddedHandle) : nullptr;
+    bool targetOverride = (tempNode && tempNode->parenthandle != targethandle);
+
 #ifdef ENABLE_SYNC
     if (source == PUTNODES_SYNC)
     {
-        client->app->putnodes_result(e, type, nn);
+        client->app->putnodes_result(e, type, nn, targetOverride);
         client->putnodes_sync_result(e, nn);
     }
     else
@@ -1297,7 +1302,7 @@ bool CommandPutNodes::procresult(Result r)
             }
         }
 #endif
-        client->app->putnodes_result((!e && empty) ? API_ENOENT : static_cast<error>(e), type, nn);
+        client->app->putnodes_result((!e && empty) ? API_ENOENT : static_cast<error>(e), type, nn, targetOverride);
     }
 #ifdef ENABLE_SYNC
     else

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1240,6 +1240,11 @@ long long MegaTransfer::getNotificationNumber() const
     return 0;
 }
 
+bool MegaTransfer::getTargetOverride() const
+{
+    return false;
+}
+
 MegaError::MegaError(int e)
 {
     errorCode = e;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -2519,6 +2519,11 @@ long long MegaTransferPrivate::getNotificationNumber() const
     return notificationNumber;
 }
 
+bool MegaTransferPrivate::getTargetOverride() const
+{
+    return mTargetOverride;
+}
+
 bool MegaTransferPrivate::serialize(string *d)
 {
     d->append((const char*)&type, sizeof(type));
@@ -2831,6 +2836,11 @@ void MegaTransferPrivate::setNotificationNumber(long long notificationNumber)
 void MegaTransferPrivate::setListener(MegaTransferListener *listener)
 {
     this->listener = listener;
+}
+
+void MegaTransferPrivate::setTargetOverride(bool targetOverride)
+{
+    mTargetOverride = targetOverride;
 }
 
 void MegaTransferPrivate::startRecursiveOperation(unique_ptr<MegaRecursiveOperation> op, MegaNode* node)
@@ -13789,7 +13799,7 @@ void MegaApiImpl::fetchnodes_result(const Error &e)
     }
 }
 
-void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<NewNode>& nn)
+void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<NewNode>& nn, bool targetOverride)
 {
     handle h = UNDEF;
     Node *n = NULL;
@@ -13834,6 +13844,7 @@ void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<
         }
 
         transfer->setNodeHandle(h);
+        transfer->setTargetOverride(targetOverride);
         transfer->setTransferredBytes(transfer->getTotalBytes());
 
         if (!e)
@@ -13867,6 +13878,7 @@ void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<
     if (request->getType() == MegaRequest::TYPE_COMPLETE_BACKGROUND_UPLOAD)
     {
         request->setNodeHandle(h);
+        request->setFlag(targetOverride);
         fireOnRequestFinish(request, make_unique<MegaErrorPrivate>(e));
         return;
     }
@@ -13888,6 +13900,7 @@ void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<
     if (request->getType() != MegaRequest::TYPE_MOVE)
     {
         request->setNodeHandle(h);
+        request->setFlag(targetOverride);
         if (request->getType() == MegaRequest::TYPE_CREATE_ACCOUNT)
         {
             fireOnRequestFinish(request, make_unique<MegaErrorPrivate>(API_OK));    // even if import fails, notify account was successfuly created anyway
@@ -13907,6 +13920,7 @@ void MegaApiImpl::putnodes_result(const Error& inputErr, targettype_t t, vector<
             else
             {
                 request->setNodeHandle(h);
+                request->setFlag(targetOverride);
                 e = client->unlink(node, false, request->getTag());
             }
         }

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7499,7 +7499,8 @@ void MegaClient::putnodes(const char* user, vector<NewNode>&& newnodes)
 
     if (!(u = finduser(user, 0)) && !user)
     {
-        return app->putnodes_result(API_EARGS, USER_HANDLE, newnodes);
+        app->putnodes_result(API_EARGS, USER_HANDLE, newnodes);
+        return;
     }
 
     queuepubkeyreq(user, ::mega::make_unique<PubKeyActionPutNodes>(move(newnodes), reqtag));

--- a/src/pubkeyaction.cpp
+++ b/src/pubkeyaction.cpp
@@ -47,7 +47,8 @@ void PubKeyActionPutNodes::proc(MegaClient* client, User* u)
         {
             if (!(t = u->pubk.encrypt(client->rng, (const byte*)nn[i].nodekey.data(), nn[i].nodekey.size(), buf, sizeof buf)))
             {
-                return client->app->putnodes_result(API_EINTERNAL, USER_HANDLE, nn);
+                client->app->putnodes_result(API_EINTERNAL, USER_HANDLE, nn);
+                return;
             }
 
             nn[i].nodekey.assign((char*)buf, t);

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1807,7 +1807,7 @@ struct StandardClient : public MegaApp
         resultproc.processresult(CATCHUP, error(API_OK));
     }
 
-    void putnodes_result(const Error& e, targettype_t tt, vector<NewNode>& nn) override
+    void putnodes_result(const Error& e, targettype_t tt, vector<NewNode>& nn, bool targetOverride) override
     {
         resultproc.processresult(PUTNODES, e, UNDEF);
     }


### PR DESCRIPTION
When the target node of a putnode does not exist, the API will put the node into the rubbish bin.