### PR TITLE
SDK-1354 - Misc. helpers.

### DIFF
--- a/include/mega/base64.h
+++ b/include/mega/base64.h
@@ -77,6 +77,14 @@ struct Base64Str
     {
         return chars;
     }
+    const byte* bytes() const
+    {
+        return reinterpret_cast<const byte*>(chars);
+    }
+    unsigned int size() const
+    {
+        return STRLEN;
+    }
 };
 
 // lowercase base32 encoding

--- a/include/mega/crypto/cryptopp.h
+++ b/include/mega/crypto/cryptopp.h
@@ -158,16 +158,50 @@ public:
     void cbc_encrypt_pkcs_padding(const std::string *data, const byte* iv, std::string *result);
 
     /**
-     * @brief Decrypt symmetrically using AES in CBC mode and pkcs padding
+     * @brief
+     * Decrypt symmetrically using AES in CBC mode and pkcs padding
      *
      * The size of the IV is one block in AES-128 (16 bytes).
      *
-     * @param data Data to be decrypted
-     * @param iv Initialisation vector.
-     * @param result Decrypted message
-     * @return Void.
+     * @param data
+     * Data to be decrypted
+     *
+     * @param iv
+     * Initialisation vector.
+     *
+     * @param result
+     * Where we should write the decrypted message.
+     *
+     * @return
+     * True if decryption was successful.
      */
-    void cbc_decrypt_pkcs_padding(const std::string *data, const byte* iv, std::string *result);
+    bool cbc_decrypt_pkcs_padding(const std::string* data, const byte* iv, std::string* result);
+
+    /**
+     * @brief
+     * Decrypt symmetrically using AES in CBC mode and pkcs padding
+     *
+     * The size of the IV is one block in AES-128 (16 bytes).
+     *
+     * @param data
+     * Data to be decrypted
+     *
+     * @param dataLength
+     * Length of data to be decryped.
+     *
+     * @param iv
+     * Initialisation vector.
+     *
+     * @param result
+     * Where we should write the decrypted message.
+     *
+     * @return
+     * True if decryption was successful.
+     */
+    bool cbc_decrypt_pkcs_padding(const byte* data,
+                                  const size_t dataLength,
+                                  const byte* iv,
+                                  std::string* result);
 
     /**
      * Authenticated symmetric encryption using AES in CCM mode (counter with CBC-MAC).
@@ -422,6 +456,7 @@ public:
      * @param length Key length
      */
     HMACSHA256(const byte *key, size_t length);
+    HMACSHA256();
 
     /**
      * @brief Add data to the HMAC
@@ -435,10 +470,22 @@ public:
      * @param out The HMAC-SHA256 will be returned in the first 32 bytes of this buffer
      */
     void get(byte *out);
+
+    /**
+     * @brief
+     * Set the HMAC's key.
+     *
+     * @param key
+     * HMAC key.
+     *
+     * @param length
+     * Length of HMAC key.
+     */
+    void setkey(const byte* key, const size_t length);
 };
 
 /**
- * @brief HMAC-SHA512 generator
+ * @brief PBKDF2 HMAC-SHA512 Key Derivation Function.
  */
 class MEGA_API PBKDF2_HMAC_SHA512
 {
@@ -446,9 +493,14 @@ class MEGA_API PBKDF2_HMAC_SHA512
 
 public:
     PBKDF2_HMAC_SHA512();
-    void deriveKey(byte* derivedkey, size_t derivedkeyLen,
-                   byte* pwd, size_t pwdLen,
-                   byte* salt, size_t saltLen, unsigned int iterations);
+
+    void deriveKey(byte* derivedkey,
+                   const size_t derivedkeyLen,
+                   const byte* pwd,
+                   const size_t pwdLen,
+                   const byte* salt,
+                   const size_t saltLen,
+                   const unsigned int iterations) const;
 };
 
 } // namespace

--- a/include/mega/db.h
+++ b/include/mega/db.h
@@ -170,6 +170,8 @@ struct MEGA_API DbAccess
 
     virtual bool probe(FileSystemAccess& fsAccess, const string& name) const = 0;
 
