### PR TITLE
SDK-1330. A fix for the occasional crashes reported, with the call stack indicating notifynode() [release v3.7.3g]

### DIFF
--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -204,7 +204,7 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
         bool publiclink : 1;
         bool newnode : 1;
     } changed;
-    
+
     void setkey(const byte* = NULL);
 
     void setkeyfromjson(const char*);
@@ -229,7 +229,7 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
 
 #ifdef ENABLE_SYNC
     // related synced item or NULL
-    LocalNode* localnode = nullptr;
+    crossref_ptr<LocalNode, Node> localnode;
 
     // active sync get
     struct SyncFileGet* syncget = nullptr;
@@ -316,7 +316,7 @@ struct MEGA_API LocalNode : public File
     handlelocalnode_map::iterator fsid_it{};
 
     // related cloud node, if any
-    Node* node = nullptr;
+    crossref_ptr<Node, LocalNode> node;
 
     // related pending node creation or NULL
     crossref_ptr<NewNode, LocalNode> newnode;
@@ -402,6 +402,8 @@ struct MEGA_API LocalNode : public File
 
 template <> inline NewNode*& crossref_other_ptr_ref<LocalNode, NewNode>(LocalNode* p) { return p->newnode.ptr; }
 template <> inline LocalNode*& crossref_other_ptr_ref<NewNode, LocalNode>(NewNode* p) { return p->localnode.ptr; }
+template <> inline Node*& crossref_other_ptr_ref<LocalNode, Node>(LocalNode* p) { return p->node.ptr; }
+template <> inline LocalNode*& crossref_other_ptr_ref<Node, LocalNode>(Node* p) { return p->localnode.ptr; }
 
 #endif
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -901,9 +901,9 @@ public:
     void store_unchecked(TO* p) { ptr = p; }
     TO*  release_unchecked() { auto p = ptr; ptr = nullptr; return p;  }
 
-    TO* get() { return ptr; }
-    TO* operator->() const { return ptr; }
-    operator TO*() const { return ptr; }
+    TO* get()              { return ptr; }
+    TO* operator->() const { assert(ptr != (void*)~0); return ptr; }
+    operator TO*() const   { assert(ptr != (void*)~0); return ptr; }
 
     // no copying
     crossref_ptr(const crossref_ptr&) = delete;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -134,9 +134,9 @@ class AuthRing;
 
 #define EOO 0
 
-// Our own version of time_t which we can be sure is 64 bit.  
+// Our own version of time_t which we can be sure is 64 bit.
 // Utils.h has functions m_time() and so on corresponding to time() which help us to use this type and avoid arithmetic overflow when working with time_t on systems where it's 32-bit
-typedef int64_t m_time_t; 
+typedef int64_t m_time_t;
 
 // monotonously increasing time in deciseconds
 typedef uint32_t dstime;
