### PR TITLE
SDK-1343. Limit logger archived file number

### DIFF
--- a/src/rotativeperformancelogger.cpp
+++ b/src/rotativeperformancelogger.cpp
@@ -352,7 +352,6 @@ private:
 
             for (auto &archivedTimestampsPathPair : archivedTimestampsPathPairs)
             {
-                if (extraFileNumber <= 0) break;
                 LocalPath& leafNameFullPathToDelete = archivedTimestampsPathPair.second;
                 if (!mFsAccess->unlinklocal(leafNameFullPathToDelete))
                 {
@@ -360,7 +359,7 @@ private:
                 }
                 else
                 {
-                    --extraFileNumber;
+                    if (--extraFileNumber <= 0) break;
                 }
             }
         }

--- a/src/rotativeperformancelogger.cpp
+++ b/src/rotativeperformancelogger.cpp
@@ -350,7 +350,8 @@ private:
                 }
             );
 
-            for (auto archivedTimestampsPathPair : archivedTimestampsPathPairs) {
+            for (auto &archivedTimestampsPathPair : archivedTimestampsPathPairs)
+            {
                 if (extraFileNumber <= 0) break;
                 LocalPath& leafNameFullPathToDelete = archivedTimestampsPathPair.second;
                 if (!mFsAccess->unlinklocal(leafNameFullPathToDelete))


### PR DESCRIPTION
Rotative performance logger can be configured to use timestamps as suffix for archived zipped logs, and a maximum age for archived files. But no size limit applies.

With this PR we will ensure that a maximum number of archived files are stored too, thus limiting archvie size.