+    virtual const LocalPath& rootPath() const = 0;
+
     int currentDbVersion;
 };
 

--- a/include/mega/db/sqlite.h
+++ b/include/mega/db/sqlite.h
@@ -38,6 +38,8 @@ public:
     DbTable* open(PrnGen &rng, FileSystemAccess& fsAccess, const string& name, const int flags) override;
 
     bool probe(FileSystemAccess& fsAccess, const string& name) const override;
+
+    const LocalPath& rootPath() const override;
 };
 
 class MEGA_API SqliteDbTable : public DbTable

--- a/include/mega/filesystem.h
+++ b/include/mega/filesystem.h
@@ -88,6 +88,8 @@ class MEGA_API LocalPath
     friend class PosixDirNotify;
     friend class WinFileAccess;
     friend class PosixFileAccess;
+    friend LocalPath NormalizeAbsolute(const LocalPath& path);
+    friend LocalPath NormalizeRelative(const LocalPath& path);
     friend void RemoveHiddenFileAttribute(LocalPath& path);
     friend void AddHiddenFileAttribute(LocalPath& path);
     friend class GfxProcFreeImage;
@@ -180,6 +182,30 @@ public:
 
 void AddHiddenFileAttribute(mega::LocalPath& path);
 void RemoveHiddenFileAttribute(mega::LocalPath& path);
+
+/**
+ * @brief
+ * Ensures that a path does not end with a separator.
+ *
+ * @param path
+ * An absolute path to normalize.
+ *
+ * @return
+ * A normalized path.
+ */
+LocalPath NormalizeAbsolute(const LocalPath& path);
+
+/**
+ * @brief
+ * Ensures that a path does not begin or end with a separator.
+ *
+ * @param path
+ * A relative path to normalize.
+ *
+ * @return
+ * A normalized path.
+ */
+LocalPath NormalizeRelative(const LocalPath& path);
 
 inline LocalPath operator+(LocalPath& a, LocalPath& b)
 {
@@ -292,6 +318,9 @@ struct MEGA_API FileAccess
 
     // absolute position write
     virtual bool fwrite(const byte *, unsigned, m_off_t) = 0;
+
+    // Truncate a file.
+    virtual bool ftruncate() = 0;
 
     FileAccess(Waiter *waiter);
     virtual ~FileAccess();
@@ -430,6 +459,8 @@ public:
 
     DirNotify(const LocalPath&, const LocalPath&);
     virtual ~DirNotify() {}
+
+    bool empty();
 };
 
 // generic host filesystem access interface
@@ -564,6 +595,12 @@ int compareUtf(const string&, bool unescaping1, const string&, bool unescaping2,
 int compareUtf(const string&, bool unescaping1, const LocalPath&, bool unescaping2, bool caseInsensitive);
 int compareUtf(const LocalPath&, bool unescaping1, const string&, bool unescaping2, bool caseInsensitive);
 int compareUtf(const LocalPath&, bool unescaping1, const LocalPath&, bool unescaping2, bool caseInsensitive);
+
+// Same as above except case insensitivity is determined by build platform.
+int platformCompareUtf(const string&, bool unescape1, const string&, bool unescape2);
+int platformCompareUtf(const string&, bool unescape1, const LocalPath&, bool unescape2);
+int platformCompareUtf(const LocalPath&, bool unescape1, const string&, bool unescape2);
+int platformCompareUtf(const LocalPath&, bool unescape1, const LocalPath&, bool unescape2);
 
 } // namespace
 

