### PR TITLE
SDK-1361 . Update gtest to 1.10.0

### DIFF
--- a/tests/include.am
+++ b/tests/include.am
@@ -41,10 +41,10 @@ tests_tool_purge_account_SOURCES = \
     tests/tool/purge_account.cpp
 
 tests_test_unit_CXXFLAGS = -I$(GTEST_DIR)/include $(FI_CXXFLAGS) $(RL_CXXFLAGS) $(ZLIB_CXXFLAGS) $(CARES_FLAGS) $(LIBCURL_FLAGS) $(CRYPTO_CXXFLAGS) $(DB_CXXFLAGS) $(SODIUM_CXXFLAGS) $(LIBSSL_FLAGS)
-tests_test_unit_LDADD = $(GTEST_DIR)/lib/libgtest.la $(GTEST_DIR)/lib/libgtest_main.la $(CRYPTO_LIBS) $(SODIUM_LDFLAGS) $(SODIUM_LIBS) $(top_builddir)/src/libmega.la
+tests_test_unit_LDADD = -L$(GTEST_DIR)/lib/ -lgtest -lgtest_main $(CRYPTO_LIBS) $(SODIUM_LDFLAGS) $(SODIUM_LIBS) $(top_builddir)/src/libmega.la
 
 tests_test_integration_CXXFLAGS = -I$(GTEST_DIR)/include -I$(top_builddir)/include $(FI_CXXFLAGS) $(RL_CXXFLAGS) $(ZLIB_CXXFLAGS) $(CARES_FLAGS) $(LIBCURL_FLAGS) $(CRYPTO_CXXFLAGS) $(DB_CXXFLAGS) $(SODIUM_CXXFLAGS) $(LIBSSL_FLAGS)
-tests_test_integration_LDADD = $(GTEST_DIR)/lib/libgtest.la $(GTEST_DIR)/lib/libgtest_main.la $(CRYPTO_LIBS) $(SODIUM_LDFLAGS) $(SODIUM_LIBS) $(top_builddir)/src/libmega.la
+tests_test_integration_LDADD = -L$(GTEST_DIR)/lib/ -lgtest -lgtest_main $(CRYPTO_LIBS) $(SODIUM_LDFLAGS) $(SODIUM_LIBS) $(top_builddir)/src/libmega.la
 
 tests_tool_purge_account_CXXFLAGS = -I$(top_builddir)/include $(FI_CXXFLAGS) $(RL_CXXFLAGS) $(ZLIB_CXXFLAGS) $(CARES_FLAGS) $(LIBCURL_FLAGS) $(CRYPTO_CXXFLAGS) $(DB_CXXFLAGS) $(SODIUM_CXXFLAGS) $(LIBSSL_FLAGS)
 tests_tool_purge_account_LDADD = $(top_builddir)/src/libmega.la


### PR DESCRIPTION
The libtool file is not available in gtest 1.10.0.
Modified how autotools build links gtest to work with it.
