### PR TITLE
SDK-1363. Cache Pro Level to detect upgrades

### DIFF
--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -889,7 +889,7 @@ public:
     storagestatus_t ststatus;
 
     // cacheable status
-    std::map<int64_t, std::shared_ptr<CacheableStatus>> mCachedStatus;
+    std::map<int64_t, CacheableStatus> mCachedStatus;
 
     // warning timestamps related to storage overquota in paywall mode
     vector<m_time_t> mOverquotaWarningTs;
@@ -1831,8 +1831,14 @@ public:
     void setKeepSyncsAfterLogout(bool keepSyncsAfterLogout);
 #endif
 
-    void loadCacheableStatus(std::shared_ptr<CacheableStatus> status);
+    // adds the new record to the map in memory and to the DB. Also initialized dedicated vars
+    void loadCachedStatus(int64_t type, int64_t value);
 
+    // add/update cached status, both in memory and DB
+    bool setCachedStatus(int64_t type, int64_t value);
+
+    // true if there is a cached value for that type
+    bool hasCachedStatus(int64_t type);
 
     MegaClient(MegaApp*, Waiter*, HttpIO*, FileSystemAccess*, DbAccess*, GfxProc*, const char*, const char*, unsigned workerThreadCount);
     ~MegaClient();

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -888,9 +888,6 @@ public:
     // storage status
     storagestatus_t ststatus;
 
-    // account type: Free|Pro Lite|Pro I|Pro II|Pro III|Business
-    AccountType mAccountType = ACCOUNT_TYPE_UNKNOWN;
-
     // cacheable status
     std::map<int64_t, std::shared_ptr<CacheableStatus>> mCachedStatus;
 

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1831,7 +1831,7 @@ public:
     void setKeepSyncsAfterLogout(bool keepSyncsAfterLogout);
 #endif
 
-    // adds the new record to the map in memory and to the DB. Also initialized dedicated vars
+    // adds the new record to the map in memory and to the DB. Also initializes dedicated vars
     void loadCachedStatus(int64_t type, int64_t value);
 
     // add/update cached status, both in memory and DB

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -888,8 +888,31 @@ public:
     // storage status
     storagestatus_t ststatus;
 
+    class CacheableStatusMap : private map<int64_t, CacheableStatus>
+    {
+    public:
+        CacheableStatusMap(MegaClient *client) { mClient = client; }
+
+        // returns the cached value for type, or defaultValue if not found
+        int64_t lookup(int64_t type, int64_t defaultValue);
+
+        // add/update cached status, both in memory and DB
+        bool addOrUpdate(int64_t type, int64_t value);
+
+        // addsOrUpdate(), but also initializes dedicated vars in the client (used to load from DB)
+        void loadCachedStatus(int64_t type, int64_t value);
+
+        // for unserialize
+        CacheableStatus *getPtr(int64_t type);
+
+        void clear() { map::clear(); }
+
+    private:
+        MegaClient *mClient = nullptr;
+    };
+
     // cacheable status
-    std::map<int64_t, CacheableStatus> mCachedStatus;
+    CacheableStatusMap mCachedStatus;
 
     // warning timestamps related to storage overquota in paywall mode
     vector<m_time_t> mOverquotaWarningTs;
@@ -1830,15 +1853,6 @@ public:
     bool getKeepSyncsAfterLogout() const;
     void setKeepSyncsAfterLogout(bool keepSyncsAfterLogout);
 #endif
-
-    // adds the new record to the map in memory and to the DB. Also initializes dedicated vars
-    void loadCachedStatus(int64_t type, int64_t value);
-
-    // add/update cached status, both in memory and DB
-    bool setCachedStatus(int64_t type, int64_t value);
-
-    // true if there is a cached value for that type
-    bool hasCachedStatus(int64_t type);
 
     MegaClient(MegaApp*, Waiter*, HttpIO*, FileSystemAccess*, DbAccess*, GfxProc*, const char*, const char*, unsigned workerThreadCount);
     ~MegaClient();

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -899,7 +899,7 @@ public:
         // add/update cached status, both in memory and DB
         bool addOrUpdate(int64_t type, int64_t value);
 
-        // addsOrUpdate(), but also initializes dedicated vars in the client (used to load from DB)
+        // adds a new item to the map. It also initializes dedicated vars in the client (used to load from DB)
         void loadCachedStatus(int64_t type, int64_t value);
 
         // for unserialize

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -821,7 +821,7 @@ public:
     bool serialize(string* data) override;
 
     // deserializes the string to a SyncConfig object. Returns null in case of failure
-    static std::shared_ptr<CacheableStatus> unserialize(MegaClient *client, const std::string& data);
+    static CacheableStatus* unserialize(MegaClient *client, const std::string& data);
     int64_t type() const;
     int64_t value() const;
 

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -821,6 +821,7 @@ public:
     bool serialize(string* data) override;
 
     // deserializes the string to a SyncConfig object. Returns null in case of failure