@@ -353,7 +353,7 @@ template <class T, class E>
 class deque_with_lazy_bulk_erase
 {
     // This is a wrapper class for deque.  Erasing an element from the middle of a deque is not cheap since all the subsequent elements need to be shuffled back.
-    // This wrapper intercepts the erase() calls for single items, and instead marks each one as 'erased'.  
+    // This wrapper intercepts the erase() calls for single items, and instead marks each one as 'erased'.
     // The supplied template class E contains the normal deque entry T, plus a flag or similar to mark an entry erased.
     // Any other operation on the deque performs all the gathered erases in a single std::remove_if for efficiency.
     // This makes an enormous difference when cancelling 100k transfers in MEGAsync's transfers window for example.
@@ -675,9 +675,9 @@ namespace CodeCounter
         std::string name;
         ScopeStats(std::string s) : name(std::move(s)) {}
 
-        inline string report(bool reset = false) 
-        { 
-            string s = " " + name + ": " + std::to_string(count) + " " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(timeSpent).count()); 
+        inline string report(bool reset = false)
+        {
+            string s = " " + name + ": " + std::to_string(count) + " " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(timeSpent).count());
             if (reset)
             {
                 count = 0;
@@ -701,9 +701,9 @@ namespace CodeCounter
         inline void start(bool b = true) { if (b && !started) { deltaStart = high_resolution_clock::now(); started = true; }  }
         inline void stop(bool b = true) { if (b && started) { sum += high_resolution_clock::now() - deltaStart; started = false; } }
         inline bool inprogress() { return started; }
-        inline string report(bool reset = false) 
-        { 
-            string s = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(sum).count()); 
+        inline string report(bool reset = false)
+        {
+            string s = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(sum).count());
             if (reset) sum = high_resolution_clock::duration{ 0 };
             return s;
         }
@@ -862,7 +862,7 @@ template<class TO, class FROM>
 FROM*& crossref_other_ptr_ref(TO* s);  // to be supplied for each pair of classes (to assign to the right member thereof) (gets around circular declarations)
 
 template <class  TO, class  FROM>
-class MEGA_API  crossref_ptr 
+class MEGA_API  crossref_ptr
 {
     friend class crossref_ptr<FROM, TO>;
 
@@ -879,7 +879,7 @@ public:
         reset();
     }
 
-    void crossref(TO* to, FROM* from) 
+    void crossref(TO* to, FROM* from)
     {
         assert(to && from);
         assert(ptr == nullptr);
@@ -898,6 +898,10 @@ public:
         }
     }
 
+    void store_unchecked(TO* p) { ptr = p; }
+    TO*  release_unchecked() { auto p = ptr; ptr = nullptr; return p;  }
+
+    TO* get() { return ptr; }
     TO* operator->() const { return ptr; }
     operator TO*() const { return ptr; }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -482,7 +482,7 @@ void MegaClient::setsid(const byte* newsid, unsigned len)
     size_t t = auth.size();
     auth.resize(t + len * 4 / 3 + 4);
     auth.resize(t + Base64::btoa(newsid, len, (char*)(auth.c_str() + t)));
-    
+
     sid.assign((const char*)newsid, len);
 }
 
@@ -580,7 +580,7 @@ SCSN::SCSN()
     clear();
 }
 
-void SCSN::clear() 
+void SCSN::clear()
 {
     memset(scsn, 0, sizeof(scsn));
     stopsc = false;
@@ -1199,7 +1199,7 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
     usehttps = true;
     orderdownloadedchunks = true;
 #endif
-    
+
     fetchingnodes = false;
     fetchnodestag = 0;
 
@@ -1273,7 +1273,7 @@ MegaClient::MegaClient(MegaApp* a, Waiter* w, HttpIO* h, FileSystemAccess* f, Db
         reqid[i] = static_cast<char>('a' + rng.genuint32(26));
     }
 
-    nextuh = 0;  
+    nextuh = 0;
     reqtag = 0;
 
     badhostcs = NULL;
@@ -2036,7 +2036,7 @@ void MegaClient::exec()
             case REQ_FAILURE:
                 if (pendingscUserAlerts->httpstatus == 200)
                 {
-                    error e = (error)atoi(pendingscUserAlerts->in.c_str());  
+                    error e = (error)atoi(pendingscUserAlerts->in.c_str());
                     if (e == API_EAGAIN || e == API_ERATELIMIT)
                     {
                         btsc.backoff();
@@ -2338,10 +2338,10 @@ void MegaClient::exec()
             do
             {
                 lastCount = transferCount;
-                
+
                 // Check the list of transfers and start a few big files, and many small, up to configured limits.
                 dispatchTransfers();
-                
+
                 // if we are cancelling a lot of transfers (eg. nodes to download were deleted), keep going. Avoid stalling when no transfers are active and all queued fail
                 transferCount = transfers[GET].size() + transfers[PUT].size();
             } while (transferCount < lastCount);
@@ -2632,7 +2632,7 @@ void MegaClient::exec()
                 }
 
                 // delete files that were overwritten by folders in checkpath()
-                execsyncdeletions();  
+                execsyncdeletions();
 
                 if (synccreate.size())
                 {
@@ -2751,7 +2751,7 @@ void MegaClient::exec()
                             }
 
                             // delete files that were overwritten by folders in syncup()
-                            execsyncdeletions();  
+                            execsyncdeletions();
 
                             if (synccreate.size())
                             {
@@ -2835,7 +2835,7 @@ void MegaClient::exec()
                                 fsaccess->notifyerr = false;
                             }
 
-                            execsyncdeletions();  
+                            execsyncdeletions();
                         }
                     }
                 }
