### PR TITLE
SDK-1377. Fix memory leak in MegaStringListPrivate ctor

### DIFF
--- a/include/mega/attrmap.h
+++ b/include/mega/attrmap.h
@@ -38,6 +38,7 @@ struct MEGA_API AttrMap
 
     // convert nameid to string
     static int nameid2string(nameid, char*);
+    static string nameid2string(nameid);
 
     // convert string to nameid
     static nameid string2nameid(const char *);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1681,17 +1681,16 @@ protected:
 class MegaStringListPrivate : public MegaStringList
 {
 public:
-    MegaStringListPrivate();
-    MegaStringListPrivate(char **newlist, int size); // takes ownership
-    virtual ~MegaStringListPrivate();
-    MEGA_DISABLE_COPY_MOVE(MegaStringListPrivate)
+    MegaStringListPrivate() = default;
+    MegaStringListPrivate(string_vector&&); // takes ownership
+    virtual ~MegaStringListPrivate() = default;
     MegaStringList *copy() const override;
     const char* get(int i) const override;
     int size() const override;
     void add(const char* value) override;
     const string_vector& getVector();
 protected:
-    MegaStringListPrivate(const MegaStringListPrivate *stringList);
+    MegaStringListPrivate(const MegaStringListPrivate& stringList) = default;
     string_vector mList;
 };
 

--- a/src/attrmap.cpp
+++ b/src/attrmap.cpp
@@ -52,6 +52,15 @@ int AttrMap::nameid2string(nameid id, char* buf)
     return static_cast<int>(ptr - buf);
 }
 
+string AttrMap::nameid2string(nameid id)
+{
+    string s;
+    s.resize(10);
+    s.resize(nameid2string(id, const_cast<char*>(s.data())));
+    return s;
+}
+
+
 nameid AttrMap::string2nameid(const char *a)
 {
     if (!a)

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -4285,7 +4285,7 @@ MegaStringListPrivate::MegaStringListPrivate(char **newlist, int size)
 {
     for (int i = 0; i < size; i++)
     {
-        mList.push_back(newlist[i]);
+        mList.push_back(std::unique_ptr<char[]>(newlist[i]).get());
     }
 }
 

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -2763,7 +2763,7 @@ GTEST_TEST(Sync, BasicSync_MassNotifyFromLocalFolderTree)
     auto startTime = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - startTime < std::chrono::seconds(5 * 60))
     {
-        int remaining = 0;
+        size_t remaining = 0;
         auto result0 = clientA1.thread_do<bool>([&](StandardClient &sc, PromiseBoolSP p)
         {
             sc.client.syncs.forEachRunningSync(


### PR DESCRIPTION
> MegaStringListPrivate(char **newlist, int size); // takes ownership

After creating the `string` with `char *` (before `push_back`) the char * should be freed to avoid the memory leak

Another alternative is use `delete newlist[i]` after push_back it into the `mList`