--- a/include/mega/json.h
+++ b/include/mega/json.h
@@ -29,7 +29,17 @@ namespace mega {
 // linear non-strict JSON scanner
 struct MEGA_API JSON
 {
-    const char* pos = nullptr;
+    JSON()
+      : pos(nullptr)
+    {
+    }
+
+    explicit JSON(const string& data)
+      : pos(data.c_str())
+    {
+    }
+
+    const char* pos;
 
     bool isnumeric();
 
@@ -38,6 +48,9 @@ struct MEGA_API JSON
     m_off_t getint();
     double getfloat();
     const char* getvalue();
+
+    fsfp_t getfp();
+    uint64_t getuint64();
 
     nameid getnameid();
     nameid getnameid(const char*) const;

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -264,6 +264,10 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     Node(MegaClient*, vector<Node*>*, handle, handle, nodetype_t, m_off_t, handle, const char*, m_time_t);
     ~Node();
 
+#ifdef ENABLE_SYNC
+    void detach(const bool recreate = false);
+#endif // ENABLE_SYNC
+
 private:
     // full folder/file key, symmetrically or asymmetrically encrypted
     // node crypto keys (raw or cooked -
@@ -401,6 +405,8 @@ struct MEGA_API LocalNode : public File
     static LocalNode* unserialize( Sync* sync, const string* sData );
 
     ~LocalNode();
+
+    void detach(const bool recreate = false);
 };
 
 template <> inline NewNode*& crossref_other_ptr_ref<LocalNode, NewNode>(LocalNode* p) { return p->newnode.ptr; }

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -160,6 +160,8 @@ public:
     bool fread(string *, unsigned, unsigned, m_off_t);
     bool fwrite(const byte *, unsigned, m_off_t) override;
 
+    bool ftruncate() override;
+
     bool sysread(byte *, unsigned, m_off_t) override;
     bool sysstat(m_time_t*, m_off_t*) override;
     bool sysopen(bool async = false) override;

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -419,6 +419,24 @@ public:
     {
         return utf8proc_toupper(c);
     }
+
+    // Platform-independent case-insensitive comparison.
+    static int icasecmp(const std::string& lhs,
+                        const std::string& rhs,
+                        const size_t length);
+
+    static int icasecmp(const std::wstring& lhs,
+                        const std::wstring& rhs,
+                        const size_t length);
+
+    // Same as above but only case-insensitive on Windows.
+    static int pcasecmp(const std::string& lhs,
+                        const std::string& rhs,
+                        const size_t length);
+
+    static int pcasecmp(const std::wstring& lhs,
+                        const std::wstring& rhs,
+                        const size_t length);
 };
 
 // for pre-c++11 where this version is not defined yet.
@@ -613,7 +631,7 @@ public:
         return mNotifications.empty();
     }
 
-    bool size()
+    size_t size()
     {
         std::lock_guard<std::mutex> g(m);
         return mNotifications.size();
@@ -738,6 +756,16 @@ public:
         return *this;
     }
 
+    bool operator==(const UnicodeCodepointIterator& rhs) const
+    {
+        return mCurrent == rhs.mCurrent && mEnd == rhs.mEnd;
+    }
+
+    bool operator!=(const UnicodeCodepointIterator& rhs) const
+    {
+        return !(*this == rhs);
+    }
+
     bool end() const
     {
         return mCurrent == mEnd;
@@ -752,6 +780,31 @@ public:
             ptrdiff_t nConsumed = traits_type::get(result, mCurrent, mEnd);
             assert(nConsumed > 0);
             mCurrent += nConsumed;
+        }
+
+        return result;
+    }
+    
+    bool match(const int32_t character)
+    {
+        if (peek() != character)
+        {
+            return false;
+        }
+
+        (void)get();
+
+        return true;
+    }
+
+    int32_t peek() const
+    {
+        int32_t result = 0;
+
+        if (mCurrent < mEnd)
+        {
+            ptrdiff_t nConsumed = traits_type::get(result, mCurrent, mEnd);
+            assert(nConsumed > 0);
         }
 
         return result;

--- a/include/mega/win32/megafs.h
+++ b/include/mega/win32/megafs.h
@@ -167,6 +167,8 @@ public:
     bool fread(string *, unsigned, unsigned, m_off_t);
     bool fwrite(const byte *, unsigned, m_off_t);
 
+    bool ftruncate() override;
+
     bool sysread(byte *, unsigned, m_off_t) override;
     bool sysstat(m_time_t*, m_off_t*) override;
     bool sysopen(bool async = false) override;

--- a/src/db/sqlite.cpp
+++ b/src/db/sqlite.cpp
@@ -165,6 +165,11 @@ bool SqliteDbAccess::probe(FileSystemAccess& fsAccess, const string& name) const
     return fileAccess->isfile(dbPath);
 }
 
