### PR TITLE
SDK-1319 - Make sure current working directory is correctly sized.

### DIFF
--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -745,6 +745,8 @@ bool PosixFileSystemAccess::cwd(LocalPath& path) const
         buf.resize(buf.size() << 1);
     }
 
+    buf.resize(strlen(buf.c_str()));
+
     return true;
 }
 


### PR DESCRIPTION
The POSIX implementation of cwd(...) was returning an incorrectly sized path.

This PR addresses the problem by resizing the resulting path down to its computed size.