### PR TITLE
SDK-1341. Alternative implementation

### DIFF
--- a/include/megaapi.h
+++ b/include/megaapi.h
@@ -2996,7 +2996,7 @@ class MegaRequest
             TYPE_CREDIT_CARD_CANCEL_SUBSCRIPTIONS, TYPE_GET_SESSION_TRANSFER_URL,
             TYPE_GET_PAYMENT_METHODS, TYPE_INVITE_CONTACT, TYPE_REPLY_CONTACT_REQUEST,
             TYPE_SUBMIT_FEEDBACK, TYPE_SEND_EVENT, TYPE_CLEAN_RUBBISH_BIN,
-            TYPE_SET_ATTR_NODE, TYPE_GET_ATTR_NODE, TYPE_CHAT_CREATE, TYPE_CHAT_FETCH, TYPE_CHAT_INVITE,
+            TYPE_SET_ATTR_NODE, TYPE_CHAT_CREATE, TYPE_CHAT_FETCH, TYPE_CHAT_INVITE,
             TYPE_CHAT_REMOVE, TYPE_CHAT_URL, TYPE_CHAT_GRANT_ACCESS, TYPE_CHAT_REMOVE_ACCESS,
             TYPE_USE_HTTPS_ONLY, TYPE_SET_PROXY,
             TYPE_GET_RECOVERY_LINK, TYPE_QUERY_RECOVERY_LINK, TYPE_CONFIRM_RECOVERY_LINK,
@@ -3024,7 +3024,7 @@ class MegaRequest
             TYPE_SEND_DEV_COMMAND,
             TYPE_GET_BANNERS, TYPE_DISMISS_BANNER,
             TYPE_BACKUP_PUT, TYPE_BACKUP_REMOVE, TYPE_BACKUP_PUT_HEART_BEAT,
-            TYPE_FETCH_GOOGLE_ADS, TYPE_QUERY_GOOGLE_ADS,
+            TYPE_FETCH_GOOGLE_ADS, TYPE_QUERY_GOOGLE_ADS, TYPE_GET_ATTR_NODE,
             TOTAL_OF_REQUEST_TYPES
         };
 
@@ -3782,7 +3782,7 @@ class MegaRequest
          *
          * @return MegaHandle list
          */
-        virtual MegaNodeList* getMegaNodeList() const;
+        virtual MegaHandleList* getMegaHandleList() const;
 };
 
 /**
@@ -10969,8 +10969,18 @@ class MegaApi
         /**
          * @brief Get a list of favourite nodes.
          *
-         * @param node Node and it's children that will be searched for favourites. Search all nodes if null
-         * @param count if count is zero return all favourite nodes, otherwie return only 'count' favourite nodes
+         * The associated request type with this request is MegaRequest::TYPE_GET_ATTR_NODE
+         * Valid data in the MegaRequest object received on callbacks:
+         * - MegaRequest::getNodeHandle - Returns the handle of the node provided
+         * - MegaRequest::getParamType - Returns MegaApi::NODE_ATTR_FAV
+         * - MegaRequest::getNumDetails - Returns the count requested
+         *
+         * Valid data in the MegaRequest object received in onRequestFinish when the error code
+         * is MegaError::API_OK:
+         * - MegaRequest::getMegaHandleList - List of handles of favourite nodes
+         *
+         * @param node Node and its children that will be searched for favourites. Search all nodes if null
+         * @param count if count is zero return all favourite nodes, otherwise return only 'count' favourite nodes
          * @param listener MegaRequestListener to track this request
          */
         void getFavourites(MegaNode* node, int count, MegaRequestListener* listener = nullptr);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -208,20 +208,6 @@ class MegaSizeProcessor : public MegaTreeProcessor
         long long getTotalBytes();
 };
 
