### PR TITLE
Fix compilation on Ubuntu + gcc 7.5 (<filesystem>)

### DIFF
--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -25,9 +25,13 @@
 #include "megaapi_impl.h"
 #include <algorithm>
 
-#if (__cplusplus >= 201700L)
+#if (__cplusplus > 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
+    #define USE_FILESYSTEM
+#elif (__cplusplus >= 201700L)
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
     #define USE_FILESYSTEM
 #elif (__clang_major__ >= 11)
     #include <filesystem>

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -43,9 +43,13 @@
 using namespace ::mega;
 using namespace ::std;
 
-#if (__cplusplus >= 201700L)
+#if (__cplusplus > 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
+    #define USE_FILESYSTEM
+#elif (__cplusplus >= 201700L)
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
     #define USE_FILESYSTEM
 #elif (__clang_major__ >= 11)
     #include <filesystem>


### PR DESCRIPTION
On Ubuntu 18.04 LTS and g++ 7.5, the <filesystem> header is not found.
This commit aims to solve the issue.