+const LocalPath& SqliteDbAccess::rootPath() const
+{
+    return mRootPath;
+}
+
 SqliteDbTable::SqliteDbTable(PrnGen &rng, sqlite3* db, FileSystemAccess &fsAccess, const string &path, const bool checkAlwaysTransacted)
   : DbTable(rng, checkAlwaysTransacted)
   , db(db)

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -18,6 +18,7 @@
  * You should have received a copy of the license along with this
  * program.
  */
+#include <cctype>
 
 #include "mega/json.h"
 #include "mega/base64.h"
@@ -414,6 +415,39 @@ const char* JSON::getvalue()
         r = pos;
     }
 
+    storeobject();
+
+    return r;
+}
+
+fsfp_t JSON::getfp()
+{
+    return getuint64();
+}
+
+uint64_t JSON::getuint64()
+{
+    const char* ptr;
+
+    if (*pos == ':' || *pos == ',')
+    {
+        pos++;
+    }
+
+    ptr = pos;
+
+    if (*ptr == '"')
+    {
+        ptr++;
+    }
+
+    if (!std::isdigit(*ptr))
+    {
+        LOG_err << "Parse error (getuint64)";
+        return std::numeric_limits<uint64_t>::max();
+    }
+
+    uint64_t r = strtoull(ptr, nullptr, 0);
     storeobject();
 
     return r;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -197,6 +197,18 @@ Node::~Node()
 #endif
 }
 
+#ifdef ENABLE_SYNC
+
+void Node::detach(const bool recreate)
+{
+    if (localnode)
+    {
+        localnode->detach(recreate);
+    }
+}
+
+#endif // ENABLE_SYNC
+
 void Node::setkeyfromjson(const char* k)
 {
     if (keyApplied()) --client->mAppliedKeyNodeCount;
@@ -1621,6 +1633,17 @@ LocalNode::~LocalNode()
     }
 
     slocalname.reset();
+}
+
+void LocalNode::detach(const bool recreate)
+{
+    // Never detach the sync root.
+    if (parent && node)
+    {
+        node->tag = sync->tag;
+        node.reset();
+        created &= !recreate;
+    }
 }
 
 LocalPath LocalNode::getLocalPath() const

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -115,6 +115,48 @@ const string& adjustBasePath(const LocalPath& name)
 
 #endif /* ! USE_IOS */
 
+LocalPath NormalizeAbsolute(const LocalPath& path)
+{
+    LocalPath result = path;
+
+    // Convenience.
+    string& raw = result.localpath;
+
+    // Append the root separator if path is empty.
+    if (raw.empty())
+    {
+        raw.push_back('/');
+    }
+
+    // Remove trailing separator if we're not the root.
+    if (raw.size() > 1 && raw.back() == '/')
+    {
+        raw.pop_back();
+    }
+
+    return result;
+}
+
+int platformCompareUtf(const string& p1, bool unescape1, const string& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, false);
+}
+
+int platformCompareUtf(const string& p1, bool unescape1, const LocalPath& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, false);
+}
+
+int platformCompareUtf(const LocalPath& p1, bool unescape1, const string& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, false);
+}
+
+int platformCompareUtf(const LocalPath& p1, bool unescape1, const LocalPath& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, false);
+}
+
 #ifdef HAVE_AIO_RT
 PosixAsyncIOContext::PosixAsyncIOContext() : AsyncIOContext()
 {
@@ -436,6 +478,21 @@ bool PosixFileAccess::fwrite(const byte* data, unsigned len, m_off_t pos)
     lseek64(fd, pos, SEEK_SET);
     return write(fd, data, len) == len;
 #endif
+}
+
+bool PosixFileAccess::ftruncate()
+{
+    retry = false;
+
+    // Truncate the file.
+    if (::ftruncate(fd, 0x0) == 0)
+    {
+        // Set the file pointer back to the start.
+        return lseek(fd, 0x0, SEEK_SET) == 0x0;
+    }
+
+    // Couldn't truncate the file.
+    return false;
 }
 
 int PosixFileAccess::stealFileDescriptor()

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1692,6 +1692,62 @@ std::string Utils::hexToString(const std::string &input)
     return output;
 }
 
