### PR TITLE
SDK-1358. Avoid UserAlert for Incoming PCR accepted

### DIFF
--- a/src/useralerts.cpp
+++ b/src/useralerts.cpp
@@ -279,7 +279,7 @@ UserAlert::ContactChange::ContactChange(int c, handle uh, const string& email, m
 
 bool UserAlert::ContactChange::checkprovisional(handle ou, MegaClient* mc)
 {
-    return action == 1 || ou != mc->me;
+    return ou != mc->me;
 }
 
 void UserAlert::ContactChange::text(string& header, string& title, MegaClient* mc)


### PR DESCRIPTION
When an Incoming Pending Contact Request is accepted, it should not generate a notification/user-alert, since it's the own user who accepted, it's not news for him.