### PR TITLE
SDK-1345. Enable session resume for writable folder links.

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -1156,18 +1156,14 @@ void DemoApp::fetchnodes_result(const Error& e)
     else
     {
         // check if we fetched a folder link and the key is invalid
-        handle h = client->getrootpublicfolder();
-        if (h != UNDEF)
+        if (client->isValidFolderLink())
         {
-            Node *n = client->nodebyhandle(h);
-            if (n && (n->attrs.map.find('n') == n->attrs.map.end()))
-            {
-                cout << "File/folder retrieval succeed, but encryption key is wrong." << endl;
-            }
-            else
-            {
-                cout << "Folder link loaded correctly." << endl;
-            }
+            cout << "Folder link loaded correctly." << endl;
+        }
+        else
+        {
+            assert(client->nodebyhandle(client->rootnodes[0]));   // node is there, but cannot be decrypted
+            cout << "File/folder retrieval succeed, but encryption key is wrong." << endl;
         }
 
         if (pdf_to_import)
@@ -3969,7 +3965,7 @@ void exec_get(autocomplete::ACState& s)
                     // node from public folder link
                     if (index != string::npos && s.words[1].s.substr(0, index).find("@") == string::npos)
                     {
-                        handle h = clientFolder->getrootpublicfolder();
+                        handle h = clientFolder->rootnodes[0];
                         char *pubauth = new char[12];
                         Base64::btoa((byte*)&h, MegaClient::NODEHANDLE, pubauth);
                         f->pubauth = pubauth;
@@ -8222,14 +8218,9 @@ void DemoAppFolder::fetchnodes_result(const Error& e)
     else
     {
         // check if we fetched a folder link and the key is invalid
-        handle h = clientFolder->getrootpublicfolder();
-        if (h != UNDEF)
+        if (clientFolder->isValidFolderLink())
         {
-            Node *n = clientFolder->nodebyhandle(h);
-            if (n && (n->attrs.map.find('n') == n->attrs.map.end()))
-            {
-                cout << "File/folder retrieval succeed, but encryption key is wrong." << endl;
-            }
+            cout << "File/folder retrieval succeed, but encryption key is wrong." << endl;
         }
         else
         {

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -335,7 +335,7 @@ public:
     void fastlogin(const char*, const byte*, uint64_t);
 
     // session login: binary session, bytecount
-    void login(const byte*, int);
+    void login(string session);
 
     // check password
     error validatepwd(const byte *);
@@ -365,7 +365,7 @@ public:
     void unblock();
 
     // dump current session
-    int dumpsession(byte*, size_t);
+    int dumpsession(string&);
 
     // create a copy of the current session
     void copysession();
@@ -388,8 +388,11 @@ public:
     // extract public handle and key from a public file/folder link
     error parsepubliclink(const char *link, handle &ph, byte *key, bool isFolderLink);
 
+    // open the SC database and get the SCSN from it
+    void checkForResumeableSCDatabase();
+
     // set folder link: node, key. authKey is the authentication key to be able to write into the folder
-    error folderaccess(const char*folderlink, const char *authKey);
+    error folderaccess(const char*folderlink, const char* authKey);
 
     // open exported file link (op=0 -> download, op=1 fetch data)
     void openfilelink(handle ph, const byte *key, int op);
@@ -951,6 +954,9 @@ public:
     // backoff for the expiration of cached user data
     BackoffTimer btugexpiration;
 
+    // if logged into public folder (which might optionally be writable)
+    bool loggedIntoFolder() const;
+
     // if logged into writable folder
     bool loggedIntoWritableFolder() const;
 
@@ -975,9 +981,6 @@ private:
 
     bool pendingscTimedOut = false;
 
-    // if logged into writable folder
-    bool mLoggedIntoWritableFolder = false;
-
     // badhost report
     HttpReq* badhostcs;
 
@@ -996,8 +999,11 @@ private:
     // lang URI component for API requests
     string lang;
 
-    // public handle being used
+    // public handle being used (logged into public folder, read-only or writable)
     handle publichandle;
+
+    // when logged into a public folder, this auth string enables writing
+    string publichandleWriteAuth;
 
     // API response JSON object
     JSON response;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -933,9 +933,6 @@ public:
     // root URL for chat stats
     static string CHATSTATSURL;
 
-    // account auth for public folders
-    string accountauth;
-
     // file that is blocking the sync engine
     LocalPath blockedfile;
 
@@ -993,17 +990,20 @@ private:
     // unique request ID
     char reqid[10];
 
-    // auth URI component for API requests
-    string auth;
-
     // lang URI component for API requests
     string lang;
 
-    // public handle being used (logged into public folder, read-only or writable)
-    handle publichandle;
+    struct FolderLink {
+        // public handle of the folder link ('&n=' param in the POST)
+        handle mPublicHandle = UNDEF;
 
-    // when logged into a public folder, this auth string enables writing
-    string publichandleWriteAuth;
+        // auth token that enables writing into the folder link (appended to the `n` param in POST)
+        string mWriteAuth;      // (optional, only for writable links)
+
+        // auth token that relates the usage of the folder link to a user's session id ('&sid=' param in the POST)
+        string mAccountAuth;    // (optional, set by the app)
+    };
+    FolderLink mFolderLink;
 
     // API response JSON object
     JSON response;
@@ -1699,17 +1699,19 @@ public:
     static void stringhash(const char*, byte*, SymmCipher*);
     static uint64_t stringhash64(string*, SymmCipher*);
 
-    // set authentication context, either a session ID or a exported folder node handle
-    void setsid(const byte*, unsigned);
-    void setrootnode(handle, const char *authKey = nullptr);
+    // builds the authentication URI to be sent in POST requests
+    string getAuthURI(bool supressSID = false);
 
     bool setlang(string *code);
 
-    // returns the handle of the root node if the account is logged into a public folder, otherwise UNDEF.
-    handle getrootpublicfolder();
+    // sets the auth token to be used when logged into a folder link
+    void setFolderLinkAccountAuth(const char *auth);
 
     // returns the public handle of the folder link if the account is logged into a public folder, otherwise UNDEF.
-    handle getpublicfolderhandle();
+    handle getFolderLinkPublicHandle();
+
+    // check if there is a valid folder link (rootnode received and the valid key)
+    bool isValidFolderLink();
 
     //returns the top-level node for a node
     Node *getrootnode(Node*);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -2808,8 +2808,6 @@ class MegaApiImpl : public MegaApp
         bool tryLockMutexFor(long long time);
 
 protected:
-        static const unsigned int MAX_SESSION_LENGTH;
-
         void init(MegaApi *api, const char *appKey, MegaGfxProcessor* processor, const char *basePath /*= NULL*/, const char *userAgent /*= NULL*/, int fseventsfd /*= -1*/, unsigned clientWorkerThreadCount /*= 1*/);
 
         static void *threadEntryPoint(void *param);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1804,7 +1804,7 @@ bool CommandLogin::procresult(Result r)
 
                 if (len_tsid)
                 {
-                    client->setsid(sidbuf, MegaClient::SIDLEN);
+                    client->sid.assign((const char *)sidbuf, MegaClient::SIDLEN);
 
                     // account does not have an RSA keypair set: verify
                     // password using symmetric challenge
@@ -1866,7 +1866,7 @@ bool CommandLogin::procresult(Result r)
                             return true;
                         }
 
-                        client->setsid(sidbuf, MegaClient::SIDLEN);
+                        client->sid.assign((const char *)sidbuf, MegaClient::SIDLEN);
                     }
                 }
 
@@ -5128,7 +5128,7 @@ bool CommandResumeEphemeralSession::procresult(Result r)
                     return false;
                 }
 
-                client->setsid(sidbuf, sizeof sidbuf);
+                client->sid.assign((const char *)sidbuf, sizeof sidbuf);
 
                 client->key.setkey(pw);
                 client->key.ecb_decrypt(keybuf);

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -1006,9 +1006,6 @@ const char* MegaNodePrivate::getDeviceId() const
     return mDeviceId.c_str();
 }
 