+int Utils::icasecmp(const std::string& lhs,
+                    const std::string& rhs,
+                    const size_t length)
+{
+    assert(lhs.size() >= length);
+    assert(rhs.size() >= length);
+
+#ifdef _WIN32
+    return _strnicmp(lhs.c_str(), rhs.c_str(), length);
+#else // _WIN32
+    return strncasecmp(lhs.c_str(), rhs.c_str(), length);
+#endif // ! _WIN32
+}
+
+int Utils::icasecmp(const std::wstring& lhs,
+                    const std::wstring& rhs,
+                    const size_t length)
+{
+    assert(lhs.size() >= length);
+    assert(rhs.size() >= length);
+
+#ifdef _WIN32
+    return _wcsnicmp(lhs.c_str(), rhs.c_str(), length);
+#else // _WIN32
+    return wcsncasecmp(lhs.c_str(), rhs.c_str(), length);
+#endif // ! _WIN32
+}
+
+int Utils::pcasecmp(const std::string& lhs,
+                    const std::string& rhs,
+                    const size_t length)
+{
+    assert(lhs.size() >= length);
+    assert(rhs.size() >= length);
+
+#ifdef _WIN32
+    return icasecmp(lhs, rhs, length);
+#else // _WIN32
+    return lhs.compare(0, length, rhs, 0, length);
+#endif // ! _WIN32
+}
+
+int Utils::pcasecmp(const std::wstring& lhs,
+                    const std::wstring& rhs,
+                    const size_t length)
+{
+    assert(lhs.size() >= length);
+    assert(rhs.size() >= length);
+
+#ifdef _WIN32
+    return icasecmp(lhs, rhs, length);
+#else // _WIN32
+    return lhs.compare(0, length, rhs, 0, length);
+#endif // ! _WIN32
+}
+
 long long abs(long long n)
 {
     // for pre-c++11 where this version is not defined yet

--- a/src/win32/fs.cpp
+++ b/src/win32/fs.cpp
@@ -19,6 +19,8 @@
  * program.
  */
 
+#include <cwctype>
+
 #include "mega.h"
 #include <wow64apiset.h>
 
@@ -32,6 +34,57 @@ namespace mega {
 WinFileSystemAccess gWfsa;
 
 int sanitizedriveletter(std::wstring& localpath);
+
+LocalPath NormalizeAbsolute(const LocalPath& path)
+{
+    LocalPath result = path;
+
+    // Convenience.
+    wstring& raw = result.localpath;
+
+    // Absolute paths should never be empty.
+    assert(!raw.empty());
+
+    // Add a drive separator if necessary.
+    if (raw.back() == L':')
+    {
+        raw.push_back(L'\\');
+    }
+
+    if (raw.size() > 1)
+    {
+        // Remove trailing separator if we're not the root.
+        if (raw.back() == L'\\')
+        {
+            if (raw[raw.size() - 2] != L':')
+            {
+                raw.pop_back();
+            }
+        }
+    }
+
+    return result;
+}
+
+int platformCompareUtf(const string& p1, bool unescape1, const string& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, true);
+}
+
+int platformCompareUtf(const string& p1, bool unescape1, const LocalPath& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, true);
+}
+
+int platformCompareUtf(const LocalPath& p1, bool unescape1, const string& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, true);
+}
+
+int platformCompareUtf(const LocalPath& p1, bool unescape1, const LocalPath& p2, bool unescape2)
+{
+    return compareUtf(p1, unescape1, p2, unescape2, true);
+}
 
 WinFileAccess::WinFileAccess(Waiter *w) : FileAccess(w)
 {
@@ -119,6 +172,31 @@ bool WinFileAccess::fwrite(const byte* data, unsigned len, m_off_t pos)
          return false;
      }
      return true;
