### PR TITLE
SDK-1305 - Silence warnings and fix build.

### DIFF
--- a/examples/megasimplesync.cpp
+++ b/examples/megasimplesync.cpp
@@ -89,23 +89,23 @@ class SyncApp : public MegaApp, public Logger
     void request_error(error e);
 
 #ifdef ENABLE_SYNC
-    void syncupdate_state(Sync *, syncstate_t);
-    void syncupdate_local_folder_addition(Sync*, LocalNode*, const char *);
-    void syncupdate_local_folder_deletion(Sync*, LocalNode*);
-    void syncupdate_local_file_addition(Sync*, LocalNode*, const char *);
-    void syncupdate_local_file_deletion(Sync*, LocalNode*);
-    void syncupdate_local_file_change(Sync*, LocalNode*, const char *);
-    void syncupdate_local_move(Sync*, LocalNode*, const char*);
-    void syncupdate_get(Sync*, Node*, const char*);
-    void syncupdate_put(Sync*, LocalNode*, const char*);
-    void syncupdate_remote_file_addition(Sync*, Node*);
-    void syncupdate_remote_file_deletion(Sync*, Node*);
-    void syncupdate_remote_folder_addition(Sync*, Node*);
-    void syncupdate_remote_folder_deletion(Sync*, Node*);
-    void syncupdate_remote_copy(Sync*, const char*);
-    void syncupdate_remote_move(Sync*, Node*, Node*);
-    void syncupdate_remote_rename(Sync*sync, Node* n, const char* prevname);
-    void syncupdate_treestate(LocalNode*);
+    void syncupdate_state(int, syncstate_t state, SyncError, bool) override;
+    void syncupdate_local_folder_addition(Sync*, LocalNode*, const char *) override;
+    void syncupdate_local_folder_deletion(Sync*, LocalNode*) override;
+    void syncupdate_local_file_addition(Sync*, LocalNode*, const char *) override;
+    void syncupdate_local_file_deletion(Sync*, LocalNode*) override;
+    void syncupdate_local_file_change(Sync*, LocalNode*, const char *) override;
+    void syncupdate_local_move(Sync*, LocalNode*, const char*) override;
+    void syncupdate_get(Sync*, Node*, const char*) override;
+    void syncupdate_put(Sync*, LocalNode*, const char*) override;
+    void syncupdate_remote_file_addition(Sync*, Node*) override;
+    void syncupdate_remote_file_deletion(Sync*, Node*) override;
+    void syncupdate_remote_folder_addition(Sync*, Node*) override;
+    void syncupdate_remote_folder_deletion(Sync*, Node*) override;
+    void syncupdate_remote_copy(Sync*, const char*) override;
+    void syncupdate_remote_move(Sync*, Node*, Node*) override;
+    void syncupdate_remote_rename(Sync* sync, Node* n, const char* prevname) override;
+    void syncupdate_treestate(LocalNode*) override;
 #endif
 
     Node* nodebypath(const char* ptr, string* user, string* namepart);
@@ -476,7 +476,7 @@ void SyncApp::request_error(error e)
 }
 
 #ifdef ENABLE_SYNC
-void SyncApp::syncupdate_state(Sync*, syncstate_t state)
+void SyncApp::syncupdate_state(int, syncstate_t state, SyncError, bool)
 {
     if (( state == SYNC_CANCELED ) || ( state == SYNC_FAILED ))
     {

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -25,7 +25,7 @@
 #include "megaapi_impl.h"
 #include <algorithm>
 
-#if (__cplusplus > 201703L)
+#if (__cplusplus >= 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -43,7 +43,7 @@
 using namespace ::mega;
 using namespace ::std;
 
-#if (__cplusplus > 201703L)
+#if (__cplusplus >= 201703L)
     #include <filesystem>
     namespace fs = std::filesystem;
     #define USE_FILESYSTEM


### PR DESCRIPTION
- Fixes filesystem inclusion on MSVC.
- Silences generated when building megasimplesync.