@@ -3411,10 +3411,10 @@ void MegaClient::dispatchTransfers()
 
     CodeCounter::ScopeTimer ccst(performanceStats.dispatchTransfers);
 
-    struct counter 
-    { 
-        m_off_t remainingsum = 0; 
-        unsigned total = 0; 
+    struct counter
+    {
+        m_off_t remainingsum = 0;
+        unsigned total = 0;
         unsigned added = 0;
         bool hasVeryBig = false;
 
@@ -3445,8 +3445,8 @@ void MegaClient::dispatchTransfers()
         counters[tc.directionIndex()].addexisting(ts->transfer->size,  ts->progressreported);
     }
 
-    std::function<bool(Transfer*)> testAddTransferFunction = [&counters, this](Transfer* t) 
-        { 
+    std::function<bool(Transfer*)> testAddTransferFunction = [&counters, this](Transfer* t)
+        {
             TransferCategory tc(t);
 
             // hard limit on puts/gets
@@ -3481,7 +3481,7 @@ void MegaClient::dispatchTransfers()
             counters[tc.index()].addnew(t->size);
             counters[tc.directionIndex()].addnew(t->size);
 
-            return true; 
+            return true;
         };
 
     std::array<vector<Transfer*>, 6> nextInCategory = transferlist.nexttransfers(testAddTransferFunction);
@@ -3852,7 +3852,7 @@ void MegaClient::checkfacompletion(handle th, Transfer* t)
         LOG_warn << "NULL file attribute handle";
     }
 
-    LOG_debug << "Transfer finished, sending callbacks - " << th;    
+    LOG_debug << "Transfer finished, sending callbacks - " << th;
     t->state = TRANSFERSTATE_COMPLETED;
     t->completefiles();
     looprequested = true;
@@ -4055,7 +4055,7 @@ void MegaClient::locallogout(bool removecaches)
     // remove any cached transfers older than two days that have not been resumed (updates transfer list)
     purgeOrphanTransfers();
 
-    // delete all remaining transfers (optimized not to remove from transfer list one by one) 
+    // delete all remaining transfers (optimized not to remove from transfer list one by one)
     // transfer destructors update the transfer in the cache database
     freeq(GET);
     freeq(PUT);
@@ -4357,7 +4357,7 @@ bool MegaClient::procsc()
                         }
                     }
                     break;
-                    
+
                 case EOO:
                     LOG_debug << "Processing of action packets finished.  More to follow: " << insca_notlast;
                     mergenewshares(1);
@@ -6052,7 +6052,7 @@ void MegaClient::sc_upc(bool incoming)
                 break;
             case MAKENAMEID3('u', 't', 's'):
                 uts = jsonsc.getint();
-                break; 
+                break;
             case 's':
                 s = int(jsonsc.getint());
                 break;
@@ -6074,12 +6074,12 @@ void MegaClient::sc_upc(bool incoming)
 
                 if (!pcr)
                 {
-                    // As this was an update triggered by us, on an object we must know about, this is kinda a problem.                    
+                    // As this was an update triggered by us, on an object we must know about, this is kinda a problem.
                     LOG_err << "upci PCR not found, huge massive problem";
                     break;
                 }
                 else