+}
+
+bool WinFileAccess::ftruncate()
+{
+    LARGE_INTEGER zero;
+
+    zero.QuadPart = 0x0;
+
+    // Set the file pointer to the start of the file.
+    if (SetFilePointerEx(hFile, zero, nullptr, FILE_BEGIN))
+    {
+        // Truncate the file.
+        if (SetEndOfFile(hFile))
+        {
+            return true;
+        }
+    }
+
+    // Why couldn't we truncate the file?
+    auto error = GetLastError();
+
+    // Is it a transient error?
+    retry = WinFileSystemAccess::istransient(error);
+
+    return false;
 }
 
 m_time_t FileTime_to_POSIX(FILETIME* ft)

--- a/tests/unit/DefaultedFileAccess.h
+++ b/tests/unit/DefaultedFileAccess.h
@@ -43,6 +43,10 @@ public:
     {
         throw NotImplemented{__func__};
     }
+    bool ftruncate() override
+    {
+        throw NotImplemented{__func__};
+    }
     bool sysread(mega::byte *, unsigned, m_off_t) override
     {
         throw NotImplemented{__func__};

--- a/tests/unit/Sync_test.cpp
+++ b/tests/unit/Sync_test.cpp
@@ -1320,6 +1320,13 @@ public:
         return true;
     }
 
+    const mega::LocalPath &rootPath() const override
+    {
+        static mega::LocalPath const dummy;
+
+        return dummy;
+    }
+
 private:
     std::vector<std::pair<uint32_t, std::string>>& mData;
 };

--- a/tests/unit/utils_test.cpp
+++ b/tests/unit/utils_test.cpp
@@ -214,6 +214,28 @@ TEST_F(ComparatorTest, CompareLocalPaths)
         lhs = fromPath("a%qb%");
 
         EXPECT_EQ(compare(lhs, lhs), 0);
+
+#ifdef _WIN32
+        // Non-UNC prefixes should be skipped.
+        lhs = fromPath("\\\\?\\C:\\");
+        rhs = fromPath("C:\\");
+
+        EXPECT_EQ(compare(lhs, rhs), 0);
+        EXPECT_EQ(compare(rhs, lhs), 0);
+
+        lhs = fromPath("\\\\.\\C:\\");
+        rhs = fromPath("C:\\");
+
+        EXPECT_EQ(compare(lhs, rhs), 0);
+        EXPECT_EQ(compare(rhs, lhs), 0);
+
+        // Prefixes should only be removed from absolute paths.
+        lhs = fromPath("\\\\?\\X");
+        rhs = fromPath("X");
+
+        EXPECT_NE(compare(lhs, rhs), 0);
+        EXPECT_NE(compare(rhs, lhs), 0);
+#endif // _WIN32
     }
 
     // Filesystem-specific
@@ -309,6 +331,28 @@ TEST_F(ComparatorTest, CompareLocalPathAgainstString)
         rhs = "a%qb%r";
 
         EXPECT_EQ(compare(lhs, rhs), 0);
+
+#ifdef _WIN32
+        // Non-UNC prefixes should be skipped.
+        lhs = fromPath("\\\\?\\C:\\");
+        rhs = "C:\\";
+
+        EXPECT_EQ(compare(lhs, rhs), 0);
+        EXPECT_EQ(compare(rhs, lhs), 0);
+
+        lhs = fromPath("\\\\.\\C:\\");
+        rhs = "C:\\";
+
+        EXPECT_EQ(compare(lhs, rhs), 0);
+        EXPECT_EQ(compare(rhs, lhs), 0);
+
+        // Prefixes should only be removed from absolute paths.
+        lhs = fromPath("\\\\?\\X");
+        rhs = "X";
+
+        EXPECT_NE(compare(lhs, rhs), 0);
+        EXPECT_NE(compare(rhs, lhs), 0);
+#endif // _WIN32
     }
 
     // Filesystem-specific
