### PR TITLE
SDK-1362. Fix issues with remote paths changes in syncs

### DIFF
--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -99,12 +99,13 @@ struct UnifiedSync
     // Try to create and start the Sync
     error enableSync(bool resetFingerprint, bool notifyApp);
 
+    // Update remote location
+    bool updateSyncRemoteLocation(Node* n, bool forceCallback);
 private:
     friend class Sync;
     friend struct Syncs;
     error startSync(MegaClient* client, const char* debris, LocalPath* localdebris, Node* remotenode, bool inshare, bool isNetwork, bool delayInitialScan, LocalPath& rootpath, std::unique_ptr<FileAccess>& openedLocalFolder);
     void changedConfigState(bool notifyApp);
-    bool updateSyncRemoteLocation(Node* n, bool forceCallback);
 };
 
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -7097,7 +7097,6 @@ void MegaClient::notifypurge(void)
         //update sync root node location and trigger failing cases
         handle rubbishHandle = rootnodes[RUBBISHNODE - ROOTNODE];
         // check for renamed/moved sync root folders
-        //syncs.forEachRunningSync([&](Sync* sync) {
         syncs.forEachUnifiedSync([&](UnifiedSync& us){
 
             Node* n = nodebyhandle(us.mConfig.getRemoteNode());


### PR DESCRIPTION
updates on remote paths for syncs are only considered for active syncs after sync revamping. 
This reverts that and makes notice of inactive syncs changes in remote paths.
Thus allows for apps to notice that and also be able to re-enable syncs whose remote went to the //bin an back