### PR TITLE
iOS Binding - add ability to run request listener callback in background threads

### DIFF
--- a/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
+++ b/bindings/ios/MEGASDK.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		B6657E9C225C2B6200EF8D91 /* raid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6657E9B225C2B6200EF8D91 /* raid.cpp */; };
 		B698890D2198CCE300D0EE89 /* MEGAFileInputStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = B698890B2198CCE300D0EE89 /* MEGAFileInputStream.mm */; };
 		B6A6CB662170125A009032C9 /* MEGABackgroundMediaUpload.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6A6CB652170125A009032C9 /* MEGABackgroundMediaUpload.mm */; };
+		B6DBB54925BE9A89005F46A5 /* ListenerDispatch.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6DBB54825BE9A76005F46A5 /* ListenerDispatch.mm */; };
 		BF9CF0D12541737500A3EBBB /* heartbeats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF9CF0D02541737500A3EBBB /* heartbeats.cpp */; };
 		BFD7F5172341B3A60039A6EE /* MEGAPushNotificationSettings.mm in Sources */ = {isa = PBXBuildFile; fileRef = BFD7F5162341B3A60039A6EE /* MEGAPushNotificationSettings.mm */; };
 /* End PBXBuildFile section */
@@ -332,6 +333,8 @@
 		B698890C2198CCE300D0EE89 /* MEGAFileInputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MEGAFileInputStream.h; sourceTree = "<group>"; };
 		B6A6CB642170125A009032C9 /* MEGABackgroundMediaUpload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MEGABackgroundMediaUpload.h; sourceTree = "<group>"; };
 		B6A6CB652170125A009032C9 /* MEGABackgroundMediaUpload.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MEGABackgroundMediaUpload.mm; sourceTree = "<group>"; };
+		B6DBB54725BE99AB005F46A5 /* ListenerDispatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ListenerDispatch.h; sourceTree = "<group>"; };
+		B6DBB54825BE9A76005F46A5 /* ListenerDispatch.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ListenerDispatch.mm; sourceTree = "<group>"; };
 		BF9CF0CF2541734200A3EBBB /* heartbeats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = heartbeats.h; sourceTree = "<group>"; };
 		BF9CF0D02541737500A3EBBB /* heartbeats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = heartbeats.cpp; path = ../../src/heartbeats.cpp; sourceTree = "<group>"; };
 		BFD7F5152341B3A60039A6EE /* MEGAPushNotificationSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MEGAPushNotificationSettings.h; sourceTree = "<group>"; };
@@ -692,6 +695,8 @@
 				B622FC762174261F00CF707C /* MEGABackgroundMediaUpload+init.h */,
 				A8FD7335230AC42B0070A5E8 /* MEGACancelToken+init.h */,
 				BFD7F5182341B3B50039A6EE /* MEGAPushNotificationSettings+init.h */,
+				B6DBB54725BE99AB005F46A5 /* ListenerDispatch.h */,
+				B6DBB54825BE9A76005F46A5 /* ListenerDispatch.mm */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -799,6 +804,7 @@
 				A87D97A21F4AD49B00A98C0E /* MEGAStringList.mm in Sources */,
 				940BF01519ED97B9007E7FA2 /* MEGAShareList.mm in Sources */,
 				5D830393256232A00082CA18 /* MEGABannerList.mm in Sources */,
+				B6DBB54925BE9A89005F46A5 /* ListenerDispatch.mm in Sources */,
 				41B2AEDA1A0A859C006C40FB /* DelegateMEGAListener.mm in Sources */,
 				A8A86BD51F559EDA00C214DA /* mega_zxcvbn.cpp in Sources */,
 				A8FD7B641E93B40E0031FC50 /* osxutils.mm in Sources */,

--- a/bindings/ios/Private/DelegateMEGARequestListener.h
+++ b/bindings/ios/Private/DelegateMEGARequestListener.h
@@ -21,12 +21,13 @@
 #import "MEGARequestDelegate.h"
 #import "megaapi.h"
 #import "MEGASdk.h"
+#import "ListenerDispatch.h"
 
 class DelegateMEGARequestListener : public mega::MegaRequestListener {
 
 public:
     
-    DelegateMEGARequestListener(MEGASdk *megaSDK, id<MEGARequestDelegate>listener, bool singleListener = true);
+    DelegateMEGARequestListener(MEGASdk *megaSDK, id<MEGARequestDelegate>listener, bool singleListener, ListenerQueueType queueType);
     id<MEGARequestDelegate>getUserListener();
     
     void onRequestStart(mega::MegaApi *api, mega::MegaRequest *request);
@@ -38,4 +39,5 @@ private:
     MEGASdk *megaSDK;
     id<MEGARequestDelegate>listener;
     bool singleListener;
+    ListenerQueueType queueType;
 };

--- a/bindings/ios/Private/DelegateMEGARequestListener.mm
+++ b/bindings/ios/Private/DelegateMEGARequestListener.mm
@@ -25,10 +25,11 @@
 
 using namespace mega;
 