-class MegaFavouriteProcessor : public MegaTreeProcessor
-{
-protected:
-    std::unique_ptr<MegaNodeList> mFavouriteNodeList;
-
-public:
-    MegaFavouriteProcessor(int max);
-    bool processMegaNode(MegaNode* node) override;
-    MegaNodeList* getFavouriteNodes();
-
-private:
-    int mMaxNodes = 0;
-};
-
 class MegaRecursiveOperation
 {
 public:
@@ -638,11 +624,12 @@ public:
     MegaHandleListPrivate();
     MegaHandleListPrivate(const MegaHandleListPrivate *hList);
     virtual ~MegaHandleListPrivate();
+    MegaHandleListPrivate(const vector<handle> &handles);
 
-    virtual MegaHandleList *copy() const;
-    virtual MegaHandle get(unsigned int i) const;
-    virtual unsigned int size() const;
-    virtual void addMegaHandle(MegaHandle megaHandle);
+    MegaHandleList *copy() const override;
+    MegaHandle get(unsigned int i) const override;
+    unsigned int size() const override;
+    void addMegaHandle(MegaHandle megaHandle) override;
 
 private:
     std::vector<MegaHandle> mList;
@@ -1240,7 +1227,7 @@ class MegaRequestPrivate : public MegaRequest
         AchievementsDetails *getAchievementsDetails() const;
         MegaTimeZoneDetails *getMegaTimeZoneDetails () const override;
         MegaStringList *getMegaStringList() const override;
-        MegaNodeList* getMegaNodeList() const override;
+        MegaHandleList* getMegaHandleList() const override;
 
 #ifdef ENABLE_CHAT
         MegaTextChatPeerList *getMegaTextChatPeerList() const override;
@@ -1261,7 +1248,7 @@ class MegaRequestPrivate : public MegaRequest
         MegaBackgroundMediaUpload *getMegaBackgroundMediaUploadPtr() const override;
         void setMegaBackgroundMediaUploadPtr(MegaBackgroundMediaUpload *);  // non-owned pointer
         void setMegaStringList(MegaStringList* stringList);
-        void setMegaNodeList(MegaNodeList* nodeList);
+        void setMegaHandleList(const vector<handle> &handles);
 
 #ifdef ENABLE_SYNC
         void setRegExp(MegaRegExp *regExp);
@@ -1321,7 +1308,7 @@ protected:
         MegaPushNotificationSettings *settings;
         MegaBackgroundMediaUpload* backgroundMediaUpload;  // non-owned pointer
         unique_ptr<MegaStringList> mStringList;
-        unique_ptr<MegaNodeList> mNodeList;
+        unique_ptr<MegaHandleList> mHandleList;
 
     private:
         unique_ptr<MegaBannerListPrivate> mBannerList;
@@ -2075,6 +2062,18 @@ class TreeProcFolderInfo : public TreeProc
         int numVersions;
         long long currentSize;
         long long versionsSize;
+};
+
+class FavouriteProcessor : public TreeProcessor
+{
+public:
+    FavouriteProcessor(int maxCount);
+    bool processNode(Node* node) override;
+    const vector<handle> &getHandles() const;
+
+private:
+    vector<handle> handles;
+    unsigned mMaxCount = 0;
 };
 
 //Thread safe request queue

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -1068,7 +1068,7 @@ MegaStringList* MegaRequest::getMegaStringList() const
     return nullptr;
 }
 
-MegaNodeList* MegaRequest::getMegaNodeList() const
+MegaHandleList* MegaRequest::getMegaHandleList() const
 {
     return nullptr;
 }

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -648,7 +648,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
     case MegaRequest::TYPE_GET_ATTR_NODE:
         if (mApi[apiIndex].lastError == API_OK)
         {
-            mMegaFavNodeList = request->getMegaHandleList()->copy();
+            mMegaFavNodeList.reset(request->getMegaHandleList()->copy());
         }
         break;
     }

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -648,7 +648,7 @@ void SdkTest::onRequestFinish(MegaApi *api, MegaRequest *request, MegaError *e)
     case MegaRequest::TYPE_GET_ATTR_NODE:
         if (mApi[apiIndex].lastError == API_OK)
         {
-            mMegaFavNodeList = request->getMegaNodeList()->copy();
+            mMegaFavNodeList = request->getMegaHandleList()->copy();
         }
         break;
     }
@@ -5120,7 +5120,8 @@ TEST_F(SdkTest, SdkFavouriteNodes)
     ASSERT_EQ(mMegaFavNodeList->size(), 2) << "synchronousGetFavourites failed...";
     err = synchronousGetFavourites(0, nullptr, 1);
     ASSERT_EQ(mMegaFavNodeList->size(), 1) << "synchronousGetFavourites failed...";
-    ASSERT_EQ(mMegaFavNodeList->get(0)->getName(), UPFILE) << "synchronousGetFavourites failed with node passed nullptr";
+    unique_ptr<MegaNode> favNode(megaApi[0]->getNodeByHandle(mMegaFavNodeList->get(0)));
+    ASSERT_EQ(favNode->getName(), UPFILE) << "synchronousGetFavourites failed with node passed nullptr";
 }
 
 TEST_F(SdkTest, DISABLED_SdkDeviceNames)

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -204,7 +204,7 @@ public:
     MegaHandle mBackupId = UNDEF;
     std::vector<std::pair<string, MegaHandle> > mBackupNameToBackupId;
     std::set<MegaHandle> mBackupIds;
-    MegaHandleList* mMegaFavNodeList = nullptr;
+    unique_ptr<MegaHandleList> mMegaFavNodeList;
 
 protected:
     void SetUp() override;

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -204,7 +204,7 @@ public:
     MegaHandle mBackupId = UNDEF;
     std::vector<std::pair<string, MegaHandle> > mBackupNameToBackupId;
     std::set<MegaHandle> mBackupIds;
-    MegaNodeList* mMegaFavNodeList = nullptr;
+    MegaHandleList* mMegaFavNodeList = nullptr;
 
 protected:
     void SetUp() override;


### PR DESCRIPTION
- Use a TreeProcessor instead of MegaTreeProcessor
- Improve documentation of new public interface
- Return a MegaHandleList object, instead of MegaNodeList
- Add sanity checks for input params