### PR TITLE
SDK 1152: Fix iOS compilation

### DIFF
--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -92,7 +92,11 @@ class MEGA_API LocalPath
     friend class GfxProcFreeImage;
     friend struct FileSystemAccess;
     friend int computeReversePathMatchScore(const LocalPath& path1, const LocalPath& path2, const FileSystemAccess& fsaccess);
+#ifdef USE_IOS
+    friend const string adjustBasePath(const LocalPath& name);
+#else
     friend const string& adjustBasePath(const LocalPath& name);
+#endif
 
 public:
     LocalPath() {}

--- a/include/mega/gfx/GfxProcCG.h
+++ b/include/mega/gfx/GfxProcCG.h
@@ -36,7 +36,7 @@ class MEGA_API GfxProcCG : public mega::GfxProc
     int maxSizeForThumbnail(const int rw, const int rh);
 private: // mega::GfxProc implementations
     const char* supportedformats();
-    bool readbitmap(FileAccess*, const LocalPath&, int);
+    bool readbitmap(mega::FileAccess*, const mega::LocalPath&, int);
     bool resizebitmap(int, int, mega::string*);
     void freebitmap();
 public:

--- a/src/gfx/GfxProcCG.mm
+++ b/src/gfx/GfxProcCG.mm
@@ -67,15 +67,14 @@ const char* GfxProcCG::supportedformats() {
 
 bool GfxProcCG::readbitmap(FileAccess* fa, const LocalPath& name, int size) {
     string absolutename;
-    if (PosixFileSystemAccess::appbasepath) {
-        if (!name.beginsWithSeparator(fa->localseparator)) {
-            absolutename = PosixFileSystemAccess::appbasepath;
-            absolutename.append(name.platformEncoded());
-            name = &absolutename;
-        }
+    NSString *sourcePath;
+    if (PosixFileSystemAccess::appbasepath && !name.beginsWithSeparator('/')) {
+        absolutename = PosixFileSystemAccess::appbasepath;
+        absolutename.append(name.platformEncoded());
+        sourcePath = [NSString stringWithCString:absolutename.c_str() encoding:[NSString defaultCStringEncoding]];
+    } else {
+        sourcePath = [NSString stringWithCString:name.platformEncoded().c_str() encoding:[NSString defaultCStringEncoding]];
     }
-
-    NSString *sourcePath = [NSString stringWithCString:name.platformEncoded().c_str() encoding:[NSString defaultCStringEncoding]];
     NSURL *sourceURL = [NSURL fileURLWithPath:sourcePath isDirectory:NO];
     if (sourceURL == nil) {
         return false;

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -89,7 +89,7 @@ bool PosixFileAccess::mFoundASymlink = false;
 
 #ifdef USE_IOS
 
-const string& adjustBasePath(const LocalPath& name)
+const string adjustBasePath(const LocalPath& name)
 {
     // return a temporary variable that the caller can optionally use c_str on (in that expression)
     if (PosixFileSystemAccess::appbasepath)

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -89,7 +89,7 @@ bool PosixFileAccess::mFoundASymlink = false;
 
 #ifdef USE_IOS
 
-static string adjustBasePath(const LocalPath& name)
+const string& adjustBasePath(const LocalPath& name)
 {
     // return a temporary variable that the caller can optionally use c_str on (in that expression)
     if (PosixFileSystemAccess::appbasepath)


### PR DESCRIPTION
Compilation errors:

<img width="805" alt="Screenshot 2020-11-09 at 12 32 47" src="https://user-images.githubusercontent.com/3861964/98556485-6259d480-22a3-11eb-8273-4328ef5364ef.png">
<img width="809" alt="Screenshot 2020-11-09 at 12 33 39" src="https://user-images.githubusercontent.com/3861964/98556495-64bc2e80-22a3-11eb-9e19-7a23d754b941.png">
<img width="815" alt="Screenshot 2020-11-09 at 12 44 24" src="https://user-images.githubusercontent.com/3861964/98556497-6554c500-22a3-11eb-9368-3134a883ddc0.png">


================

After fixing the compilation errors, uploads failed (with API_EREAD), the problem happened when returning the `absolutename`, (returning a copy instead a reference fixed the issue: https://github.com/meganz/sdk/pull/2346/commits/b577aa83c18ce6b9271cbbd7182c13e055006f3e, but maybe there is a better approach to fix it):

<img width="2173" alt="Screenshot 2020-11-09 at 14 15 03" src="https://user-images.githubusercontent.com/3861964/98556665-959c6380-22a3-11eb-9d78-75e38e331879.png">
<img width="2173" alt="Screenshot 2020-11-09 at 14 15 20" src="https://user-images.githubusercontent.com/3861964/98556686-9a611780-22a3-11eb-85d3-900aca84e7ab.png">
<img width="2173" alt="Screenshot 2020-11-09 at 14 15 28" src="https://user-images.githubusercontent.com/3861964/98556689-9af9ae00-22a3-11eb-9479-89ff18243218.png">