-DelegateMEGARequestListener::DelegateMEGARequestListener(MEGASdk *megaSDK, id<MEGARequestDelegate>listener, bool singleListener) {
+DelegateMEGARequestListener::DelegateMEGARequestListener(MEGASdk *megaSDK, id<MEGARequestDelegate>listener, bool singleListener, ListenerQueueType queueType) {
     this->megaSDK = megaSDK;
     this->listener = listener;
     this->singleListener = singleListener;
+    this->queueType = queueType;
 }
 
 id<MEGARequestDelegate>DelegateMEGARequestListener::getUserListener() {
@@ -40,7 +41,7 @@ void DelegateMEGARequestListener::onRequestStart(MegaApi *api, MegaRequest *requ
         MegaRequest *tempRequest = request->copy();
         MEGASdk *tempMegaSDK = this->megaSDK;
         id<MEGARequestDelegate> tempListener = this->listener;
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch(this->queueType, ^{
             [tempListener onRequestStart:tempMegaSDK request:[[MEGARequest alloc] initWithMegaRequest:tempRequest cMemoryOwn:YES]];
         });
     }
@@ -53,7 +54,7 @@ void DelegateMEGARequestListener::onRequestFinish(MegaApi *api, MegaRequest *req
         MEGASdk *tempMegaSDK = this->megaSDK;
         id<MEGARequestDelegate> tempListener = this->listener;
         bool tempSingleListener = singleListener;
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch(this->queueType, ^{
             [tempListener onRequestFinish:tempMegaSDK request:[[MEGARequest alloc] initWithMegaRequest:tempRequest cMemoryOwn:YES] error:[[MEGAError alloc] initWithMegaError:tempError cMemoryOwn:YES]];
             if (tempSingleListener) {
                 [megaSDK freeRequestListener:this];
@@ -67,7 +68,7 @@ void DelegateMEGARequestListener::onRequestUpdate(MegaApi *api, MegaRequest *req
         MegaRequest *tempRequest = request->copy();
         MEGASdk *tempMegaSDK = this->megaSDK;
         id<MEGARequestDelegate> tempListener = this->listener;
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch(this->queueType, ^{
             [tempListener onRequestUpdate:tempMegaSDK request:[[MEGARequest alloc] initWithMegaRequest:tempRequest cMemoryOwn:YES]];
         });
     }
@@ -79,7 +80,7 @@ void DelegateMEGARequestListener::onRequestTemporaryError(MegaApi *api, MegaRequ
         MegaError *tempError = e->copy();
         MEGASdk *tempMegaSDK = this->megaSDK;
         id<MEGARequestDelegate> tempListener = this->listener;
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch(this->queueType, ^{
             [tempListener onRequestTemporaryError:tempMegaSDK request:[[MEGARequest alloc] initWithMegaRequest:tempRequest cMemoryOwn:YES] error:[[MEGAError alloc] initWithMegaError:tempError cMemoryOwn:YES]];
         });
     }

--- a/bindings/ios/Private/ListenerDispatch.h
+++ b/bindings/ios/Private/ListenerDispatch.h
@@ -1,0 +1,39 @@
+/**
+ * @file ListenerDispatch.h
+ * @brief dispatch functions for listener
+ *
+ * (c) 2021 - by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifndef ListenerDispatch_h
+#define ListenerDispatch_h
+
+typedef NS_ENUM (NSUInteger, ListenerQueueType) {
+    ListenerQueueTypeCurrent, // Current thread will be used. It is recommended to use current thread whenever it is possible. It has no thread switching, hence good performance
+    ListenerQueueTypeMain, // Main queue for UI update
+    ListenerQueueTypeGlobalBackground, // Global queue with QOS background
+    ListenerQueueTypeGlobalUtility, // Global queue with QOS utility
+    ListenerQueueTypeGlobalUserInitiated, // Global queue with QOS user initiated
+};
+
+typedef void (^ListenerBlock)(void);
+
+void dispatch(ListenerQueueType queueType, ListenerBlock block);
+
+#endif

--- a/bindings/ios/Private/ListenerDispatch.mm
+++ b/bindings/ios/Private/ListenerDispatch.mm
@@ -1,0 +1,44 @@
+/**
+ * @file ListenerDispatch.m
+ * @brief dispatch functions for listener
+ *
+ * (c) 2021 - by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+#import "ListenerDispatch.h"
+
+void dispatch(ListenerQueueType queueType, ListenerBlock block) {
+    switch (queueType) {
+        case ListenerQueueTypeCurrent:
+            block();
+            break;
+        case ListenerQueueTypeMain:
+            dispatch_async(dispatch_get_main_queue(), block);
+            break;
+        case ListenerQueueTypeGlobalBackground:
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), block);
+            break;
+        case ListenerQueueTypeGlobalUtility:
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), block);
+            break;
+        case ListenerQueueTypeGlobalUserInitiated:
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), block);
+            break;
+        default:
+            block();
+    }
+}


### PR DESCRIPTION
https://jira.developers.mega.co.nz/browse/IOS-4463

This is to boost app performance to move away from unnecessary UI threads switching. It is recommended to use ListenerQueueTypeCurrent to avoid thread switching and boost app performance.

SDK Objective-C++ Binding Guide:
https://confluence.developers.mega.co.nz/pages/viewpage.action?pageId=3639396#SDKObjectiveC++BindingGuide-ListenerCallbacks