### PR TITLE
iOS Binding: fix the file handle crash by catching the exception

### DIFF
--- a/bindings/ios/Private/MEGAFileInputStream.mm
+++ b/bindings/ios/Private/MEGAFileInputStream.mm
@@ -41,11 +41,15 @@ bool MEGAFileInputStream::read(char *buffer, size_t size) {
         return false;
     }
     
-    if (buffer == NULL) {
-        [this->fileHandle seekToFileOffset:currentOffset + size];
+    @try {
+        if (buffer == NULL) {
+            [this->fileHandle seekToFileOffset:currentOffset + size];
+            return true;
+        }
+        
+        memcpy(buffer, [this->fileHandle readDataOfLength:size].bytes, size);
         return true;
+    } @catch (NSException *exception) {
+        return false;
     }
-    
-    memcpy(buffer, [this->fileHandle readDataOfLength:size].bytes, size);
-    return true;
 }


### PR DESCRIPTION
fix crash: https://console.firebase.google.com/u/0/project/mega-prod-ae8e1/crashlytics/app/ios:mega.ios/issues/72a66bdee67b99bd6ddb84d7d4c4bc25?time=last-thirty-days&sessionEventKey=8ab3dcf59e2c40e7a3941358f9fbb21c_1489948180463587810