### PR TITLE
fix memory leaks in recentActions and CameraUploads

### DIFF
--- a/bindings/ios/MEGABackgroundMediaUpload.mm
+++ b/bindings/ios/MEGABackgroundMediaUpload.mm
@@ -58,13 +58,21 @@
 }
 
 - (NSString *)encryptFileAtPath:(NSString *)inputFilePath startPosition:(int64_t)start length:(int64_t *)length outputFilePath:(NSString *)outputFilePath adjustsSizeOnly:(BOOL)adjustsSizeOnly {
-    const char *suffix = self.mediaUpload->encryptFile(inputFilePath.UTF8String, start, length, outputFilePath.UTF8String, adjustsSizeOnly);
-    return suffix == NULL ? nil : @(suffix);
+    const char *val = self.mediaUpload->encryptFile(inputFilePath.UTF8String, start, length, outputFilePath.UTF8String, adjustsSizeOnly);
+    NSString *suffix = val == NULL ? nil : @(val);
+    
+    delete [] val;
+    
+    return suffix;
 }
 
 - (NSString *)uploadURLString {
-    const char *urlString = self.mediaUpload->getUploadURL();
-    return urlString == NULL ? nil : @(urlString);
+    const char *val = self.mediaUpload->getUploadURL();
+    NSString *urlString = val == NULL ? nil : @(val);
+    
+    delete [] val;
+    
+    return urlString;
 }
 
 - (void)setCoordinatesWithLatitude:(double)latitude longitude:(double)longitude isUnshareable:(BOOL)unshareable {
@@ -73,7 +81,11 @@
 
 - (NSData *)serialize {
     const char *binary = self.mediaUpload->serialize();
-    return binary == NULL ? nil : [NSData dataWithBytes:binary length:strlen(binary)];
+    NSData *data = binary == NULL ? nil : [NSData dataWithBytes:binary length:strlen(binary)];
+    
+    delete [] binary;
+    
+    return data;
 }
 
 + (instancetype)unserializByData:(NSData *)data MEGASdk:(MEGASdk *)sdk {

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -2136,6 +2136,7 @@ using namespace mega;
     
     return [MEGANodeList.alloc initWithNodeList:self.megaApi->searchByType(node ? [node getCPtr] : NULL, searchString.UTF8String, cancelToken ? [cancelToken getCPtr] : NULL, recursive, (int)orderType, (int)nodeFormatType, (int)folderTargetType) cMemoryOwn:YES];
 }
+
 - (NSMutableArray *)recentActions {
     MegaRecentActionBucketList *megaRecentActionBucketList = self.megaApi->getRecentActions();
     int count = megaRecentActionBucketList->size();
@@ -2144,6 +2145,8 @@ using namespace mega;
         MEGARecentActionBucket *recentActionBucket = [MEGARecentActionBucket.alloc initWithMegaRecentActionBucket:megaRecentActionBucketList->get(i)->copy() cMemoryOwn:YES];
         [recentActionBucketMutableArray addObject:recentActionBucket];
     }
+    
+    delete megaRecentActionBucketList;
     
     return recentActionBucketMutableArray;
 }

--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -16080,6 +16080,8 @@ class MegaApi
          * This function uses the default parameters for the MEGA apps, which consider (currently)
          * interactions during the last 30 days and max 10.000 nodes.
          *
+         * You take the ownership of the returned value.
+         *
          * @return List of buckets containing nodes that were added/modifed as a set
          */
         MegaRecentActionBucketList* getRecentActions();


### PR DESCRIPTION
In iOS 5.4 build, we have detected big memory leaks in recent actions and some obvious small leaks in camera uploads. This PR is to fix the leaks.