-                {                    
+                {
                     if (!m)
                     {
                         LOG_err << "m element not provided";
@@ -6303,7 +6303,7 @@ void MegaClient::sc_se()
                 LOG_debug << "Email changed from `" << u->email << "` to `" << email << "`";
 
                 mapuser(uh, email.c_str()); // update email used as index for user's map
-                u->changed.email = true;               
+                u->changed.email = true;
                 notifyuser(u);
             }
             // TODO: manage different status once multiple-emails is supported
@@ -6492,7 +6492,7 @@ void MegaClient::sc_chatupdate(bool readingPublicChat)
 
             default:
                 if (!jsonsc.storeobject())
-                {                    
+                {
                     delete upnotif;
                     return;
                 }
@@ -6980,7 +6980,7 @@ Node* MegaClient::sc_deltree()
                     reqtag = 0;
                     proctree(n, &td);
                     reqtag = creqtag;
-                    
+
                     useralerts.convertNotedSharedNodes(false, originatingUser);
                 }
                 return n;
@@ -8049,12 +8049,12 @@ void MegaClient::readipc(JSON *j)
 
                         if (pcrindex[p] != NULL)
                         {
-                            pcrindex[p]->update(m, NULL, ts, uts, msg, false);                        
-                        } 
+                            pcrindex[p]->update(m, NULL, ts, uts, msg, false);
+                        }
                         else
                         {
                             pcrindex[p] = new PendingContactRequest(p, m, NULL, ts, uts, msg, false);
-                        }                       
+                        }
 
                         break;
                     default:
@@ -8132,8 +8132,8 @@ void MegaClient::readopc(JSON *j)
 
                         if (pcrindex[p] != NULL)
                         {
-                            pcrindex[p]->update(e, m, ts, uts, msg, true);                        
-                        } 
+                            pcrindex[p]->update(e, m, ts, uts, msg, true);
+                        }
                         else
                         {
                             pcrindex[p] = new PendingContactRequest(p, e, m, ts, uts, msg, true);
@@ -8599,7 +8599,7 @@ void MegaClient::getpubkey(const char *user)
 
 // resume session - load state from local cache, if available
 void MegaClient::login(const byte* session, int size)
-{   
+{
     int sessionversion = 0;
     if (size == sizeof key.key + SIDLEN + 1)
     {
@@ -8701,7 +8701,7 @@ int MegaClient::dumpsession(byte* session, size_t size)
     }
 
     memcpy(session + sizeof key.key, sid.data(), sid.size());
-    
+
     return int(size);
 }
 
@@ -9630,8 +9630,7 @@ void MegaClient::notifynode(Node* n)
             }
 
             n->localnode->deleted = true;
-            n->localnode->node = NULL;
-            n->localnode = NULL;
+            n->localnode.reset();
         }
         else
         {
@@ -9666,7 +9665,7 @@ void MegaClient::notifynode(Node* n)
                     else
                     {
                         app->syncupdate_remote_move(n->localnode->sync, n,
-                            n->localnode->parent ? n->localnode->parent->node : NULL);
+                            n->localnode->parent ? n->localnode->parent->node.get() : nullptr);
                     }
                 }
             }
@@ -10210,7 +10209,7 @@ void MegaClient::procmcna(JSON *j)
                 }
             }
             j->leaveobject();
-        }        
+        }
         j->leavearray();
     }
 }