+    // returns a pointer to the unserialized value, owned by MegaClient passed as parameter
     static CacheableStatus* unserialize(MegaClient *client, const std::string& data);
     int64_t type() const;
     int64_t value() const;

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -812,6 +812,7 @@ public:
         STATUS_STORAGE = 1,
         STATUS_BUSINESS = 2,
         STATUS_BLOCKED = 3,
+        STATUS_PRO_LEVEL = 4,
     };
 
     CacheableStatus(int64_t type, int64_t value);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4665,7 +4665,7 @@ bool CommandGetUserQuota::procresult(Result r)
                     // Pro level can change without a payment (ie. with coupons or by helpdesk)
                     // and in those cases, the `psts` packet is not triggered. However, the SDK
                     // should notify the app and resume transfers, etc.
-                    bool changed = client->setCachedStatus(CacheableStatus::STATUS_PRO_LEVEL, details->pro_level);
+                    bool changed = client->mCachedStatus.addOrUpdate(CacheableStatus::STATUS_PRO_LEVEL, details->pro_level);
                     if (changed)
                     {
                         client->app->account_updated();

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4660,14 +4660,39 @@ bool CommandGetUserQuota::procresult(Result r)
                     }
                 }
 
-                if (mPro && client->mAccountType != details->pro_level)
+                if (mPro)
                 {
                     // Pro level can change without a payment (ie. with coupons or by helpdesk)
                     // and in those cases, the `psts` packet is not triggered. However, the SDK
                     // should notify the app and resume transfers, etc.
-                    client->mAccountType = static_cast<AccountType>(details->pro_level);
-                    client->app->account_updated();
-                    client->abortbackoff(true);
+                    auto &proLevel = client->mCachedStatus[CacheableStatus::STATUS_PRO_LEVEL];
+                    bool changed = false;
+                    if (!proLevel)
+                    {
+                        proLevel = std::make_shared<CacheableStatus>(CacheableStatus::STATUS_BLOCKED, details->pro_level);
+                        changed = true;
+                    }
+                    else if (proLevel->value() != details->pro_level)
+                    {
+                        proLevel->setValue(details->pro_level);
+                        changed = true;
+                    }
+
+                    if (changed)
+                    {
+                        client->app->account_updated();
+                        client->abortbackoff(true);
+
+                        if (client->statusTable)
+                        {
+                            DBTableTransactionCommitter committer(client->statusTable);
+                            LOG_verbose << "Adding/updating status to database: " << proLevel->type() << " = " << proLevel->value();
+                            if (!client->statusTable->put(MegaClient::CACHEDSTATUS, proLevel.get(), &client->key))
+                            {
+                                LOG_err << "Failed to add/update status to db: " << proLevel->type() << " = " << proLevel->value();
+                            }
+                        }
+                    }
                 }
 
                 client->app->account_details(details, mStorage, mTransfer, mPro, false, false, false);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4665,33 +4665,11 @@ bool CommandGetUserQuota::procresult(Result r)
                     // Pro level can change without a payment (ie. with coupons or by helpdesk)
                     // and in those cases, the `psts` packet is not triggered. However, the SDK
                     // should notify the app and resume transfers, etc.
