### PR TITLE
SDK-1356. fix iOS beta crash in opensctable

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -9306,12 +9306,12 @@ void MegaClient::opensctable()
         {
             sctable = dbaccess->open(rng, *fsaccess, dbname);
             pendingsccommit = false;
-        }
 
-        // sctable always has a transaction started.
-        // We only commit once we have an up to date SCSN and the table state matches it.
-        sctable->begin();
-        assert(sctable->inTransaction());
+            // sctable always has a transaction started.
+            // We only commit once we have an up to date SCSN and the table state matches it.
+            sctable->begin();
+            assert(sctable->inTransaction());
+        }
     }
 }
 


### PR DESCRIPTION
Only begin() on the database in the block where we created it.