### PR TITLE
SDK-1293. Shortname only to be used for FS notification matching (not for OS calls)

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -31,7 +31,7 @@
     #include <readline/history.h>
 #endif
 
-#if (__cplusplus >= 201700L)
+#if (__cplusplus >= 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -367,8 +367,8 @@ struct MEGA_API LocalNode : public File
     localnode_set::iterator notseen_it{};
 
     // build full local path to this node
-    void getlocalpath(LocalPath&, bool sdisable = false) const;
-    LocalPath getLocalPath(bool sdisable = false) const;
+    void getlocalpath(LocalPath&) const;
+    LocalPath getLocalPath() const;
     string localnodedisplaypath(FileSystemAccess& fsa) const;
 
     // return child node by name

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -8463,7 +8463,7 @@ bool CommandQueryGoogleAds::procresult(Command::Result r)
         return false;
     }
 
-    int value = client->json.getint();
+    int value = client->json.getint32();
     mCompletion(API_OK, value);
     return true;
 }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -486,7 +486,7 @@ MegaNodePrivate::MegaNodePrivate(Node *node)
     this->syncdeleted = (node->syncdeleted != SYNCDEL_NONE);
     if(node->localnode)
     {
-        localPath = node->localnode->getLocalPath(true).platformEncoded();
+        localPath = node->localnode->getLocalPath().platformEncoded();
         localPath.append("", 1);
     }
 #endif
@@ -4198,7 +4198,7 @@ const char *MegaStringListPrivate::get(int i) const
 
 int MegaStringListPrivate::size() const
 {
-    return mList.size();
+    return int(mList.size());
 }
 
 void MegaStringListPrivate::add(const char *value)
@@ -8885,7 +8885,7 @@ string MegaApiImpl::getLocalPath(MegaNode *n)
         return string();
     }
 
-    string result = node->localnode->getLocalPath(true).platformEncoded();
+    string result = node->localnode->getLocalPath().platformEncoded();
     result.append("", 1);
 
     sdkMutex.unlock();
@@ -12160,7 +12160,7 @@ void MegaApiImpl::file_added(File *f)
         LocalNode *l = dynamic_cast<LocalNode *>(f);
         if (l)
         {
-            path = l->getLocalPath(true).toPath(*fsAccess);
+            path = l->getLocalPath().toPath(*fsAccess);
         }
         else
 #endif
