### PR TITLE
SDK-1396 - Don't bother waiting for catchup()'s result.

### DIFF
--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1196,10 +1196,7 @@ struct StandardClient : public MegaApp
     {
         resultproc.prepresult(CATCHUP, ++next_request_tag,
             [&](){
-                auto request_sent = thread_do<bool>([](StandardClient& sc, PromiseBoolSP pb) { sc.client.catchup(); pb->set_value(true); });
-                if (!waitonresults(&request_sent)) {
-                    out() << "catchup not sent" << endl;
-                }
+                client.catchup();
             },
             [pb](error e) {
                 if (e)


### PR DESCRIPTION
The Sync integration tests periodically call "catchup()" to force the processing of pending action packets.

This change-set resolves a deadlock that would occur when catchup(PromiseBoolSP) was waiting for a result.
