### PR TITLE
iOS Binding - fix the node access crash when the index is out of bounds

### DIFF
--- a/bindings/ios/MEGANodeList.mm
+++ b/bindings/ios/MEGANodeList.mm
@@ -75,7 +75,16 @@ using namespace mega;
 }
 
 - (MEGANode *)nodeAtIndex:(NSInteger)index {
-    return  self.nodeList ? [[MEGANode alloc] initWithMegaNode:self.nodeList->get((int)index)->copy() cMemoryOwn:YES] : nil;
+    if (self.nodeList == NULL) {
+        return nil;
+    }
+
+    MegaNode *node = self.nodeList->get((int)index);
+    if (node) {
+        return [[MEGANode alloc] initWithMegaNode:node->copy() cMemoryOwn:YES];
+    } else {
+        return nil;
+    }
 }
 
 - (NSNumber *)size {


### PR DESCRIPTION
Crashlytics: https://console.firebase.google.com/u/0/project/mega-prod-ae8e1/crashlytics/app/ios:mega.ios/issues/2b4860458104663e8b2981e33fa2862b?time=last-seven-days&sessionEventKey=533b2493b09a4244a3b32028ddbc6775_1489986620796869560