### PR TITLE
SDK-1326 - Update build_sdk.sh to work on ARM64.

### DIFF
--- a/contrib/build_sdk.sh
+++ b/contrib/build_sdk.sh
@@ -845,7 +845,7 @@ freeimage_pkg() {
     fi
 
     # freeimage's LibPNG has a problem with deciding to use neon on 64 bit arm, resulting in a missing symbol
-    if [ "$ARCH" == "aarch64" ]; then
+    if [ "$ARCH" == "aarch64" -o "$ARCH" == "arm64" ]; then
         export CFLAGS="$CFLAGS -DPNG_ARM_NEON_OPT=0"
     fi 
 


### PR DESCRIPTION
In order to build the SDK correctly, we need to disable NEON optimizations on 64bit ARM platforms.

Prior to this change set, we only disabled those optimizations for the AArch64 architecture. This, unfortunately, does not cover 64bit ARM architectures that report themselves as ARM64.

This update is necessary for us to build the SDK for Synology DSM 7.0.