### PR TITLE
SDK-1383 - Restore the legacy DB behavior

### DIFF
--- a/include/mega/db.h
+++ b/include/mega/db.h
@@ -159,8 +159,8 @@ enum DbOpenFlag
 
 struct MEGA_API DbAccess
 {
-    static const int LEGACY_DB_VERSION = 11;
-    static const int DB_VERSION = LEGACY_DB_VERSION + 1;
+    static const int LEGACY_DB_VERSION;
+    static const int DB_VERSION;
 
     DbAccess();
 

--- a/include/mega/db/sqlite.h
+++ b/include/mega/db/sqlite.h
@@ -26,21 +26,6 @@
 #include <sqlite3.h>
 
 namespace mega {
-class MEGA_API SqliteDbAccess : public DbAccess
-{
-    LocalPath mRootPath;
-
-public:
-    explicit SqliteDbAccess(const LocalPath& rootPath);
-
-    ~SqliteDbAccess();
-
-    DbTable* open(PrnGen &rng, FileSystemAccess& fsAccess, const string& name, const int flags) override;
-
-    bool probe(FileSystemAccess& fsAccess, const string& name) const override;
-
-    const LocalPath& rootPath() const override;
-};
 
 class MEGA_API SqliteDbTable : public DbTable
 {
@@ -65,7 +50,30 @@ public:
     ~SqliteDbTable();
 
     bool inTransaction() const override;
+
+    LocalPath dbFile() const;
 };
+
+class MEGA_API SqliteDbAccess : public DbAccess
+{
+    LocalPath mRootPath;
+
+public:
+    explicit SqliteDbAccess(const LocalPath& rootPath);
+
+    ~SqliteDbAccess();
+
+    LocalPath databasePath(const FileSystemAccess& fsAccess,
+                           const string& name,
+                           const int version) const;
+
+    SqliteDbTable* open(PrnGen &rng, FileSystemAccess& fsAccess, const string& name, const int flags = 0x0) override;
+
+    bool probe(FileSystemAccess& fsAccess, const string& name) const override;
+
+    const LocalPath& rootPath() const override;
+};
+
 } // namespace
 
 #endif

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -118,6 +118,9 @@ void DbTable::checkCommitter(DBTableTransactionCommitter*)
     assert(mTransactionCommitter);
 }
 
+const int DbAccess::LEGACY_DB_VERSION = 11;
+const int DbAccess::DB_VERSION = DbAccess::LEGACY_DB_VERSION + 1;
+
 DbAccess::DbAccess()
 {
     currentDbVersion = LEGACY_DB_VERSION;

--- a/src/db/sqlite.cpp
+++ b/src/db/sqlite.cpp
@@ -24,28 +24,6 @@
 #ifdef USE_SQLITE
 namespace mega {
 
-static LocalPath databasePath(const FileSystemAccess& fsAccess,
-                              const LocalPath& rootPath,
-                              const string& name,
-                              const int version)
-{
-    ostringstream osstream;
-
-    osstream << "megaclient_statecache"
-             << version
-             << "_"
-             << name
-             << ".db";
-
-    LocalPath path = rootPath;
-
-    path.appendWithSeparator(
-      LocalPath::fromPath(osstream.str(), fsAccess),
-      false);
-
-    return path;
-}
-
 SqliteDbAccess::SqliteDbAccess(const LocalPath& rootPath)
   : mRootPath(rootPath)
 {
@@ -55,12 +33,34 @@ SqliteDbAccess::~SqliteDbAccess()
 {
 }
 
-DbTable* SqliteDbAccess::open(PrnGen &rng, FileSystemAccess& fsAccess, const string& name, const int flags)
+LocalPath SqliteDbAccess::databasePath(const FileSystemAccess& fsAccess,
+                                       const string& name,
+                                       const int version) const
 {
-    auto dbPath = databasePath(fsAccess, mRootPath, name, DB_VERSION);
+    ostringstream osstream;
+
+    osstream << "megaclient_statecache"
+             << version
+             << "_"
+             << name
+             << ".db";
+
+    LocalPath path = mRootPath;
+
+    path.appendWithSeparator(
+      LocalPath::fromPath(osstream.str(), fsAccess),
+      false);
+
+    return path;
+}
+
+SqliteDbTable* SqliteDbAccess::open(PrnGen &rng, FileSystemAccess& fsAccess, const string& name, const int flags)
+{
+    auto dbPath = databasePath(fsAccess, name, DB_VERSION);
+    auto upgraded = true;
 
     {
-        auto legacyPath = databasePath(fsAccess, mRootPath, name, LEGACY_DB_VERSION);
+        auto legacyPath = databasePath(fsAccess, name, LEGACY_DB_VERSION);
         auto fileAccess = fsAccess.newfileaccess();
 
         if (fileAccess->fopen(legacyPath))
@@ -71,6 +71,7 @@ DbTable* SqliteDbAccess::open(PrnGen &rng, FileSystemAccess& fsAccess, const str
             {
                 LOG_debug << "Using a legacy database.";
                 dbPath = std::move(legacyPath);
+                upgraded = false;
             }
             else if ((flags & DB_OPEN_FLAG_RECYCLE))
             {
@@ -84,7 +85,7 @@ DbTable* SqliteDbAccess::open(PrnGen &rng, FileSystemAccess& fsAccess, const str
 
                     fsAccess.renamelocal(from, to);
 
-                    suffix = LocalPath::fromPath("-shm", fsAccess);
+                    suffix = LocalPath::fromPath("-wal", fsAccess);
                     from = legacyPath + suffix;
                     to = dbPath + suffix;
 
@@ -104,6 +105,12 @@ DbTable* SqliteDbAccess::open(PrnGen &rng, FileSystemAccess& fsAccess, const str
                 fsAccess.unlinklocal(legacyPath);
             }
         }
+    }
+
+    if (upgraded)
+    {
+        LOG_debug << "Using an upgraded DB: " << dbPath.toPath(fsAccess);
+        currentDbVersion = DB_VERSION;
     }
 
     const string dbPathStr = dbPath.toPath(fsAccess);
@@ -153,14 +160,14 @@ bool SqliteDbAccess::probe(FileSystemAccess& fsAccess, const string& name) const
 {
     auto fileAccess = fsAccess.newfileaccess();
 
-    LocalPath dbPath = databasePath(fsAccess, mRootPath, name, DB_VERSION);
+    LocalPath dbPath = databasePath(fsAccess, name, DB_VERSION);
 
     if (fileAccess->isfile(dbPath))
     {
         return true;
     }
 
-    dbPath = databasePath(fsAccess, mRootPath, name, LEGACY_DB_VERSION);
+    dbPath = databasePath(fsAccess, name, LEGACY_DB_VERSION);
 
     return fileAccess->isfile(dbPath);
 }
@@ -202,6 +209,11 @@ SqliteDbTable::~SqliteDbTable()
 bool SqliteDbTable::inTransaction() const
 {
     return sqlite3_get_autocommit(db) == 0;
+}
+
+LocalPath SqliteDbTable::dbFile() const
+{
+    return LocalPath::fromPath(dbfile, *fsaccess);
 }
 
 // set cursor to first record


### PR DESCRIPTION
Databases are now created using the correct database version.

A bank of unit tests have been added to validate the expected behavior of open, probe, rootPath.