@@ -10252,7 +10251,7 @@ void MegaClient::cr_response(node_vector* shares, node_vector* nodes, JSON* sele
     {
         if ((*shares)[si] && ((*shares)[si]->inshare || !(*shares)[si]->sharekey))
         {
-            // security feature: we only distribute node keys for our own outgoing shares.  
+            // security feature: we only distribute node keys for our own outgoing shares.
             LOG_warn << "Attempt to obtain node key for invalid/third-party share foiled";
             (*shares)[si] = NULL;
             sendevent(99445, "Inshare key request rejected", 0);
@@ -11265,7 +11264,7 @@ void MegaClient::fetchnodes(bool nocache)
         sctable->begin();
         pendingsccommit = false;
 
-        // allow sc requests to start 
+        // allow sc requests to start
         scsn.setScsn(cachedscsn);
         LOG_info << "Session loaded from local cache. SCSN: " << scsn.text();
 
@@ -12207,7 +12206,7 @@ void MegaClient::abortreads(handle h, bool p, m_off_t offset, m_off_t count)
     DirectReadNode* drn;
 
     encodehandletype(&h, p);
-    
+
     if ((it = hdrns.find(h)) != hdrns.end())
     {
         drn = it->second;
@@ -12399,7 +12398,7 @@ error MegaClient::addsync(SyncConfig syncConfig, const char* debris, string* loc
     string localPath = syncConfig.getLocalPath();
     auto rootpath = LocalPath::fromPath(localPath, *fsaccess);
     rootpath.trimNonDriveTrailingSeparator(*fsaccess);
-    
+
     bool isnetwork = false;
     if (!fsaccess->issyncsupported(rootpath, &isnetwork))
     {
@@ -12486,7 +12485,7 @@ void MegaClient::stopxfers(LocalNode* l, DBTableTransactionCommitter& committer)
             stopxfers(it->second, committer);
         }
     }
-  
+
     stopxfer(l, &committer);
 }
 
@@ -12552,7 +12551,7 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
     // build child hash - nameclash resolution: use newest/largest version
     for (node_list::iterator it = l->node->children.begin(); it != l->node->children.end(); it++)
     {
-        attr_map::iterator ait;        
+        attr_map::iterator ait;
 
         // node must be syncable, alive, decrypted and have its name defined to
         // be considered - also, prevent clashes with the local debris folder
@@ -12655,7 +12654,9 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
                         stopxfer(rit->second->localnode, &committer);  // TODO: can we have one transaction for recursing through syncdown() ?
                     }
 
-                    rit->second->localnode = (LocalNode*)~0;
+                    // we will iterate all the nchildren next, and check this marker pointer is reset.
+                    rit->second->localnode.reset();
+                    rit->second->localnode.store_unchecked((LocalNode*)~0);
                 }
             }
             else
@@ -12743,7 +12744,7 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
             if (rit->second->localnode->parent)
             {
                 LOG_debug << "with a previous parent: " << rit->second->localnode->parent->name;
-                
+
                 LocalPath curpath = rit->second->localnode->getLocalPath();
                 rit->second->localnode->treestate(TREESTATE_SYNCING);
 
@@ -12801,7 +12802,14 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
                         }
                     }
                     f.reset();
-                    rit->second->localnode = NULL;
+                    if (rit->second->localnode.get() == (LocalNode*)~0)
+                    {
+                        rit->second->localnode.store_unchecked(nullptr);
+                    }
+                    else
+                    {
+                        rit->second->localnode.reset();
+                    }
 
                     // start fetching this node, unless fetch is already in progress
                     // FIXME: to cover renames that occur during the
@@ -12862,6 +12870,12 @@ bool MegaClient::syncdown(LocalNode* l, LocalPath& localpath, bool rubbish)
                 }
             }
         }
+
+        if (rit->second->localnode.get() == (LocalNode*)~0)
+        {
+            // make sure we are not leaving this marker pointer in the localnode
+            rit->second->localnode.store_unchecked(nullptr);
+        }
     }
 
     return success;
@@ -12910,7 +12924,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                         char report[256];
 
                         Base64::btoa((const byte *)&(*it)->nodehandle, MegaClient::NODEHANDLE, report);
-                        
+
                         sprintf(report + 8, " %d %.200s", (*it)->type, buf);
 
                         // report an "undecrypted child" event
@@ -13075,7 +13089,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                     {
                         LOG_debug << "LocalNode is older: " << ll->name << " LNmtime: " << ll->mtime << " Nmtime: " << rit->second->mtime;
                         continue;
-                    }                           
+                    }
 
                     if (ll->mtime == rit->second->mtime)
                     {
@@ -13277,7 +13291,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
                     {
                         ll->sync->localbytes -= ll->size;
                         ll->genfingerprint(fa.get());
-                        ll->sync->localbytes += ll->size;                        
+                        ll->sync->localbytes += ll->size;
 
                         ll->sync->statecacheadd(ll);
                     }
@@ -13294,7 +13308,7 @@ bool MegaClient::syncup(LocalNode* l, dstime* nds)
 
                     continue;
                 }
-                
+
                 ll->created = false;
             }
         }
