### PR TITLE
SDK-1372. Protect against invalid `statusTable`

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -11756,8 +11756,9 @@ void MegaClient::fetchnodes(bool nocache)
 
     // only initial load from local cache
     if ((loggedin() == FULLACCOUNT || loggedIntoFolder() ) &&
-        !nodes.size() && sctable && !ISUNDEF(cachedscsn) &&
-        fetchsc(sctable) && fetchStatusTable(statusTable.get()))
+            !nodes.size() && !ISUNDEF(cachedscsn) &&
+            sctable && fetchsc(sctable) &&
+            statusTable && fetchStatusTable(statusTable.get()))
     {
         WAIT_CLASS::bumpds();
         fnstats.mode = FetchNodesStats::MODE_DB;


### PR DESCRIPTION
iOS reported crashes at `fetchStatusTable()`. Analog to the checkup of `sctable` before calling `fetchsc()`, the same should apply to the status table too.