### PR TITLE
SDK-1298. Add new flag to MegaTransferPrivate

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -4154,6 +4154,13 @@ class MegaTransfer
         virtual bool isForeignOverquota() const;
 
         /**
+         * @brief Returns true if the transfer may force a new upload.
+         *
+         * @return true if the transfer can force a new upload.
+         */
+        virtual bool isForceNewUpload() const;
+
+        /**
          * @brief Returns true is this is a streaming transfer
          * @return true if this is a streaming transfer, false otherwise
          * @see MegaApi::startStreaming

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -705,7 +705,7 @@ class MegaTransferPrivate : public MegaTransfer, public Cacheable
         void setStartFirst(bool startFirst);
         void setBackupTransfer(bool backupTransfer);
         void setForeignOverquota(bool backupTransfer);
-        void setForceNewUpload(bool backupTransfer);
+        void setForceNewUpload(bool forceNewUpload);
         void setStreamingTransfer(bool streamingTransfer);
         void setLastBytes(char *lastBytes);
         void setLastError(const MegaError *e);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -705,6 +705,7 @@ class MegaTransferPrivate : public MegaTransfer, public Cacheable
         void setStartFirst(bool startFirst);
         void setBackupTransfer(bool backupTransfer);
         void setForeignOverquota(bool backupTransfer);
+        void setForceNewUpload(bool backupTransfer);
         void setStreamingTransfer(bool streamingTransfer);
         void setLastBytes(char *lastBytes);
         void setLastError(const MegaError *e);
@@ -746,6 +747,7 @@ class MegaTransferPrivate : public MegaTransfer, public Cacheable
         virtual bool shouldStartFirst() const;
         bool isBackupTransfer() const override;
         bool isForeignOverquota() const override;
+        bool isForceNewUpload() const override;
         char *getLastBytes() const override;
         MegaError getLastError() const override;
         const MegaError *getLastErrorExtended() const override;
@@ -787,6 +789,7 @@ protected:
             bool startFirst : 1;
             bool backupTransfer : 1;
             bool foreignOverquota : 1;
+            bool forceNewUpload : 1;
         };
 
         int64_t startTime;

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1215,6 +1215,11 @@ bool MegaTransfer::isForeignOverquota() const
     return false;
 }
 
+bool MegaTransfer::isForceNewUpload() const
+{
+    return false;
+}
+
 char *MegaTransfer::getLastBytes() const
 {
     return NULL;

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -2293,6 +2293,7 @@ MegaTransferPrivate::MegaTransferPrivate(const MegaTransferPrivate *transfer)
     this->setStartFirst(transfer->shouldStartFirst());
     this->setBackupTransfer(transfer->isBackupTransfer());
     this->setForeignOverquota(transfer->isForeignOverquota());
+    this->setForceNewUpload(transfer->isForceNewUpload());
     this->setLastError(transfer->lastError.get());
     this->setFolderTransferTag(transfer->getFolderTransferTag());
     this->setAppData(transfer->getAppData());
@@ -2377,6 +2378,11 @@ bool MegaTransferPrivate::isBackupTransfer() const
 bool MegaTransferPrivate::isForeignOverquota() const
 {
     return foreignOverquota;
+}
+
+bool MegaTransferPrivate::isForceNewUpload() const
+{
+    return forceNewUpload;
 }
 
 bool MegaTransferPrivate::isSourceFileTemporary() const
@@ -2792,6 +2798,11 @@ void MegaTransferPrivate::setBackupTransfer(bool backupTransfer)
 void MegaTransferPrivate::setForeignOverquota(bool foreignOverquota)
 {
     this->foreignOverquota = foreignOverquota;
+}
+
+void MegaTransferPrivate::setForceNewUpload(bool forceNewUpload)
+{
+    this->forceNewUpload = forceNewUpload;
 }
 
 void MegaTransferPrivate::setStreamingTransfer(bool streamingTransfer)
@@ -7607,7 +7618,7 @@ bool MegaApiImpl::hasToForceUpload(const Node &node, const MegaTransferPrivate &
     string name = node.displayname();
     LocalPath lp = LocalPath::fromPath(name, *client->fsaccess);
     bool isMedia = gfxAccess->isgfx(lp) || gfxAccess->isvideo(lp);
-    bool canForceUpload = transfer.isStreamingTransfer();
+    bool canForceUpload = transfer.isForceNewUpload();
     bool isPdf = name.find(".pdf") != string::npos;
 
     return canForceUpload && (isMedia || isPdf) && !(hasPreview && hasThumbnail);
@@ -8306,7 +8317,7 @@ void MegaApiImpl::startUpload(bool startFirst, const char *localPath, MegaNode *
         transfer->setFolderTransferTag(folderTransferTag);
     }
 
-    transfer->setStreamingTransfer(forceNewUpload);
+    transfer->setForceNewUpload(forceNewUpload);
 
     transferQueue.push(transfer);
     waiter->notify();
@@ -8456,7 +8467,7 @@ void MegaApiImpl::retryTransfer(MegaTransfer *transfer, MegaTransferListener *li
     {
         MegaNode *parent = getNodeByHandle(t->getParentHandle());
         startUpload(t->shouldStartFirst(), t->getPath(), parent, t->getFileName(), t->getTime(), 0,
-                          t->isBackupTransfer(), t->getAppData(), t->isSourceFileTemporary(), t->isStreamingTransfer(),
+                          t->isBackupTransfer(), t->getAppData(), t->isSourceFileTemporary(), t->isForceNewUpload(),
                           client->fsaccess->getlocalfstype(LocalPath::fromPath(t->getPath(), *fsAccess)), listener);
         delete parent;
     }


### PR DESCRIPTION
The `startChatForUpload()` used the flag for streaming, which should be in use only for downloads. However, there's generic code that takes into account that flag for downloads too. In result, transfers started with the aforementioned method cannot be cancelled and are returned by `MegaApi::getStreamingTransfers()`.

This commits adds a new flag to the transfers, so it can be used for this type of uploads without interference with streaming transfers.