### PR TITLE
SDK-1375 - Only use -fgomp if supported by the compiler.

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -264,6 +264,7 @@ ENDIF(WIN32)
 
 include(CheckIncludeFile)
 include(CheckFunctionExists)
+
 check_include_file(inttypes.h HAVE_INTTYPES_H)
 check_include_file(dirent.h HAVE_DIRENT_H)
 check_include_file(uv.h HAVE_LIBUV)
@@ -447,7 +448,15 @@ if (USE_THIRDPARTY_FROM_VCPKG)
             endif()
 
             IF(NOT CMAKE_HOST_APPLE AND NOT CMAKE_HOST_WIN32)
-                set(Mega_PlatformSpecificLibs ${Mega_PlatformSpecificLibs} -fopenmp -fgomp)
+                include(CheckCXXCompilerFlag)
+
+                check_cxx_compiler_flag(-fgomp HAS_FGOMP)
+                check_cxx_compiler_flag(-fopenmp HAS_FOPENMP)
+
+                set(Mega_PlatformSpecificLibs
+                      ${Mega_PlatformSpecificLibs}
+                      $<$<BOOL:${HAS_FGOMP}>:-fgomp>
+                      $<$<BOOL:${HAS_FOPENMP}>:-fopenmp>)
             ENDIF()
 
         ENDIF(USE_LIBRAW)


### PR DESCRIPTION
Don't specify the -fgomp compiler flag unless it's actually supported by the compiler.

This fixes a build failure on Debian 10 Buster.