@@ -13582,8 +13596,7 @@ void MegaClient::movetosyncdebris(Node* dn, bool unlink)
     if (dn->localnode)
     {
         dn->tag = dn->localnode->sync->tag;
-        dn->localnode->node = NULL;
-        dn->localnode = NULL;
+        dn->localnode.reset();
     }
 
     Node* n = dn;
@@ -13600,13 +13613,13 @@ void MegaClient::movetosyncdebris(Node* dn, bool unlink)
         }
         else
         {
-            dn->todebris_it = todebris.insert(dn).first;        
+            dn->todebris_it = todebris.insert(dn).first;
         }
     }
 }
 
 void MegaClient::execsyncdeletions()
-{                
+{
     if (todebris.size())
     {
         execmovetosyncdebris();
@@ -13895,7 +13908,7 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
             }
 
 #ifdef USE_MEDIAINFO
-            mediaFileInfo.requestCodecMappingsOneTime(this, &f->localname);  
+            mediaFileInfo.requestCodecMappingsOneTime(this, &f->localname);
 #endif
         }
         else
@@ -14202,10 +14215,10 @@ Node* MegaClient::nodebyfingerprint(LocalNode* localNode)
     remoteNode = remoteNodes->begin();
 
     // Compare the local file's metamac against a random candidate.
-    // 
+    //
     // If we're unable to generate the metamac, fail in such a way that
     // guarantees safe behavior.
-    // 
+    //
     // That is, treat both nodes as distinct until we're absolutely certain
     // they are identical.
     auto ifAccess = fsaccess->newfileaccess();
@@ -14255,7 +14268,7 @@ node_vector MegaClient::getRecentNodes(unsigned maxcount, m_time_t since, bool i
     v.reserve(nodes.size());
     for (node_map::iterator i = nodes.begin(); i != nodes.end(); ++i)
     {
-        if (i->second->type == FILENODE && i->second->ctime >= since &&  // recent files only 
+        if (i->second->type == FILENODE && i->second->ctime >= since &&  // recent files only
             (!i->second->parent || i->second->parent->type != FILENODE)) // excluding versions
         {
             v.push_back(i->second);
@@ -14315,7 +14328,7 @@ namespace action_bucket_compare
                     return false; // otherwise double-check by extension
                 }
             }
-#endif  
+#endif
         }
         return action_bucket_compare::webclient_mime_video_extensions.find(ext) != string::npos;
     }
@@ -14495,7 +14508,7 @@ void MegaClient::setchunkfailed(string* url)
             badhosts.append("S");
             ptr++;
         }
-        
+
         badhosts.append(ptr+6,7);
         btbadhost.reset();
     }
@@ -14794,9 +14807,9 @@ std::string MegaClient::PerformanceStats::report(bool reset, HttpIO* httpio, Wai
     }
 #endif
 #ifdef WIN32
-    s << " waiter nonzero timeout: " << static_cast<WinWaiter*>(waiter)->performanceStats.waitTimedoutNonzero 
+    s << " waiter nonzero timeout: " << static_cast<WinWaiter*>(waiter)->performanceStats.waitTimedoutNonzero
       << " zero timeout: " << static_cast<WinWaiter*>(waiter)->performanceStats.waitTimedoutZero