-const unsigned int MegaApiImpl::MAX_SESSION_LENGTH = 64;
-
-
 MegaBackgroundMediaUploadPrivate::MegaBackgroundMediaUploadPrivate(MegaApi* capi)
     : api(MegaApiImpl::ImplOf(capi))
 {
@@ -6205,45 +6202,29 @@ void MegaApiImpl::login(const char *login, const char *password, MegaRequestList
 
 char *MegaApiImpl::dumpSession()
 {
-    sdkMutex.lock();
-    byte session[MAX_SESSION_LENGTH];
-    char* buf = NULL;
-    int size;
-    size = client->dumpsession(session, sizeof session);
-    if (size > 0)
+    SdkMutexGuard g(sdkMutex);
+    string session;
+    if (client->dumpsession(session))
     {
-        buf = new char[sizeof(session) * 4 / 3 + 4];
-        Base64::btoa(session, size, buf);
+        return MegaApi::strdup(Base64::btoa(session).c_str());
     }
-
-    sdkMutex.unlock();
-    return buf;
+    return nullptr;
 }
 
 char *MegaApiImpl::getSequenceNumber()
 {
-    sdkMutex.lock();
-
-    char *scsn = MegaApi::strdup(client->scsn.text());
-
-    sdkMutex.unlock();
-
-    return scsn;
+    SdkMutexGuard g(sdkMutex);
+    return MegaApi::strdup(client->scsn.text());
 }
 
 char *MegaApiImpl::getAccountAuth()
 {
-    sdkMutex.lock();
-    char* buf = NULL;
-
+    SdkMutexGuard g(sdkMutex);
     if (client->loggedin())
     {
-        buf = new char[MAX_SESSION_LENGTH * 4 / 3 + 4];
-        Base64::btoa((const byte *)client->sid.data(), int(client->sid.size()), buf);
+        return MegaApi::strdup(Base64::btoa(client->sid).c_str());
     }
-
-    sdkMutex.unlock();
-    return buf;
+    return nullptr;
 }
 
 void MegaApiImpl::setAccountAuth(const char *auth)
@@ -11762,7 +11743,7 @@ MegaNodeList* MegaApiImpl::search(MegaNode *n, const char* searchString, MegaCan
     {
         return new MegaNodeListPrivate();
     }
-    
+
     MegaNodeList *nodeList = nullptr;
     if (n)
     {
@@ -15659,7 +15640,7 @@ void MegaApiImpl::getua_result(TLVstore *tlv, attr_t type)
                 request->setName(Base64::atob(buf).c_str());
                 break;
             }
- 
+
             default:
                 break;
         }
@@ -19344,9 +19325,7 @@ void MegaApiImpl::sendPendingRequests()
             client->locallogout(false);
             if (sessionKey)
             {
-                byte session[MAX_SESSION_LENGTH];
-                int size = Base64::atob(sessionKey, (byte *)session, sizeof session);
-                client->login(session, size);
+                client->login(Base64::atob(string(sessionKey)));
             }
             else if (login && (base64pwkey || password) && !megaFolderLink)
             {
@@ -23243,9 +23222,9 @@ void MegaApiImpl::sendPendingRequests()
                 }
 
                 client->reqs.add(new CommandBackupPut(client,
-                                                      (MegaHandle)request->getParentHandle(), 
+                                                      (MegaHandle)request->getParentHandle(),
                                                       bType,
-                                                      request->getNodeHandle(), 
+                                                      request->getNodeHandle(),
                                                       localFolderEncrypted.empty() ? nullptr : localFolderEncrypted.c_str(),
                                                       client->getDeviceidHash().c_str(),
                                                       request->getAccess(),
@@ -23261,13 +23240,13 @@ void MegaApiImpl::sendPendingRequests()
         }
         case MegaRequest::TYPE_BACKUP_PUT_HEART_BEAT:
         {
-            client->reqs.add(new CommandBackupPutHeartBeat(client, 
-                                                           (MegaHandle)request->getParentHandle(), 
+            client->reqs.add(new CommandBackupPutHeartBeat(client,
+                                                           (MegaHandle)request->getParentHandle(),
                                                            (uint8_t)request->getAccess(),
                                                            (uint8_t)request->getNumDetails(),
                                                            (uint32_t)request->getParamType(),
                                                            (uint32_t)request->getTransferTag(),
-                                                           request->getNumber(), 
+                                                           request->getNumber(),
                                                            request->getNodeHandle()));
             break;
         }

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -6229,22 +6229,9 @@ char *MegaApiImpl::getAccountAuth()
 
 void MegaApiImpl::setAccountAuth(const char *auth)
 {
-    sdkMutex.lock();
-    if (!auth)
-    {
-        client->accountauth.clear();
-    }
-    else
-    {
-        client->accountauth = auth;
-    }
+    SdkMutexGuard g(sdkMutex);
 
-    handle h = client->getrootpublicfolder();
-    if (h != UNDEF)
-    {
-        client->setrootnode(h);
-    }
-    sdkMutex.unlock();
+    client->setFolderLinkAccountAuth(auth);
 }
 
 void MegaApiImpl::createAccount(const char* email, const char* password, const char* firstname, const char* lastname, MegaHandle lastPublicHandle, int lastPublicHandleType, int64_t lastAccessTimestamp, MegaRequestListener *listener)
@@ -11287,7 +11274,7 @@ void MegaApiImpl::authorizeMegaNodePrivate(MegaNodePrivate *node)
         }
         else
         {
-            h = MegaApiImpl::handleToBase64(client->getrootpublicfolder());
+            h = MegaApiImpl::handleToBase64(client->rootnodes[0]);
             node->setPublicAuth(h);
         }
         delete [] h;
@@ -13810,16 +13797,12 @@ void MegaApiImpl::fetchnodes_result(const Error &e)
 
         if (e == API_OK)
         {
-            // check if we fetched a folder link and the key is invalid
-            handle h = client->getrootpublicfolder();
-            if (h != UNDEF)
+            assert(!ISUNDEF(client->rootnodes[0]));    // is folder link fetched properly?
+
+            request->setNodeHandle(client->getFolderLinkPublicHandle());
+            if (client->isValidFolderLink())    // is the key for the folder link valid?
             {
-                request->setNodeHandle(client->getpublicfolderhandle());
-                Node *n = client->nodebyhandle(h);
-                if (n && (n->attrs.map.find('n') == n->attrs.map.end()))
-                {
-                    request->setFlag(true);
-                }
+                request->setFlag(true);
             }
         }
 
@@ -13848,16 +13831,12 @@ void MegaApiImpl::fetchnodes_result(const Error &e)
     {
         if (e == API_OK)
         {
-            // check if we fetched a folder link and the key is invalid
-            handle h = client->getrootpublicfolder();
-            if (h != UNDEF)
+            assert(!ISUNDEF(client->rootnodes[0]));    // is folder link fetched properly?
+
+            request->setNodeHandle(client->getFolderLinkPublicHandle());
+            if (client->isValidFolderLink())    // is the key for the folder link valid?
             {
-                request->setNodeHandle(client->getpublicfolderhandle());
-                Node *n = client->nodebyhandle(h);
-                if (n && (n->attrs.map.find('n') == n->attrs.map.end()))
-                {
-                    request->setFlag(true);
-                }
+                request->setFlag(true);
             }
         }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -8248,7 +8248,7 @@ int MegaClient::readnodes(JSON* j, int notify, putsource_t source, vector<NewNod
                 Node::copystring(n->attrstring.get(), a);
                 n->setkeyfromjson(k);
 
-                // folder link access: first returned record defines root node and identity 
+                // folder link access: first returned record defines root node and identity
 				// (this code used to be in Node::Node but is not suitable for session resume)
                 if (ISUNDEF(*rootnodes))
                 {
@@ -9254,12 +9254,12 @@ int MegaClient::dumpsession(string& session)
             SymmCipher cipher;
             cipher.setkey((const byte *)sessionkey.data(), int(sessionkey.size()));
             cipher.ecb_encrypt(key.key, k);
-            memcpy(session.data()+1, k, sizeof k);
+            memcpy(const_cast<char*>(session.data())+1, k, sizeof k);
         }
         else
         {
             session.resize(sizeof key.key);
-            memcpy(session.data(), key.key, sizeof key.key);
+            memcpy(const_cast<char*>(session.data()), key.key, sizeof key.key);
         }
 
         session.append(sid.data(), sid.size());

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -75,20 +75,6 @@ Node::Node(MegaClient* cclient, node_vector* dp, handle h, handle ph,
 
     client->nodes[h] = this;
 
-    // folder link access: first returned record defines root node and
-    // identity
-    if (ISUNDEF(*client->rootnodes))
-    {
-        *client->rootnodes = h;
-
-        if (client->loggedIntoWritableFolder())
-        {
-            // If logged into writable folder, we need the sharekey set in the root node
-            // so as to include it in subsequent put nodes
-            sharekey = new SymmCipher(client->key); //we use the "master key", in this case the secret share key
-        }
-    }
-
     if (t >= ROOTNODE && t <= RUBBISHNODE)
     {
         client->rootnodes[t - ROOTNODE] = h;

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1029,7 +1029,7 @@ struct StandardClient : public MegaApp
     void loginFromSession(const string& session, promise<bool>& pb)
     {
         resultproc.prepresult(LOGIN, ++next_request_tag,
-            [&](){ client.login((byte*)session.data(), (int)session.size()); },
+            [&](){ client.login(session); },
             [&pb](error e) { pb.set_value(!e);  return true; });
     }
 
@@ -3015,8 +3015,8 @@ GTEST_TEST(Sync, BasicSync_RemoveLocalNodeBeforeSessionResume)
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
 
     // save session
-    ::mega::byte session[64];
-    int sessionsize = pclientA1->client.dumpsession(session, sizeof session);
+    string session;
+    pclientA1->client.dumpsession(session);
 
     // logout (but keep caches)
     fs::path sync1path = pclientA1->syncSet(1).localpath;
@@ -3028,7 +3028,7 @@ GTEST_TEST(Sync, BasicSync_RemoveLocalNodeBeforeSessionResume)
 
     // resume session, see if nodes and localnodes get in sync
     pclientA1.reset(new StandardClient(localtestroot, "clientA1"));
-    ASSERT_TRUE(pclientA1->login_fetchnodes(string((char*)session, sessionsize)));
+    ASSERT_TRUE(pclientA1->login_fetchnodes(session));
 
     waitonsyncs(std::chrono::seconds(4), pclientA1.get(), &clientA2);
 
@@ -3132,8 +3132,8 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterNonclashingLocalAndRemoteCh
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model2.findnode("f"), 2));
 
     out() << "********************* save session A1" << endl;
-    ::mega::byte session[64];
-    int sessionsize = pclientA1->client.dumpsession(session, sizeof session);
+    string session;
+    pclientA1->client.dumpsession(session);
 
     out() << "*********************  logout A1 (but keep caches on disk)" << endl;
     fs::path sync1path = pclientA1->syncSet(1).localpath;
@@ -3167,7 +3167,7 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterNonclashingLocalAndRemoteCh
 
     out() << "*********************  resume A1 session (with sync), see if A2 nodes and localnodes get in sync again" << endl;
     pclientA1.reset(new StandardClient(localtestroot, "clientA1"));
-    ASSERT_TRUE(pclientA1->login_fetchnodes(string((char*)session, sessionsize)));
+    ASSERT_TRUE(pclientA1->login_fetchnodes(session));
     ASSERT_EQ(pclientA1->basefolderhandle, clientA2.basefolderhandle);
     waitonsyncs(DEFAULTWAIT, pclientA1.get(), &clientA2);
 
@@ -3201,8 +3201,8 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterClashingLocalAddRemoteDelet
     ASSERT_TRUE(clientA2.confirmModel_mainthread(model.findnode("f"), 2));
 
     // save session A1
-    ::mega::byte session[64];
-    int sessionsize = pclientA1->client.dumpsession(session, sizeof session);
+    string session;
+    pclientA1->client.dumpsession(session);
     fs::path sync1path = pclientA1->syncSet(1).localpath;
 
     // logout A1 (but keep caches on disk)
@@ -3220,7 +3220,7 @@ GTEST_TEST(Sync, BasicSync_ResumeSyncFromSessionAfterClashingLocalAddRemoteDelet
 
     // resume A1 session (with sync), see if A2 nodes and localnodes get in sync again
     pclientA1.reset(new StandardClient(localtestroot, "clientA1"));
-    ASSERT_TRUE(pclientA1->login_fetchnodes(string((char*)session, sessionsize)));
+    ASSERT_TRUE(pclientA1->login_fetchnodes(session));
     ASSERT_EQ(pclientA1->basefolderhandle, clientA2.basefolderhandle);
     waitonsyncs(std::chrono::seconds(10), pclientA1.get(), &clientA2);
 
@@ -4561,9 +4561,8 @@ TEST(Sync, TwoWay_Highlevel_Symmetries)
     }
 
     // save session and local log out A1R to set up for resume
-    ::mega::byte session[64];
-    int sessionsize = 0;
-    sessionsize = clientA1Resume.client.dumpsession(session, sizeof session);
+    string session;
+    clientA1Resume.client.dumpsession(session);
     clientA1Resume.localLogout();
 
     int paused = 0;
@@ -4589,7 +4588,7 @@ TEST(Sync, TwoWay_Highlevel_Symmetries)
     CatchupClients(&clientA1Steady, &clientA2);
 
     // resume A1R session (with sync), see if A2 nodes and localnodes get in sync again
-    ASSERT_TRUE(clientA1Resume.login_fetchnodes(string((char*)session, sessionsize)));
+    ASSERT_TRUE(clientA1Resume.login_fetchnodes(session));
     ASSERT_EQ(clientA1Resume.basefolderhandle, clientA2.basefolderhandle);
 
     int resumed = 0;


### PR DESCRIPTION
Session resume is also enabled for read-only folder links.
Resuming means we can load the locally cached node database instead of re-requesting from the server, just like a normal account
Of course for folder links it's not really using a session id, but follows the pattern of calling dumpsession() and re-login with the output of that.