-                    auto &proLevel = client->mCachedStatus[CacheableStatus::STATUS_PRO_LEVEL];
-                    bool changed = false;
-                    if (!proLevel)
-                    {
-                        proLevel = std::make_shared<CacheableStatus>(CacheableStatus::STATUS_BLOCKED, details->pro_level);
-                        changed = true;
-                    }
-                    else if (proLevel->value() != details->pro_level)
-                    {
-                        proLevel->setValue(details->pro_level);
-                        changed = true;
-                    }
-
+                    bool changed = client->setCachedStatus(CacheableStatus::STATUS_PRO_LEVEL, details->pro_level);
                     if (changed)
                     {
                         client->app->account_updated();
                         client->abortbackoff(true);
-
-                        if (client->statusTable)
-                        {
-                            DBTableTransactionCommitter committer(client->statusTable);
-                            LOG_verbose << "Adding/updating status to database: " << proLevel->type() << " = " << proLevel->value();
-                            if (!client->statusTable->put(MegaClient::CACHEDSTATUS, proLevel.get(), &client->key))
-                            {
-                                LOG_err << "Failed to add/update status to db: " << proLevel->type() << " = " << proLevel->value();
-                            }
-                        }
                     }
                 }
 

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -5437,7 +5437,8 @@ void MegaClient::sc_updatenode()
 
 void MegaClient::CacheableStatusMap::loadCachedStatus(int64_t type, int64_t value)
 {
-    insert(pair<int64_t, CacheableStatus>(type, CacheableStatus(type, value)));
+    auto it = insert(pair<int64_t, CacheableStatus>(type, CacheableStatus(type, value)));
+    assert(it.second);
 
     LOG_verbose << "Loaded status from cache: " << type << " = " << value;
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -2082,9 +2082,9 @@ error UnifiedSync::startSync(MegaClient* client, const char* debris, LocalPath* 
 {
     //check we are not in any blocking situation
     using CType = CacheableStatus::Type;
-    bool overStorage = mClient.mCachedStatus[CType::STATUS_STORAGE] ? (mClient.mCachedStatus[CType::STATUS_STORAGE]->value() >= STORAGE_RED) : false;
-    bool businessExpired = mClient.mCachedStatus[CType::STATUS_BUSINESS] ? (mClient.mCachedStatus[CType::STATUS_BUSINESS]->value() == BIZ_STATUS_EXPIRED) : false;
-    bool blocked = mClient.mCachedStatus[CType::STATUS_BLOCKED] ? (mClient.mCachedStatus[CType::STATUS_BLOCKED]->value()) : false;
+    bool overStorage = client->hasCachedStatus(CType::STATUS_STORAGE) ? (client->mCachedStatus.at(CType::STATUS_STORAGE).value() >= STORAGE_RED) : false;
+    bool businessExpired = client->hasCachedStatus(CType::STATUS_BUSINESS) ? (client->mCachedStatus.at(CType::STATUS_BUSINESS).value() == BIZ_STATUS_EXPIRED) : false;
+    bool blocked = client->hasCachedStatus(CType::STATUS_BLOCKED) ? (client->mCachedStatus.at(CType::STATUS_BLOCKED).value()) : false;
 
     mConfig.mError = NO_SYNC_ERROR;
     mConfig.mEnabled = true;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -2082,9 +2082,9 @@ error UnifiedSync::startSync(MegaClient* client, const char* debris, LocalPath* 
 {
     //check we are not in any blocking situation
     using CType = CacheableStatus::Type;
-    bool overStorage = client->hasCachedStatus(CType::STATUS_STORAGE) ? (client->mCachedStatus.at(CType::STATUS_STORAGE).value() >= STORAGE_RED) : false;
-    bool businessExpired = client->hasCachedStatus(CType::STATUS_BUSINESS) ? (client->mCachedStatus.at(CType::STATUS_BUSINESS).value() == BIZ_STATUS_EXPIRED) : false;
-    bool blocked = client->hasCachedStatus(CType::STATUS_BLOCKED) ? (client->mCachedStatus.at(CType::STATUS_BLOCKED).value()) : false;
+    bool overStorage = client->mCachedStatus.lookup(CType::STATUS_STORAGE, STORAGE_UNKNOWN) >= STORAGE_RED;
+    bool businessExpired = client->mCachedStatus.lookup(CType::STATUS_BUSINESS, BIZ_STATUS_UNKNOWN) == BIZ_STATUS_EXPIRED;
+    bool blocked = client->mCachedStatus.lookup(CType::STATUS_BLOCKED, 0) == 1;
 
     mConfig.mError = NO_SYNC_ERROR;
     mConfig.mEnabled = true;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2247,7 +2247,7 @@ bool CacheableStatus::serialize(std::string* data)
     return const_cast<const CacheableStatus*>(this)->serialize(*data);
 }
 
-std::shared_ptr<CacheableStatus> CacheableStatus::unserialize(class MegaClient *client, const std::string& data)
+CacheableStatus* CacheableStatus::unserialize(class MegaClient *client, const std::string& data)
 {
     int64_t type;
     int64_t value;
@@ -2262,10 +2262,8 @@ std::shared_ptr<CacheableStatus> CacheableStatus::unserialize(class MegaClient *
         return {};
     }
 
-    auto cacheableStatus = std::make_shared<CacheableStatus>(type, value);
-
-    client->loadCacheableStatus(cacheableStatus);
-    return cacheableStatus;
+    client->loadCachedStatus(type, value);
+    return &client->mCachedStatus.at(type);
 }
 
 bool CacheableStatus::serialize(std::string& data) const

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2262,8 +2262,8 @@ CacheableStatus* CacheableStatus::unserialize(class MegaClient *client, const st
         return nullptr;
     }
 
-    client->loadCachedStatus(type, value);
-    return &client->mCachedStatus.at(type);
+    client->mCachedStatus.loadCachedStatus(type, value);
+    return client->mCachedStatus.getPtr(type);
 }
 
 bool CacheableStatus::serialize(std::string& data) const

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2255,11 +2255,11 @@ CacheableStatus* CacheableStatus::unserialize(class MegaClient *client, const st
     CacheableReader reader{data};
     if (!reader.unserializei64(type))
     {
-        return {};
+        return nullptr;
     }
     if (!reader.unserializei64(value))
     {
-        return {};
+        return nullptr;
     }
 
     client->loadCachedStatus(type, value);


### PR DESCRIPTION
As a side-effect of SDK-1327, the app gets one `onAccountUpdate()` upon initialization, even when the account is not down/upgraded. To avoid it, we need to know the previous value. This commit aims to solve it.