-      << " io trigger: " << static_cast<WinWaiter*>(waiter)->performanceStats.waitIOCompleted 
+      << " io trigger: " << static_cast<WinWaiter*>(waiter)->performanceStats.waitIOCompleted
       << " event trigger: "  << static_cast<WinWaiter*>(waiter)->performanceStats.waitSignalled << "\n";
 #endif
     if (reset)

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1444,9 +1444,12 @@ void LocalNode::setnode(Node* cnode)
 {
     deleted = false;
 
-    if (cnode) cnode->localnode.reset();
     node.reset();
-    node.crossref(cnode, this);
+    if (cnode)
+    {
+        cnode->localnode.reset();
+        node.crossref(cnode, this);
+    }
 }
 
 void LocalNode::setnotseen(int newnotseen)

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -802,11 +802,11 @@ void Sync::addstatecachechildren(uint32_t parent_dbid, idlocalnode_map* tmap, Lo
     for (auto it = range.first; it != range.second; it++)
     {
         ScopedLengthRestore restoreLen(localpath);
-        
+
         localpath.appendWithSeparator(it->second->localname, true, client->fsaccess->localseparator);
 
         LocalNode* l = it->second;
-        Node* node = l->node;
+        Node* node = l->node.release_unchecked();
         handle fsid = l->fsid;
         m_off_t size = l->size;
 
@@ -832,7 +832,7 @@ void Sync::addstatecachechildren(uint32_t parent_dbid, idlocalnode_map* tmap, Lo
         if (fa->fopen(localpath))  // exists, is file
         {
             auto sn = client->fsaccess->fsShortname(localpath);
-            assert(!l->localname.empty() && 
+            assert(!l->localname.empty() &&
                 (!l->slocalname && (!sn || l->localname == *sn) ||
                 (l->slocalname && sn && !l->slocalname->empty() && *l->slocalname != l->localname && *l->slocalname == *sn)));
         }
@@ -1788,7 +1788,7 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
 
 bool Sync::checkValidNotification(int q, Notification& notification)
 {
-    // This code moved from filtering before going on notifyq, to filtering after when it's thread-safe to do so 
+    // This code moved from filtering before going on notifyq, to filtering after when it's thread-safe to do so
 
     if (q == DirNotify::DIREVENTS || q == DirNotify::EXTRA)
     {

--- a/src/treeproc.cpp
+++ b/src/treeproc.cpp
@@ -126,7 +126,7 @@ void LocalTreeProcMove::proc(MegaClient*, LocalNode* localnode)
     if (recreate)
     {
         localnode->created = false;
-        localnode->node = NULL;
+        localnode->node.reset();
     }
 
     nc++;
@@ -143,11 +143,7 @@ void LocalTreeProcUpdateTransfers::proc(MegaClient *, LocalNode *localnode)
 
 void LocalTreeProcUnlinkNodes::proc(MegaClient *, LocalNode *localnode)
 {
-    if (localnode->node)
-    {
-        localnode->node->localnode = NULL;
-        localnode->node = NULL;
-    }
+    localnode->node.reset();
 }
 
 #endif

--- a/tests/unit/Serialization_test.cpp
+++ b/tests/unit/Serialization_test.cpp
@@ -380,7 +380,7 @@ TEST(Serialization, LocalNode_forFolder_withoutParent_withoutNode)
     l.setfsid(10, client.cli->fsidnode);
     std::string data;
     ASSERT_TRUE(l.serialize(&data));
-#ifndef WIN32    
+#ifndef WIN32
     ASSERT_EQ(45u, data.size());
 #endif
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
@@ -453,7 +453,7 @@ TEST(Serialization, LocalNode_forFolder)
     l->parent_dbid = l->parent->dbid;
     auto& n = mt::makeNode(*client.cli, mega::FOLDERNODE, 42);
     l->setfsid(10, client.cli->fsidnode);
-    l->node = &n;
+    l->setnode(&n);
     std::string data;
     ASSERT_TRUE(l->serialize(&data));
 #ifndef WIN32

--- a/tests/unit/Serialization_test.cpp
+++ b/tests/unit/Serialization_test.cpp
@@ -384,6 +384,7 @@ TEST(Serialization, LocalNode_forFolder_withoutParent_withoutNode)
     ASSERT_EQ(45u, data.size());
 #endif
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, l);
 }
 
@@ -405,6 +406,7 @@ TEST(Serialization, LocalNode_forFile_withoutNode)
     ASSERT_EQ(65u, data.size());
 #endif
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 
@@ -425,6 +427,7 @@ TEST(Serialization, LocalNode_forFile_withoutNode_withMaxMtime)
     ASSERT_EQ(69u, data.size());
 #endif
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 
@@ -440,6 +443,7 @@ TEST(Serialization, LocalNode_forFolder_withoutParent)
     ASSERT_EQ(45u, data.size());
 #endif
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, l);
 }
 
@@ -460,6 +464,7 @@ TEST(Serialization, LocalNode_forFolder)
     ASSERT_EQ(44u, data.size());
 #endif
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 
@@ -474,7 +479,7 @@ TEST(Serialization, LocalNode_forFolder_32bit)
     l->parent_dbid = l->parent->dbid;
     auto& n = mt::makeNode(*client.cli, mega::FOLDERNODE, 42);
     l->setfsid(10, client.cli->fsidnode);
-    l->node = &n;
+    l->setnode(&n);
 
     // This is the result of serialization on 32bit Windows
     const std::array<unsigned char, 42> rawData = {
@@ -488,6 +493,7 @@ TEST(Serialization, LocalNode_forFolder_32bit)
     const std::string data(reinterpret_cast<const char*>(rawData.data()), rawData.size());
 
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 
@@ -500,7 +506,7 @@ TEST(Serialization, LocalNode_forFolder_oldLocalNodeWithoutSyncable)
     l->parent_dbid = l->parent->dbid;
     auto& n = mt::makeNode(*client.cli, mega::FOLDERNODE, 42);
     l->setfsid(10, client.cli->fsidnode);
-    l->node = &n;
+    l->setnode(&n);
 
     // This array represents an old LocalNode without extension bytes
     const std::array<unsigned char, 33> rawData = {
@@ -513,6 +519,7 @@ TEST(Serialization, LocalNode_forFolder_oldLocalNodeWithoutSyncable)
     const std::string data(reinterpret_cast<const char*>(rawData.data()), rawData.size());
 
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 
@@ -523,7 +530,7 @@ TEST(Serialization, LocalNode_forFile)
     auto l = mt::makeLocalNode(*sync, *sync->localroot, mega::FILENODE, "sweet");
     l->mSyncable = false;
     auto& n = mt::makeNode(*client.cli, mega::FILENODE, 42);
-    l->node = &n;
+    l->setnode(&n);
     l->size = 1;
     l->setfsid(10, client.cli->fsidnode);
     l->parent->dbid = 13;
@@ -534,6 +541,7 @@ TEST(Serialization, LocalNode_forFile)
     ASSERT_TRUE(l->serialize(&data));
     ASSERT_EQ(61u, data.size());
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 
@@ -543,7 +551,7 @@ TEST(Serialization, LocalNode_forFiles_oldLocalNodeWithoutSyncable)
     auto sync = mt::makeSync(*client.cli, "wicked");
     auto l = mt::makeLocalNode(*sync, *sync->localroot, mega::FILENODE, "sweet");
     auto& n = mt::makeNode(*client.cli, mega::FILENODE, 42);
-    l->node = &n;
+    l->setnode(&n);
     l->size = 1;
     l->setfsid(10, client.cli->fsidnode);
     l->parent->dbid = 13;
@@ -562,6 +570,7 @@ TEST(Serialization, LocalNode_forFiles_oldLocalNodeWithoutSyncable)
     const std::string data(rawData.data(), rawData.size());
 
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 
@@ -572,7 +581,7 @@ TEST(Serialization, LocalNode_forFile_32bit)
     auto l = mt::makeLocalNode(*sync, *sync->localroot, mega::FILENODE, "sweet");
     l->mSyncable = false;
     auto& n = mt::makeNode(*client.cli, mega::FILENODE, 42);
-    l->node = &n;
+    l->setnode(&n);
     l->size = 1;
     l->setfsid(10, client.cli->fsidnode);
     l->parent->dbid = 13;
@@ -591,6 +600,7 @@ TEST(Serialization, LocalNode_forFile_32bit)
     const std::string data(rawData.data(), rawData.size());
 
     std::unique_ptr<mega::LocalNode> dl{mega::LocalNode::unserialize(sync.get(), &data)};
+    dl->node.store_unchecked(nullptr); // deserialize breaks the crossref_ptr rules
     checkDeserializedLocalNode(*dl, *l);
 }
 #endif


### PR DESCRIPTION
…ting notifynode().

Careful analysis of the exact condition required shows a Node's localnode pointer must be dangling.
Reused the crossref_ptr class to ensure that Node and LocalNode pointers to each other are consistent and never dangle.