### PR TITLE
iOS CU Heartbeat - add being logout notification to iOS binding

### DIFF
--- a/bindings/ios/MEGASdk.h
+++ b/bindings/ios/MEGASdk.h
@@ -51,6 +51,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * @brief MEGAIsBeingLogoutNotification will be published before app starts logout.
+ */
+extern NSString * const MEGAIsBeingLogoutNotification;
+
 typedef uint64_t MEGAHandle;
 
 typedef NS_ENUM (NSInteger, MEGASortOrderType) {

--- a/bindings/ios/MEGASdk.mm
+++ b/bindings/ios/MEGASdk.mm
@@ -49,6 +49,8 @@
 #import <set>
 #import <pthread.h>
 
+NSString * const MEGAIsBeingLogoutNotification = @"nz.mega.isBeingLogout";
+
 using namespace mega;
 
 @interface MEGASdk () {
@@ -587,10 +589,12 @@ using namespace mega;
 }
 
 - (void)logoutWithDelegate:(id<MEGARequestDelegate>)delegate {
+    [NSNotificationCenter.defaultCenter postNotificationName:MEGAIsBeingLogoutNotification object:nil];
     self.megaApi->logout([self createDelegateMEGARequestListener:delegate singleListener:YES]);
 }
 
 - (void)logout {
+    [NSNotificationCenter.defaultCenter postNotificationName:MEGAIsBeingLogoutNotification object:nil];
     self.megaApi->logout();
 }
 


### PR DESCRIPTION
Add being logout notification so we can have a chance to remove backup registration before logout. 
- If we call remove backup after logout, it returns error `Bad session id` - `API_ESID`
- If we call remove backup when logout request starts, it will return error `Access Denied` - `API_EACCESS`

So the solution is post a notification before we start logout.