@@ -13138,7 +13138,7 @@ void MegaApiImpl::syncupdate_local_folder_deletion(Sync *sync, LocalNode *localN
 {
     client->abortbackoff(false);
 
-    string path = localNode->getLocalPath(true).toPath(*fsAccess);
+    string path = localNode->getLocalPath().toPath(*fsAccess);
     LOG_debug << "Sync - local folder deletion detected: " << path.c_str();
 
     if(syncMap.find(sync->tag) == syncMap.end()) return;
@@ -13167,7 +13167,7 @@ void MegaApiImpl::syncupdate_local_file_deletion(Sync *sync, LocalNode *localNod
 {
     client->abortbackoff(false);
 
-    string path = localNode->getLocalPath(true).toPath(*fsAccess);
+    string path = localNode->getLocalPath().toPath(*fsAccess);
     LOG_debug << "Sync - local file deletion detected: " << path.c_str();
 
     if(syncMap.find(sync->tag) == syncMap.end()) return;
@@ -13195,7 +13195,7 @@ void MegaApiImpl::syncupdate_local_move(Sync *sync, LocalNode *localNode, const 
 {
     client->abortbackoff(false);
 
-    string path = localNode->getLocalPath(true).toPath(*fsAccess);
+    string path = localNode->getLocalPath().toPath(*fsAccess);
     LOG_debug << "Sync - local rename/move " << path.c_str() << " -> " << to;
 
     if(syncMap.find(sync->tag) == syncMap.end()) return;
@@ -13325,7 +13325,7 @@ void MegaApiImpl::syncupdate_treestate(LocalNode *l)
     if(syncMap.find(l->sync->tag) == syncMap.end()) return;
     MegaSyncPrivate* megaSync = syncMap.at(l->sync->tag);
 
-    string s = l->getLocalPath(true).platformEncoded();
+    string s = l->getLocalPath().platformEncoded();
 
     fireOnFileSyncStateChanged(megaSync, &s, (int)l->ts);
 }
@@ -23123,7 +23123,7 @@ void MegaApiImpl::sendPendingRequests()
         }
         case MegaRequest::TYPE_FETCH_GOOGLE_ADS:
         {
-                int flags = request->getNumber();
+                int flags = int(request->getNumber());
                 if (flags < MegaApi::GOOGLE_ADS_FORCE_ADS || flags > MegaApi::GOOGLE_ADS_FLAG_IGNORE_ROLLOUT)
                 {
                     e = API_EARGS;
@@ -23150,7 +23150,7 @@ void MegaApiImpl::sendPendingRequests()
         }
         case MegaRequest::TYPE_QUERY_GOOGLE_ADS:
         {
-            int flags = request->getNumber();
+            int flags = int(request->getNumber());
             if (flags < MegaApi::GOOGLE_ADS_FORCE_ADS || flags > MegaApi::GOOGLE_ADS_FLAG_IGNORE_ROLLOUT)
             {
                 e = API_EARGS;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -13814,7 +13814,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds, size_t& parentPending)
                     {
                         LOG_debug << "Modification time changed only";
                         auto f = fsaccess->newfileaccess();
-                        auto lpath = ll->getLocalPath(true);
+                        auto lpath = ll->getLocalPath();
                         LocalPath stream = lpath;
                         stream.append(LocalPath::fromPlatformEncoded(wstring(L":$CmdTcID:$DATA", 15)));
                         if (f->fopen(stream))
@@ -14235,7 +14235,7 @@ void MegaClient::syncupdate()
                 nextreqtag();
                 startxfer(PUT, l, committer);
 
-                tmppath = l->getLocalPath(true).toPath(*fsaccess);
+                tmppath = l->getLocalPath().toPath(*fsaccess);
                 app->syncupdate_put(l->sync, l, tmppath.c_str());
             }
         }
@@ -14369,7 +14369,7 @@ void MegaClient::unlinkifexists(LocalNode *l, FileAccess *fa, LocalPath& reuseBu
     // sdisable = true for this call.  In the case where we are doing a full scan due to fs notifications failing,
     // and a file was renamed but retains the same shortname, we would check the presence of the wrong file.
     // Also shortnames are slowly being deprecated by Microsoft, so using full names is now the normal case anyway.
-    l->getlocalpath(reuseBuffer, true);
+    l->getlocalpath(reuseBuffer);
     if (fa->fopen(reuseBuffer) || fa->type == FOLDERNODE)
     {
         LOG_warn << "Deletion of existing file avoided";
@@ -15298,7 +15298,7 @@ Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
     // they are identical.
     auto ifAccess = fsaccess->newfileaccess();
 
-    auto localPath = localNode->getLocalPath(true);
+    auto localPath = localNode->getLocalPath();
 
     if (!ifAccess->fopen(localPath, true, false))
         return nullptr;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1608,14 +1608,14 @@ LocalNode::~LocalNode()
     slocalname.reset();
 }
 
-LocalPath LocalNode::getLocalPath(bool sdisable) const
+LocalPath LocalNode::getLocalPath() const
 {
     LocalPath lp;
-    getlocalpath(lp, sdisable);
+    getlocalpath(lp);
     return lp;
 }
 
-void LocalNode::getlocalpath(LocalPath& path, bool sdisable) const
+void LocalNode::getlocalpath(LocalPath& path) const
 {
     if (!sync)
     {
@@ -1630,23 +1630,15 @@ void LocalNode::getlocalpath(LocalPath& path, bool sdisable) const
     {
         assert(!l->parent || l->parent->sync == sync);
 
-        // use short name, if available (less likely to overflow MAXPATH,
-        // perhaps faster?) and sdisable not set.  Use localname from the sync root though, as it has the absolute path.
-        if (!sdisable && l->slocalname && l->parent)
-        {
-            path.prependWithSeparator(*l->slocalname, sync->client->fsaccess->localseparator);
-        }
-        else
-        {
-            path.prependWithSeparator(l->localname, sync->client->fsaccess->localseparator);
-        }
+        // sync root has absolute path, the rest are just their leafname
+        path.prependWithSeparator(l->localname, sync->client->fsaccess->localseparator);
     }
 }
 
 string LocalNode::localnodedisplaypath(FileSystemAccess& fsa) const
 {
     LocalPath local;
-    getlocalpath(local, true);
+    getlocalpath(local);
     return local.toPath(fsa);
 }
 
@@ -1665,7 +1657,7 @@ LocalNode* LocalNode::childbyname(LocalPath* localname)
 
 void LocalNode::prepare()
 {
-    getlocalpath(transfer->localfilename, true);
+    getlocalpath(transfer->localfilename);
 
     // is this transfer in progress? update file's filename.
     if (transfer->slot && transfer->slot->fa && !transfer->slot->fa->nonblocking_localname.empty())

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -354,7 +354,7 @@ size_t assignFilesystemIdsImpl(const FingerprintCache& fingerprints, Fingerprint
             auto l = nodeIt->second;
             if (l != l->sync->localroot.get()) // never assign fs ID to the root localnode
             {
-                nodePath = l->getLocalPath(false);
+                nodePath = l->getLocalPath();
                 for (auto fileIt = fileRange.first; fileIt != fileRange.second; ++fileIt)
                 {
                     auto& filePath = fileIt->second.path;
@@ -1180,7 +1180,7 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
             LOG_warn << "Parent not detected yet. Unknown remainder: " << newname.toPath(*client->fsaccess);
             if (parent)
             {
-                LocalPath notifyPath = parent->getLocalPath(true);
+                LocalPath notifyPath = parent->getLocalPath();
                 notifyPath.appendWithSeparator(newname.subpathTo(index), true, client->fsaccess->localseparator);
                 dirnotify->notify(DirNotify::DIREVENTS, l, std::move(notifyPath), true);
             }
@@ -1480,7 +1480,7 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
                             if (currentsecs - updatedfileinitialts <= FILE_UPDATE_MAX_DELAY_SECS)
                             {
                                 bool waitforupdate = false;
-                                auto local = it->second->getLocalPath(true);
+                                auto local = it->second->getLocalPath();
                                 auto prevfa = client->fsaccess->newfileaccess(false);
 
                                 bool exists = prevfa->fopen(local);
@@ -1761,7 +1761,7 @@ bool Sync::checkValidNotification(int q, Notification& notification)
         LocalPath tmppath;
         if (notification.localnode)
         {
-            tmppath = notification.localnode->getLocalPath(true);
+            tmppath = notification.localnode->getLocalPath();
         }
 
         if (!notification.path.empty())

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -985,7 +985,7 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
             if (ll)
             {
                 LOG_debug << "Verifying sync upload";
-                synclocalpath = ll->getLocalPath(true);
+                synclocalpath = ll->getLocalPath();
                 localpath = &synclocalpath;
             }
             else

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -25,7 +25,7 @@
 #include "megaapi_impl.h"
 #include <algorithm>
 
-#if (__cplusplus >= 201703L)
+#if (__cplusplus > 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -25,7 +25,7 @@
 #include "megaapi_impl.h"
 #include <algorithm>
 
-#if (__cplusplus > 201703L)
+#if (__cplusplus >= 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -43,7 +43,7 @@
 using namespace ::mega;
 using namespace ::std;
 
-#if (__cplusplus > 201703L)
+#if (__cplusplus >= 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM
@@ -1545,7 +1545,7 @@ struct StandardClient : public MegaApp
             return false;
         }
 
-        auto localpath = n->getLocalPath(false).toName(*client.fsaccess, FS_UNKNOWN);
+        auto localpath = n->getLocalPath().toName(*client.fsaccess, FS_UNKNOWN);
         string n_localname = n->localname.toName(*client.fsaccess, FS_UNKNOWN);
         if (n_localname.size())
         {
@@ -1564,7 +1564,7 @@ struct StandardClient : public MegaApp
             EXPECT_EQ(mn->parent->type, Model::ModelNode::folder);
             EXPECT_EQ(n->parent->type, FOLDERNODE);
 
-            string parentpath = n->parent->getLocalPath(false).toName(*client.fsaccess, FS_UNKNOWN);
+            string parentpath = n->parent->getLocalPath().toName(*client.fsaccess, FS_UNKNOWN);
             EXPECT_EQ(localpath.substr(0, parentpath.size()), parentpath);
         }
         if (n->node && n->parent && n->parent->node)

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -43,7 +43,7 @@
 using namespace ::mega;
 using namespace ::std;
 
-#if (__cplusplus >= 201703L)
+#if (__cplusplus > 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM

--- a/tests/unit/Commands_test.cpp
+++ b/tests/unit/Commands_test.cpp
@@ -321,7 +321,7 @@ TEST(Commands, CommandCommandFetchGoogleAds)
     ClientMockup client(megaApp, httpIO, fileSystem);
     client.json.pos = R"({"id": "wphl","iu": "/22060108601/wph/wph_l"},{"id":"wphr","iu": "/22060108601/wph/wph_r"},{"id":"wpht","iu": "/22060108601/wph/wph_t"})";
     std::vector<std::string> v;
-    handle h;
+    handle h = UNDEF;
     int adFlags = 512;
 
     ::mega::CommandFetchGoogleAds command(&client, adFlags, v, h, [](::mega::Error e, ::mega::string_map value)
@@ -349,7 +349,7 @@ TEST(Commands, CommandQueryGoogleAds)
     MegaAppMockup megaApp;
     ClientMockup client(megaApp, httpIO, fileSystem);
     client.json.pos = R"(1)";
-    handle h;
+    handle h = UNDEF;
     int adFlags = 512;
 
     ::mega::CommandQueryGoogleAds command(&client, adFlags, h, [](::mega::Error e, int value)


### PR DESCRIPTION
Any calls to the filesystem, use the long name.  It'll be the same code path for systems with and without (which is getting much more common) having shortname generation turned on.
Shortname will only be used for filesystem notification matching.
Also fixed some warnings (on windows) that had crept into the code base.