@@ -392,5 +436,219 @@ TEST(URLCodec, UnescapeShortEscape)
     input = "a%a";
     URLCodec::unescape(&input, &output);
     EXPECT_EQ(output, "a%a");
+}
+
+
+TEST(Filesystem, isContainingPathOf)
+{
+    using namespace mega;
+
+#ifdef _WIN32
+#define SEP "\\"
+#else // _WIN32
+#define SEP "/"
+#endif // ! _WIN32
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath lhs;
+    LocalPath rhs;
+    size_t pos;
+
+    // lhs does not contain rhs.
+    pos = -1;
+    lhs = LocalPath::fromPath("a" SEP "b", fsAccess);
+    rhs = LocalPath::fromPath("a" SEP "c", fsAccess);
+
+    EXPECT_FALSE(lhs.isContainingPathOf(rhs, &pos));
+    EXPECT_EQ(pos, -1);
+
+    // lhs does not contain rhs.
+    // they do, however, share a common prefix.
+    pos = -1;
+    lhs = LocalPath::fromPath("a", fsAccess);
+    rhs = LocalPath::fromPath("ab", fsAccess);
+
+    EXPECT_FALSE(lhs.isContainingPathOf(rhs, &pos));
+    EXPECT_EQ(pos, -1);
+
+    // lhs contains rhs.
+    // no trailing separator.
+    pos = -1;
+    lhs = LocalPath::fromPath("a", fsAccess);
+    rhs = LocalPath::fromPath("a" SEP "b", fsAccess);
+
+    EXPECT_TRUE(lhs.isContainingPathOf(rhs, &pos));
+    EXPECT_EQ(pos, 2);
+
+    // trailing separator.
+    pos = -1;
+    lhs = LocalPath::fromPath("a" SEP, fsAccess);
+    rhs = LocalPath::fromPath("a" SEP "b", fsAccess);
+
+    EXPECT_TRUE(lhs.isContainingPathOf(rhs, &pos));
+    EXPECT_EQ(pos, 2);
+
+    // lhs contains itself.
+    pos = -1;
+    lhs = LocalPath::fromPath("a" SEP "b", fsAccess);
+
+    EXPECT_TRUE(lhs.isContainingPathOf(lhs, &pos));
+    EXPECT_EQ(pos, 3);
+
+#ifdef _WIN32
+    // case insensitive.
+    pos = -1;
+    lhs = LocalPath::fromPath("a" SEP "B", fsAccess);
+    rhs = LocalPath::fromPath("A" SEP "b", fsAccess);
+
+    EXPECT_TRUE(lhs.isContainingPathOf(rhs, &pos));
+    EXPECT_EQ(pos, 3);
+#endif // _WIN32
+
+#undef SEP
+}
+
+#ifdef _WIN32
+
+TEST(Filesystem, NormalizeAbsoluteAddDriveSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("C:", fsAccess);
+    LocalPath expected = LocalPath::fromPath("C:\\", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+
+    input = LocalPath::fromPath("\\\\.\\C:", fsAccess);
+    expected = LocalPath::fromPath("\\\\.\\C:\\", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+
+    input = LocalPath::fromPath("\\\\?\\C:", fsAccess);
+    expected = LocalPath::fromPath("\\\\?\\C:\\", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+}
+
+TEST(Filesystem, NormalizeAbsoluteRemoveTrailingSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("A\\", fsAccess);
+    LocalPath expected = LocalPath::fromPath("A", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+
+    input = LocalPath::fromPath("\\\\.\\C:\\A\\", fsAccess);
+    expected = LocalPath::fromPath("\\\\.\\C:\\A", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+
+    input = LocalPath::fromPath("\\\\?\\C:\\A\\", fsAccess);
+    expected = LocalPath::fromPath("\\\\?\\C:\\A", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+}
+
+TEST(Filesystem, NormalizeRelativeRemoveLeadingSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("\\a\\b\\", fsAccess);
+    LocalPath expected = LocalPath::fromPath("a\\b", fsAccess);
+
+    EXPECT_EQ(NormalizeRelative(input), expected);
+    EXPECT_EQ(NormalizeRelative(expected), expected);
+}
+
+TEST(Filesystem, NormalizeRelativeRemoveTrailingSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("a\\b\\", fsAccess);
+    LocalPath expected = LocalPath::fromPath("a\\b", fsAccess);
+
+    EXPECT_EQ(NormalizeRelative(input), expected);
+    EXPECT_EQ(NormalizeRelative(expected), expected);
+}
+
+#else // _WIN32
+
+TEST(Filesystem, NormalizeAbsoluteAddRootSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("", fsAccess);
+    LocalPath expected = LocalPath::fromPath("/", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+}
+
+TEST(Filesystem, NormalizeAbsoluteRemoveTrailingSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("a/", fsAccess);
+    LocalPath expected = LocalPath::fromPath("a", fsAccess);
+
+    EXPECT_EQ(NormalizeAbsolute(input), expected);
+    EXPECT_EQ(NormalizeAbsolute(expected), expected);
+}
+
+TEST(Filesystem, NormalizeRelativeRemoveLeadingSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("/a/b/", fsAccess);
+    LocalPath expected = LocalPath::fromPath("a/b", fsAccess);
+
+    EXPECT_EQ(NormalizeRelative(input), expected);
+    EXPECT_EQ(NormalizeRelative(expected), expected);
+}
+
+TEST(Filesystem, NormalizeRelativeRemoveTrailingSeparator)
+{
+    using namespace mega;
+
+    FSACCESS_CLASS fsAccess;
+
+    LocalPath input = LocalPath::fromPath("a/b/", fsAccess);
+    LocalPath expected = LocalPath::fromPath("a/b", fsAccess);
+
+    EXPECT_EQ(NormalizeRelative(input), expected);
+    EXPECT_EQ(NormalizeRelative(expected), expected);
+}
+
+#endif // _WIN32
+
+TEST(Filesystem, NormalizeRelativeEmpty)
+{
+    using namespace mega;
+
+    LocalPath path;
+
+    EXPECT_EQ(NormalizeRelative(path), path);
 }
 


### PR DESCRIPTION
- Base64
  - Added two convenience methods to Base64Str.
    - bytes()
      - String's contents as const byte*.
    - size()
      - Size of the string's contents.

- CryptoPP
  - Cleaned up formatting a little.
  - cbc_decrypt_pkcs_padding
    - Exception safe.
    - Returns false if decryption fails.
  - cbc_encrypt_pkcs_padding
    - Exception safe.

- DB
  - You can now retrieve the DB's root path.

- Filesystem
  - Various helper functions.
    - DirNotify::empty()
      - Returns true if all queues are exhausted.
    - FileSystemAccess::ftruncate()
      - Truncates specified file to zero bytes.
    - LocalPath::isContainingPathOf(...)
      - Now uses Unicode-aware comparators.
      - Platform-specific case-sensitivity.
        - Case insensitive only on Windows.
    - NormalizeAbsolute()
      - Removes trailing separator.
    - NormalizeRelative()
      - Removes leading and trailing separators.

- JSON
  - JSON::JSON(...)
    - Added convenience constructors for JSON.
  - JSON::getfp()
    - Method for extracting a fingerprint from JSON.
  - JSON::getuint64()
    - Method for reading a uint64_t from JSON.

- Node
  - LocalNode::detach(...)
  - Node::detach(...)
    - Useful for breaking the link between a local and remote node.

- Utils
  - Fixed ThreadSafeDeque::size().
  - Misc. improvements to UnicodeCodepointIterator.
  - Utils::icasecmp
    - Platform-independent case-insensitive string comparison.
  - Utils::pcasecmp
    - Platform-specific case-sensitive string comparison.
      - Case-insensitive only on Windows.