### PR TITLE
SDK-1379 - Update MegaApi unit test to use new MegaStringListPrivate constructor.

### DIFF
--- a/tests/unit/MegaApi_test.cpp
+++ b/tests/unit/MegaApi_test.cpp
@@ -33,13 +33,15 @@ namespace {
 
 unique_ptr<MegaStringList> createMegaStringList(const vector<const char*>& data)
 {
-    vector<char*> list;
+    string_vector list;
+
     for (const auto& value : data)
     {
-        list.emplace_back(MegaApi::strdup(value));
+        list.emplace_back(value);
     }
+
     return unique_ptr<MegaStringList>{
-        new MegaStringListPrivate{list.data(), static_cast<int>(list.size())}};
+        new MegaStringListPrivate{std::move(list)}};
 }
 
 } // anonymous


### PR DESCRIPTION
Updates the unit tests so that they use the new MegaStringListPrivate constructor.

This is necessary so that the unit tests build.
