### PR TITLE
SDK-1397. Introduce NodeHandle helper class, fix some tests

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -628,12 +628,12 @@ bool DemoApp::sync_syncable(Sync *, const char *name, LocalPath&)
 }
 #endif
 
-AppFileGet::AppFileGet(Node* n, handle ch, byte* cfilekey, m_off_t csize, m_time_t cmtime, string* cfilename,
+AppFileGet::AppFileGet(Node* n, NodeHandle ch, byte* cfilekey, m_off_t csize, m_time_t cmtime, string* cfilename,
                        string* cfingerprint, const string& targetfolder)
 {
     if (n)
     {
-        h = n->nodehandle;
+        h = n->nodeHandle();
         hprivate = true;
 
         *(FileFingerprint*) this = *n;
@@ -664,7 +664,7 @@ AppFileGet::AppFileGet(Node* n, handle ch, byte* cfilekey, m_off_t csize, m_time
     }
 }
 
-AppFilePut::AppFilePut(const LocalPath& clocalname, handle ch, const char* ctargetuser)
+AppFilePut::AppFilePut(const LocalPath& clocalname, NodeHandle ch, const char* ctargetuser)
 {
     // full local path
     localname = clocalname;
@@ -1482,7 +1482,7 @@ static char* line;
 static AccountDetails account;
 
 // Current remote directory.
-static handle cwd = UNDEF;
+static NodeHandle cwd;
 
 // Where we were on the local filesystem when megacli started.
 static LocalPath startDir;
@@ -1745,7 +1745,7 @@ static Node* nodebypath(const char* ptr, string* user = NULL, string* namepart =
         }
         else
         {
-            n = client->nodebyhandle(cwd);
+            n = client->nodeByHandle(cwd);
         }
     }
 
@@ -1995,9 +1995,9 @@ static void local_dumptree(const fs::path& de, int recurse, int depth = 0)
 }
 #endif
 
-static void nodepath(handle h, string* path)
+static void nodepath(NodeHandle h, string* path)
 {
-    Node* n = client->nodebyhandle(h);
+    Node* n = client->nodeByHandle(h);
     *path = n ? n->displaypath() : "";
 }
 
@@ -2452,7 +2452,7 @@ void exec_find(autocomplete::ACState& s)
 {
     if (s.words[1].s == "raided")
     {
-        if (Node* n = client->nodebyhandle(cwd))
+        if (Node* n = client->nodeByHandle(cwd))
         {
             auto q = std::make_shared<FileFindCommand::Stack>();
             getDepthFirstFileHandles(n, *q);
@@ -2513,7 +2513,7 @@ bool recurse_findemptysubfoldertrees(Node* n, bool moveToTrash)
 void exec_findemptysubfoldertrees(autocomplete::ACState& s)
 {
     bool moveToTrash = s.extractflag("-movetotrash");
-    if (Node* n = client->nodebyhandle(cwd))
+    if (Node* n = client->nodeByHandle(cwd))
     {
         if (recurse_findemptysubfoldertrees(n, moveToTrash))
         {
@@ -2607,7 +2607,7 @@ Node* nodeFromRemotePath(const string& s)
     Node* n;
     if (s.empty())
     {
-        n = client->nodebyhandle(cwd);
+        n = client->nodeByHandle(cwd);
     }
     else
     {
@@ -2989,7 +2989,7 @@ void exec_timelocal(autocomplete::ACState& s)
 
 void exec_backupcentre(autocomplete::ACState& s)
 {
-    bool del = s.extractflag("-del");
+    bool delFlag = s.extractflag("-del");
 
     if (s.words.size() == 1)
     {
@@ -3023,7 +3023,7 @@ void exec_backupcentre(autocomplete::ACState& s)
             }
         }));
     }
-    else if (s.words.size() == 2 && del)
+    else if (s.words.size() == 2 && delFlag)
     {
         handle backupId;
         Base64::atob(s.words[1].s.c_str(), (byte*)&backupId, MegaClient::BACKUPHANDLE);
@@ -3237,7 +3237,7 @@ bool recursiveget(fs::path&& localpath, Node* n, bool folders, unsigned& queued)
     {
         if (!folders)
         {
-            auto f = new AppFileGet(n, UNDEF, NULL, -1, 0, NULL, NULL, localpath.u8string());
+            auto f = new AppFileGet(n, NodeHandle(), NULL, -1, 0, NULL, NULL, localpath.u8string());
             f->appxfer_it = appxferq[GET].insert(appxferq[GET].end(), f);
             DBTableTransactionCommitter committer(client->tctable);
             client->startxfer(GET, f, committer);
@@ -3551,7 +3551,7 @@ void exec_ls(autocomplete::ACState& s)
     }
     else
     {
-        n = client->nodebyhandle(cwd);
+        n = client->nodeByHandle(cwd);
     }
 
     if (n)
@@ -3572,7 +3572,7 @@ void exec_cd(autocomplete::ACState& s)
             }
             else
             {
-                cwd = n->nodehandle;
+                cwd = n->nodeHandle();
             }
         }
         else
@@ -3582,7 +3582,7 @@ void exec_cd(autocomplete::ACState& s)
     }
     else
     {
-        cwd = client->rootnodes[0];
+        cwd = NodeHandle().set6byte(client->rootnodes[0]);
     }
 }
 
@@ -3941,7 +3941,7 @@ void exec_du(autocomplete::ACState& s)
     }
     else
     {
-        n = client->nodebyhandle(cwd);
+        n = client->nodeByHandle(cwd);
     }
 
     if (n)
@@ -4157,7 +4157,7 @@ void uploadLocalPath(nodetype_t type, std::string name, LocalPath& localname, No
             }
             fa.reset();
 
-            AppFile* f = new AppFilePut(localname, parent ? parent->nodehandle : UNDEF, targetuser.c_str());
+            AppFile* f = new AppFilePut(localname, parent ? parent->nodeHandle() : NodeHandle(), targetuser.c_str());
             *static_cast<FileFingerprint*>(f) = fp;
             f->appxfer_it = appxferq[PUT].insert(appxferq[PUT].end(), f);
             client->startxfer(PUT, f, committer);
@@ -4239,7 +4239,7 @@ void uploadLocalFolderContent(LocalPath& localname, Node* cloudFolder)
 
 void exec_put(autocomplete::ACState& s)
 {
-    handle target = cwd;
+    NodeHandle target = cwd;
     string targetuser;
     string newname;
     int total = 0;
@@ -4251,12 +4251,12 @@ void exec_put(autocomplete::ACState& s)
     {
         if ((n = nodebypath(s.words[2].s.c_str(), &targetuser, &newname)))
         {
-            target = n->nodehandle;
+            target = n->nodeHandle();
         }
     }
     else    // target is current path
     {
-        n = client->nodebyhandle(target);
+        n = client->nodeByHandle(target);
     }
 
     if (client->loggedin() == NOTLOGGEDIN && !targetuser.size() && !client->loggedIntoWritableFolder())
@@ -4778,7 +4778,7 @@ void exec_mkdir(autocomplete::ACState& s)
         Node* n;
         if (exactLeafName)
         {
-            n = client->nodebyhandle(cwd);
+            n = client->nodeByHandle(cwd);
             newname = s.words[1].s;
         }
         else
@@ -4830,7 +4830,7 @@ void exec_getfa(autocomplete::ACState& s)
 
     if (s.words.size() < 3)
     {
-        n = client->nodebyhandle(cwd);
+        n = client->nodeByHandle(cwd);
     }
     else if (!(n = nodebypath(s.words[2].s.c_str())))
     {
@@ -5877,7 +5877,7 @@ void exec_reload(autocomplete::ACState& s)
         nocache = true;
     }
 
-    cwd = UNDEF;
+    cwd = NodeHandle();
     client->cachedscsn = UNDEF;
     client->fetchnodes(nocache);
 }
@@ -5888,7 +5888,7 @@ void exec_logout(autocomplete::ACState& s)
 
     bool keepSyncConfigs = s.extractflag("-keepsyncconfigs");
 
-    cwd = UNDEF;
+    cwd = NodeHandle();
     client->logout(keepSyncConfigs);
 
     if (clientFolder)
@@ -6331,7 +6331,7 @@ void exec_version(autocomplete::ACState& s)
     cout << "* MediaInfo" << endl;
 #endif
 
-    cwd = UNDEF;
+    cwd = NodeHandle();
 }
 
 void exec_showpcr(autocomplete::ACState& s)
@@ -6585,7 +6585,7 @@ void exec_locallogout(autocomplete::ACState& s)
 {
     cout << "Logging off locally..." << endl;
 
-    cwd = UNDEF;
+    cwd = NodeHandle();
     client->locallogout(false, true);
 }
 
@@ -7171,7 +7171,7 @@ void DemoApp::exportnode_result(handle h, handle ph)
     if ((n = client->nodebyhandle(h)))
     {
         string path;
-        nodepath(h, &path);
+        nodepath(NodeHandle().set6byte(h), &path);
         cout << "Exported " << path << ": ";
 
         if (n->type != FILENODE && !n->sharekey)
@@ -7280,7 +7280,7 @@ void DemoApp::openfilelink_result(handle ph, const byte* key, m_off_t size,
         }
         else
         {
-            n = client->nodebyhandle(cwd);
+            n = client->nodeByHandle(cwd);
         }
 
         if (!n)
@@ -7461,7 +7461,7 @@ void DemoApp::checkfile_result(handle h, error e, byte* filekey, m_off_t size, m
         cout << "Initiating download..." << endl;
 
         DBTableTransactionCommitter committer(client->tctable);
-        AppFileGet* f = new AppFileGet(NULL, h, filekey, size, tm, filename, fingerprint);
+        AppFileGet* f = new AppFileGet(NULL, NodeHandle().set6byte(h), filekey, size, tm, filename, fingerprint);
         f->appxfer_it = appxferq[GET].insert(appxferq[GET].end(), f);
         client->startxfer(GET, f, committer);
     }
@@ -7571,9 +7571,9 @@ void DemoApp::nodes_updated(Node** n, int count)
     nodestats(c[1], "added or updated");
     nodestats(c[0], "removed");
 
-    if (ISUNDEF(cwd))
+    if (cwd.isUndef())
     {
-        cwd = client->rootnodes[0];
+        cwd = NodeHandle().set6byte(client->rootnodes[0]);
     }
 }
 

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -58,7 +58,7 @@ struct AppFileGet : public AppFile
     void completed(Transfer*, LocalNode*) override;
     void terminated() override;
 
-    AppFileGet(Node*, handle = UNDEF, byte* = NULL, m_off_t = -1, m_time_t = 0, string* = NULL, string* = NULL, const string& targetfolder = "");
+    AppFileGet(Node*, NodeHandle = NodeHandle(), byte* = NULL, m_off_t = -1, m_time_t = 0, string* = NULL, string* = NULL, const string& targetfolder = "");
     ~AppFileGet();
 };
 
@@ -71,7 +71,7 @@ struct AppFilePut : public AppFile
 
     void displayname(string*);
 
-    AppFilePut(const LocalPath&, handle, const char*);
+    AppFilePut(const LocalPath&, NodeHandle, const char*);
     ~AppFilePut();
 };
 

--- a/include/mega/autocomplete.h
+++ b/include/mega/autocomplete.h
@@ -201,11 +201,11 @@ namespace autocomplete {
     struct MEGA_API MegaFS : public ACNode
     {
         MegaClient* client;
-        ::mega::handle* cwd;
+        ::mega::NodeHandle* cwd;
         bool reportFiles = true;
         bool reportFolders = true;
         std::string descPref;
-        MegaFS(bool files, bool folders, MegaClient* a, ::mega::handle* curDirHandle, const std::string descriptionPrefix);
+        MegaFS(bool files, bool folders, MegaClient* a, ::mega::NodeHandle* curDirHandle, const std::string descriptionPrefix);
         bool addCompletions(ACState& s) override;
         std::ostream& describe(std::ostream& s) const override;
         bool match(ACState& s) const override;
@@ -263,9 +263,9 @@ namespace autocomplete {
     ACN localFSPath(const std::string descriptionPrefix = "");
     ACN localFSFile(const std::string descriptionPrefix = "");
     ACN localFSFolder(const std::string descriptionPrefix = "");
-    ACN remoteFSPath(MegaClient*, ::mega::handle*, const std::string descriptionPrefix = "");
-    ACN remoteFSFile(MegaClient*, ::mega::handle*, const std::string descriptionPrefix = "");
-    ACN remoteFSFolder(MegaClient*, ::mega::handle*, const std::string descriptionPrefix = "");
+    ACN remoteFSPath(MegaClient*, ::mega::NodeHandle*, const std::string descriptionPrefix = "");
+    ACN remoteFSFile(MegaClient*, ::mega::NodeHandle*, const std::string descriptionPrefix = "");
+    ACN remoteFSFolder(MegaClient*, ::mega::NodeHandle*, const std::string descriptionPrefix = "");
     ACN contactEmail(MegaClient*);
 
 }} //namespaces

--- a/include/mega/file.h
+++ b/include/mega/file.h
@@ -60,7 +60,7 @@ struct MEGA_API File: public FileFingerprint
     LocalPath localname;
 
     // source/target node handle
-    handle h;
+    NodeHandle h;
 
     // previous node, if any
     Node *previousNode = nullptr;

--- a/include/mega/megaclient.h
+++ b/include/mega/megaclient.h
@@ -1389,6 +1389,7 @@ public:
     // remove node subtree
     void deltree(handle);
 
+    Node* nodeByHandle(NodeHandle) const;
     Node* nodebyhandle(handle) const;
     Node* nodebyfingerprint(FileFingerprint*);
 #ifdef ENABLE_SYNC
@@ -1724,10 +1725,10 @@ public:
     Node *getrootnode(Node*);
 
     //returns true if the node referenced by the handle belongs to the logged-in account
-    bool isPrivateNode(handle h);
+    bool isPrivateNode(NodeHandle h);
 
     //returns true if the node referenced by the handle belongs to other account than the logged-in account
-    bool isForeignNode(handle h);
+    bool isForeignNode(NodeHandle h);
 
     // process node subtree
     void proctree(Node*, TreeProc*, bool skipinshares = false, bool skipversions = false);

--- a/include/mega/node.h
+++ b/include/mega/node.h
@@ -45,6 +45,9 @@ struct MEGA_API NodeCore
     // node's own handle
     handle nodehandle = UNDEF;
 
+    // inline convenience function to get a typed version that ensures we use the 6 bytes of a node handle, and not 8
+    NodeHandle nodeHandle() const { return NodeHandle().set6byte(nodehandle); }
+
     // parent node handle (in a Node context, temporary placeholder until parent is set)
     handle parenthandle = UNDEF;
 
@@ -133,7 +136,7 @@ struct MEGA_API Node : public NodeCore, FileFingerprint
     bool setparent(Node*);
 
     // follow the parent links all the way to the top
-    Node* firstancestor();
+    const Node* firstancestor() const;
 
     // copy JSON-delimited string
     static void copystring(string*, const char*);

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -404,7 +404,7 @@ public:
 private:
     // Reads this database from the specified slot on disk.
     error read(JSONSyncConfigIOContext& ioContext,
-               const unsigned int slot);
+               unsigned int slot);
 
     // Remove config by backup tag.
     error removeByBackupId(handle backupId, bool flush);
@@ -449,7 +449,7 @@ public:
     bool deserialize(const LocalPath& dbPath,
                      JSONSyncConfigMap& configs,
                      JSON& reader,
-                     const unsigned int slot) const;
+                     unsigned int slot) const;
 
     // Deserialize configs from JSON.
     bool deserialize(JSONSyncConfigMap& configs,
@@ -462,11 +462,11 @@ public:
     // Read data from the specified slot.
     virtual error read(const LocalPath& dbPath,
                        string& data,
-                       const unsigned int slot);
+                       unsigned int slot);
 
     // Remove an existing slot from disk.
     virtual error remove(const LocalPath& dbPath,
-                         const unsigned int slot);
+                         unsigned int slot);
 
     // Remove all existing slots from disk.
     virtual error remove(const LocalPath& dbPath);
@@ -478,7 +478,7 @@ public:
     // Write data to the specified slot.
     virtual error write(const LocalPath& dbPath,
                         const string& data,
-                        const unsigned int slot);
+                        unsigned int slot);
 
     // Prefix applied to configuration database names.
     static const string NAME_PREFIX;
@@ -486,7 +486,7 @@ public:
 private:
     // Generate complete database path.
     LocalPath dbFilePath(const LocalPath& dbPath,
-                         const unsigned int slot) const;
+                         unsigned int slot) const;
 
     // Decrypt data.
     bool decrypt(const string& in, string& out);

--- a/include/mega/types.h
+++ b/include/mega/types.h
@@ -270,7 +270,7 @@ class NodeHandle
     uint64_t h = 0xFFFFFFFFFFFFFFFF;
 public:
     bool isUndef() { return (h & 0xFFFFFFFFFFFF) == 0xFFFFFFFFFFFF; }
-    NodeHandle& set6byte(uint64_t n) { h = n; assert((n & 0xFFFF000000000000) == 0); return *this; }
+    NodeHandle& set6byte(uint64_t n) { h = n; assert((n & 0xFFFF000000000000) == 0 || n == 0xFFFFFFFFFFFFFFFF); return *this; }
     bool eq(NodeHandle b) { return (h & 0xFFFFFFFFFFFF) == (b.h & 0xFFFFFFFFFFFF); }
     bool eq(handle b) { return (h & 0xFFFFFFFFFFFF) == (b & 0xFFFFFFFFFFFF); }
     bool ne(handle b) { return (h & 0xFFFFFFFFFFFF) != (b & 0xFFFFFFFFFFFF); }

--- a/include/mega/utils.h
+++ b/include/mega/utils.h
@@ -57,6 +57,7 @@ namespace mega {
 #define MAKENAMEID8(a, b, c, d, e, f, g, h) (nameid)((((uint64_t)a) << 56) + (((uint64_t)b) << 48) + (((uint64_t)c) << 40) + (((uint64_t)d) << 32) + ((e) << 24) + ((f) << 16) + ((g) << 8) + (h))
 
 std::string toNodeHandle(handle nodeHandle);
+std::string toNodeHandle(NodeHandle nodeHandle);
 std::string toHandle(handle h);
 #define LOG_NODEHANDLE(x) toNodeHandle(x)
 #define LOG_HANDLE(x) toHandle(x)

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -1969,7 +1969,7 @@ struct MegaFilePut : public MegaFile
 {
     void completed(Transfer* t, LocalNode*) override;
     void terminated() override;
-    MegaFilePut(MegaClient *client, LocalPath clocalname, string *filename, handle ch, const char* ctargetuser, int64_t mtime = -1, bool isSourceTemporary = false, Node *pvNode = nullptr);
+    MegaFilePut(MegaClient *client, LocalPath clocalname, string *filename, NodeHandle ch, const char* ctargetuser, int64_t mtime = -1, bool isSourceTemporary = false, Node *pvNode = nullptr);
     ~MegaFilePut() {}
 
     bool serialize(string*) override;

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -674,7 +674,7 @@ std::ostream& LocalFS::describe(std::ostream& s) const
     return s << descPref << (descPref.size() < 10 ? (reportFiles ? (reportFolders ? "localpath" : "localfile") : "localfolder") : "");
 }
 
-MegaFS::MegaFS(bool files, bool folders, MegaClient* c, ::mega::handle* curDirHandle, const std::string descriptionPrefix)
+MegaFS::MegaFS(bool files, bool folders, MegaClient* c, ::mega::NodeHandle* curDirHandle, const std::string descriptionPrefix)
     : client(c)
     , cwd(curDirHandle)
     , reportFiles(files)
@@ -762,7 +762,7 @@ bool MegaFS::addCompletions(ACState& s)
 
                 if (!n && *cwd != UNDEF)
                 {
-                    n = client->nodebyhandle(*cwd);
+                    n = client->nodeByHandle(*cwd);
                     pathprefix.clear();
                 }
             }
@@ -1345,17 +1345,17 @@ ACN localFSFolder(const std::string descriptionPrefix)
     return ACN(new LocalFS(false, true, descriptionPrefix));
 }
 
-ACN remoteFSPath(MegaClient* client, ::mega::handle* cwd, const std::string descriptionPrefix)
+ACN remoteFSPath(MegaClient* client, ::mega::NodeHandle* cwd, const std::string descriptionPrefix)
 {
     return ACN(new MegaFS(true, true, client, cwd, descriptionPrefix));
 }
 
-ACN remoteFSFile(MegaClient* client, ::mega::handle* cwd, const std::string descriptionPrefix)
+ACN remoteFSFile(MegaClient* client, ::mega::NodeHandle* cwd, const std::string descriptionPrefix)
 {
     return ACN(new MegaFS(true, false, client, cwd, descriptionPrefix));
 }
 
-ACN remoteFSFolder(MegaClient* client, ::mega::handle* cwd, const std::string descriptionPrefix)
+ACN remoteFSFolder(MegaClient* client, ::mega::NodeHandle* cwd, const std::string descriptionPrefix)
 {
     return ACN(new MegaFS(false, true, client, cwd, descriptionPrefix));
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -319,9 +319,9 @@ CommandPutFile::CommandPutFile(MegaClient* client, TransferSlot* ctslot, int ms)
     bool begun = false;
     for (auto &file : tslot->transfer->files)
     {
-        if (!ISUNDEF(file->h))
+        if (!file->h.isUndef())
         {
-            Node *node = client->nodebyhandle(file->h);
+            Node *node = client->nodeByHandle(file->h);
             if (node)
             {
                 handle rootnode = client->getrootnode(node)->nodehandle;
@@ -351,7 +351,7 @@ CommandPutFile::CommandPutFile(MegaClient* client, TransferSlot* ctslot, int ms)
         // Target user goes alone, not inside an array. Note: we are skipping this if a)more than two b)the array had been created for node handles
         for (auto &file : tslot->transfer->files)
         {
-            if (ISUNDEF(file->h) && file->targetuser.size())
+            if (file->h.isUndef() && file->targetuser.size())
             {
                 arg("t", file->targetuser.c_str());
                 break;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -37,7 +37,6 @@ File::File()
     hforeign = false;
     syncxfer = false;
     temporaryfile = false;
-    h = UNDEF;
     tag = 0;
 }
 
@@ -213,7 +212,7 @@ File *File::unserialize(string *d)
     file->privauth.assign(privauth, privauthlen);
     file->pubauth.assign(pubauth, pubauthlen);
 
-    file->h = MemAccess::get<handle>(ptr);
+    file->h.set6byte(MemAccess::get<handle>(ptr));
     ptr += sizeof(handle);
 
     memcpy(file->filekey, ptr, FILENODEKEYLENGTH);
@@ -339,7 +338,7 @@ void File::completed(Transfer* t, LocalNode* l)
         }
         else
         {
-            handle th = h;
+            handle th = h.as8byte();
 
             // inaccessible target folder - use //bin instead
             if (!t->client->nodebyhandle(th))
@@ -434,7 +433,7 @@ void File::displayname(string* dname)
     {
         Node* n;
 
-        if ((n = transfer->client->nodebyhandle(h)))
+        if ((n = transfer->client->nodeByHandle(h)))
         {
             *dname = n->displayname();
         }
@@ -451,7 +450,7 @@ SyncFileGet::SyncFileGet(Sync* csync, Node* cn, const LocalPath& clocalname)
     sync = csync;
 
     n = cn;
-    h = n->nodehandle;
+    h = n->nodeHandle();
     *(FileFingerprint*)this = *n;
     localname = clocalname;
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -36,6 +36,17 @@
 
 namespace mega {
 
+
+std::ostream& operator<<(std::ostream& s, NodeHandle h)
+{
+    return s << toNodeHandle(h);
+}
+
+SimpleLogger& operator<<(SimpleLogger& s, NodeHandle h)
+{
+    return s << toNodeHandle(h);
+}
+
 Logger *SimpleLogger::logger = nullptr;
 
 // by the default, display logs with level equal or less than logInfo

--- a/src/megaapi.cpp
+++ b/src/megaapi.cpp
@@ -5822,7 +5822,7 @@ const char* MegaSync::getMegaSyncErrorCode()
 
 const char* MegaSync::getMegaSyncErrorCode(int errorCode)
 {
-    return strdup(SyncConfig::syncErrorToStr(static_cast<SyncError>(errorCode)).c_str());
+    return MegaApi::strdup(SyncConfig::syncErrorToStr(static_cast<SyncError>(errorCode)).c_str());
 }
 
 const char* MegaSync::getMegaSyncWarningCode()

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -6951,7 +6951,7 @@ void MegaApiImpl::getFavourites(MegaNode* node, int count, MegaRequestListener* 
     request->setParamType(MegaApi::NODE_ATTR_FAV);
     request->setNumDetails(count);
     requestQueue.push(request);
-    waiter->notify(); 
+    waiter->notify();
 }
 
 static void encodeCoordinates(double latitude, double longitude, int& lat, int& lon)
@@ -17087,6 +17087,7 @@ void MegaApiImpl::processTransferFailed(Transfer *tr, MegaTransferPrivate *trans
     else
     {
         transfer->setState(MegaTransfer::STATE_RETRYING);
+        LOG_verbose << "processTransferFailed checking handle " << transfer->getParentHandle();
         transfer->setForeignOverquota(e == API_EOVERQUOTA && client->isForeignNode(NodeHandle().set6byte(transfer->getParentHandle())));
         fireOnTransferTemporaryError(transfer, std::move(megaError));
     }
@@ -18645,8 +18646,8 @@ unsigned MegaApiImpl::sendPendingTransfers()
 
                     currentTransfer = transfer;
                     string wFileName = fileName;
-                    MegaFilePut *f = new MegaFilePut(client, std::move(wLocalPath), &wFileName, 
-                            NodeHandle().set6byte(transfer->getParentHandle()), 
+                    MegaFilePut *f = new MegaFilePut(client, std::move(wLocalPath), &wFileName,
+                            NodeHandle().set6byte(transfer->getParentHandle()),
                             uploadToInbox ? inboxTarget : "", mtime, isSourceTemporary, previousNode);
                     *static_cast<FileFingerprint*>(f) = fp;  // deliberate slicing - startxfer would re-fingerprint if we don't supply this info
                     f->setTransfer(transfer);
@@ -20600,7 +20601,7 @@ void MegaApiImpl::sendPendingRequests()
                 FavouriteProcessor processor(count);
                 processTree(node, &processor);
                 request->setMegaHandleList(processor.getHandles());
-                
+
                 fireOnRequestFinish(request, make_unique<MegaErrorPrivate>(API_OK));
             }
             break;

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -540,9 +540,9 @@ Node *MegaClient::getrootnode(Node *node)
     return n;
 }
 
-bool MegaClient::isPrivateNode(handle h)
+bool MegaClient::isPrivateNode(NodeHandle h)
 {
-    Node *node = nodebyhandle(h);
+    Node *node = nodeByHandle(h);
     if (!node)
     {
         return false;
@@ -552,9 +552,9 @@ bool MegaClient::isPrivateNode(handle h)
     return (rootnode == rootnodes[0] || rootnode == rootnodes[1] || rootnode == rootnodes[2]);
 }
 
-bool MegaClient::isForeignNode(handle h)
+bool MegaClient::isForeignNode(NodeHandle h)
 {
-    Node *node = nodebyhandle(h);
+    Node *node = nodeByHandle(h);
     if (!node)
     {
         return false;
@@ -3577,7 +3577,7 @@ void MegaClient::dispatchTransfers()
                         if ((*it)->hprivate && !(*it)->hforeign)
                         {
                             // Make sure we have the size field
-                            Node* n = nodebyhandle((*it)->h);
+                            Node* n = nodeByHandle((*it)->h);
                             if (!n)
                             {
                                 missingPrivateNode = true;
@@ -3698,7 +3698,7 @@ void MegaClient::dispatchTransfers()
 
                 if (openfinished && openok)
                 {
-                    handle h = UNDEF;
+                    NodeHandle h;
                     bool hprivate = true;
                     const char *privauth = NULL;
                     const char *pubauth = NULL;
@@ -3772,7 +3772,7 @@ void MegaClient::dispatchTransfers()
                         for (file_list::iterator it = nexttransfer->files.begin();
                             it != nexttransfer->files.end(); it++)
                         {
-                            if (!(*it)->hprivate || (*it)->hforeign || nodebyhandle((*it)->h))
+                            if (!(*it)->hprivate || (*it)->hforeign || nodeByHandle((*it)->h))
                             {
                                 h = (*it)->h;
                                 hprivate = (*it)->hprivate;
@@ -3798,7 +3798,7 @@ void MegaClient::dispatchTransfers()
                     {
                         reqs.add((ts->pendingcmd = (nexttransfer->type == PUT)
                             ? (Command*)new CommandPutFile(this, ts, putmbpscap)
-                            : (Command*)new CommandGetFile(this, ts, NULL, h, hprivate, privauth, pubauth, chatauth)));
+                            : (Command*)new CommandGetFile(this, ts, NULL, h.as8byte(), hprivate, privauth, pubauth, chatauth)));
                     }
 
                     LOG_debug << "Activating transfer";
@@ -7217,6 +7217,12 @@ Node* MegaClient::nodebyhandle(handle h) const
     }
 
     return nullptr;
+}
+
+Node* MegaClient::nodeByHandle(NodeHandle h) const
+{
+    if (h.isUndef()) return nullptr;
+    return nodebyhandle(h.as8byte());
 }
 
 // server-client deletion
@@ -14263,7 +14269,7 @@ void MegaClient::syncupdate()
             {
                 if (l->parent->node)
                 {
-                    l->h = l->parent->node->nodehandle;
+                    l->h = l->parent->node->nodeHandle();
                 }
 
                 l->previousNode = l->node;
@@ -14960,8 +14966,8 @@ bool MegaClient::startxfer(direction_t d, File* f, DBTableTransactionCommitter& 
             }
         }
 
-        assert( (ISUNDEF(f->h) && f->targetuser.size() && (f->targetuser.size() == 11 || f->targetuser.find("@")!=string::npos) ) // <- uploading to inbox
-                || (!ISUNDEF(f->h) && (nodebyhandle(f->h) || d == GET) )); // target handle for the upload should be known at this time (except for inbox uploads)
+        assert( (f->h.isUndef() && f->targetuser.size() && (f->targetuser.size() == 11 || f->targetuser.find("@")!=string::npos) ) // <- uploading to inbox
+                || (!f->h.isUndef() && (nodeByHandle(f->h) || d == GET) )); // target handle for the upload should be known at this time (except for inbox uploads)
     }
 
     return true;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -155,7 +155,7 @@ Node::~Node()
             parent->children.erase(child_it);
         }
 
-        Node* fa = firstancestor();
+        const Node* fa = firstancestor();
         handle ancestor = fa->nodehandle;
         if (ancestor == client->rootnodes[0] || ancestor == client->rootnodes[1] || ancestor == client->rootnodes[2] || fa->inshare)
         {
@@ -1025,7 +1025,7 @@ bool Node::setparent(Node* p)
     NodeCounter nc;
     bool gotnc = false;
 
-    Node *originalancestor = firstancestor();
+    const Node *originalancestor = firstancestor();
     handle oah = originalancestor->nodehandle;
     if (oah == client->rootnodes[0] || oah == client->rootnodes[1] || oah == client->rootnodes[2] || originalancestor->inshare)
     {
@@ -1052,7 +1052,7 @@ bool Node::setparent(Node* p)
         child_it = parent->children.insert(parent->children.end(), this);
     }
 
-    Node* newancestor = firstancestor();
+    const Node* newancestor = firstancestor();
     handle nah = newancestor->nodehandle;
     if (nah == client->rootnodes[0] || nah == client->rootnodes[1] || nah == client->rootnodes[2] || newancestor->inshare)
     {
@@ -1095,9 +1095,9 @@ bool Node::setparent(Node* p)
     return true;
 }
 
-Node* Node::firstancestor()
+const Node* Node::firstancestor() const
 {
-    Node* n = this;
+    const Node* n = this;
     while (n->parent != NULL)
     {
         n = n->parent;
@@ -1713,13 +1713,13 @@ void LocalNode::completed(Transfer* t, LocalNode*)
     // exist or is newer
     if (!parent || !parent->node || (node && mtime < node->mtime))
     {
-        h = t->client->rootnodes[RUBBISHNODE - ROOTNODE];
+        h = NodeHandle().set6byte(t->client->rootnodes[RUBBISHNODE - ROOTNODE]);
     }
     else
     {
         // otherwise, overwrite node if it already exists and complete in its
         // place
-        h = parent->node->nodehandle;
+        h = parent->node->nodeHandle();
     }
 
     File::completed(t, this);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -3073,7 +3073,7 @@ error JSONSyncConfigDB::write(JSONSyncConfigIOContext& ioContext)
 }
 
 error JSONSyncConfigDB::read(JSONSyncConfigIOContext& ioContext,
-                             const unsigned int slot)
+                             unsigned int slot)
 {
     // Try and read the database from the specified slot.
     string data;
@@ -3177,7 +3177,7 @@ JSONSyncConfigIOContext::~JSONSyncConfigIOContext()
 bool JSONSyncConfigIOContext::deserialize(const LocalPath& dbPath,
                                           JSONSyncConfigMap& configs,
                                           JSON& reader,
-                                          const unsigned int slot) const
+                                          unsigned int slot) const
 {
     auto path = dbFilePath(dbPath, slot).toPath(mFsAccess);
 
@@ -3344,7 +3344,7 @@ error JSONSyncConfigIOContext::getSlotsInOrder(const LocalPath& dbPath,
 
 error JSONSyncConfigIOContext::read(const LocalPath& dbPath,
                                     string& data,
-                                    const unsigned int slot)
+                                    unsigned int slot)
 {
     // Generate path to the configuration file.
     LocalPath path = dbFilePath(dbPath, slot);
@@ -3395,7 +3395,7 @@ error JSONSyncConfigIOContext::read(const LocalPath& dbPath,
 }
 
 error JSONSyncConfigIOContext::remove(const LocalPath& dbPath,
-                                      const unsigned int slot)
+                                      unsigned int slot)
 {
     LocalPath path = dbFilePath(dbPath, slot);
 
@@ -3450,7 +3450,7 @@ void JSONSyncConfigIOContext::serialize(const JSONSyncConfigMap& configs,
 
 error JSONSyncConfigIOContext::write(const LocalPath& dbPath,
                                      const string& data,
-                                     const unsigned int slot)
+                                     unsigned int slot)
 {
     LocalPath path = dbPath;
 
@@ -3518,7 +3518,7 @@ error JSONSyncConfigIOContext::write(const LocalPath& dbPath,
 }
 
 LocalPath JSONSyncConfigIOContext::dbFilePath(const LocalPath& dbPath,
-                                              const unsigned int slot) const
+                                              unsigned int slot) const
 {
     using std::to_string;
 

--- a/src/transfer.cpp
+++ b/src/transfer.cpp
@@ -453,7 +453,7 @@ void Transfer::failed(const Error& e, DBTableTransactionCommitter& committer, ds
 #ifdef ENABLE_SYNC
             if (f->syncxfer)
             {
-                client->disableSyncContainingNode(f->h, FOREIGN_TARGET_OVERSTORAGE, true);  // still try to resume at startup
+                client->disableSyncContainingNode(f->h.as8byte(), FOREIGN_TARGET_OVERSTORAGE, true);  // still try to resume at startup
             }
 #endif
             removeTransferFile(API_EOVERQUOTA, f, &committer);
@@ -642,7 +642,7 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
                 syncxfer = true;
             }
 
-            if (!fixedfingerprint && (n = client->nodebyhandle((*it)->h))
+            if (!fixedfingerprint && (n = client->nodeByHandle((*it)->h))
                  && !(*(FileFingerprint*)this == *(FileFingerprint*)n))
             {
                 LOG_debug << "Wrong fingerprint already fixed";
@@ -712,7 +712,7 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
                 set<handle> nodes;
                 for (file_list::iterator it = files.begin(); it != files.end(); it++)
                 {
-                    if ((*it)->hprivate && !(*it)->hforeign && (n = client->nodebyhandle((*it)->h))
+                    if ((*it)->hprivate && !(*it)->hforeign && (n = client->nodeByHandle((*it)->h))
                             && nodes.find(n->nodehandle) == nodes.end())
                     {
                         nodes.insert(n->nodehandle);
@@ -864,7 +864,7 @@ void Transfer::complete(DBTableTransactionCommitter& committer)
                 if (success)
                 {
                     // set missing node attributes
-                    if ((*it)->hprivate && !(*it)->hforeign && (n = client->nodebyhandle((*it)->h)))
+                    if ((*it)->hprivate && !(*it)->hforeign && (n = client->nodeByHandle((*it)->h)))
                     {
                         if (!client->gfxdisabled && client->gfx && client->gfx->isgfx(localname) &&
                             keys.find(n->nodekey()) == keys.end() &&    // this file hasn't been processed yet

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -45,6 +45,10 @@ string toNodeHandle(handle nodeHandle)
     return string(base64Handle);
 }
 
+string toNodeHandle(NodeHandle nodeHandle)
+{
+    return toNodeHandle(nodeHandle.as8byte());
+}
 string toHandle(handle h)
 {
     char base64Handle[14];

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -5099,7 +5099,7 @@ TEST_F(SdkTest, SdkFavouriteNodes)
 
     auto err = synchronousSetNodeFavourite(0, subFolderA.get(), true);
     err = synchronousSetNodeFavourite(0, n1.get(), true);
-    
+
     err = synchronousGetFavourites(0, subFolderA.get(), 0);
     ASSERT_EQ(MegaError::API_OK, err) << "synchronousGetFavourites (error: " << err << ")";
     ASSERT_EQ(mMegaFavNodeList->size(), 2u) << "synchronousGetFavourites failed...";
@@ -6092,13 +6092,13 @@ TEST_F(SdkTest, SyncRemoteNode)
         // Rename remote folder --> Sync fail
         LOG_verbose << "SyncRemoteNode :  Rename remote node with sync active.";
         std::string basePathRenamed = "SyncRemoteNodeRenamed";
-        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), basePathRenamed.c_str()));
+        ASSERT_EQ(API_OK, doRenameNode(0, remoteBaseNode.get(), basePathRenamed.c_str()));
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_PATH_HAS_CHANGED, sync->getError());
 
         LOG_verbose << "SyncRemoteNode :  Restoring remote folder name.";
-        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), basePath.u8string().c_str()));
+        ASSERT_EQ(API_OK, doRenameNode(0, remoteBaseNode.get(), basePath.u8string().c_str()));
         ASSERT_NE(remoteBaseNode.get(), nullptr);
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
@@ -6122,13 +6122,13 @@ TEST_F(SdkTest, SyncRemoteNode)
     {
         TestingWithLogErrorAllowanceGuard g;
         LOG_verbose << "SyncRemoteNode :  Move remote node with sync active to the secondary folder.";
-        ASSERT_TRUE(doMoveNode(0, remoteBaseNode.get(), remoteMoveNodeParent.get()));
+        ASSERT_EQ(API_OK, doMoveNode(0, remoteBaseNode.get(), remoteMoveNodeParent.get()));
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_PATH_HAS_CHANGED, sync->getError());
 
         LOG_verbose << "SyncRemoteNode :  Moving back the remote node.";
-        ASSERT_TRUE(doMoveNode(0, remoteBaseNode.get(), remoteRootNode.get()));
+        ASSERT_EQ(API_OK, doMoveNode(0, remoteBaseNode.get(), remoteRootNode.get()));
         ASSERT_NE(remoteBaseNode.get(), nullptr);
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
@@ -6148,13 +6148,13 @@ TEST_F(SdkTest, SyncRemoteNode)
         TestingWithLogErrorAllowanceGuard g;
         LOG_verbose << "SyncRemoteNode :  Rename remote node.";
         std::string renamedBasePath = basePath.u8string() + "Renamed";
-        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), renamedBasePath.c_str()));
+        ASSERT_EQ(API_OK, doRenameNode(0, remoteBaseNode.get(), renamedBasePath.c_str()));
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_PATH_HAS_CHANGED, sync->getError());
 
         LOG_verbose << "SyncRemoteNode :  Renaming back the remote node.";
-        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), basePath.u8string().c_str()));
+        ASSERT_EQ(API_OK, doRenameNode(0, remoteBaseNode.get(), basePath.u8string().c_str()));
         ASSERT_NE(remoteBaseNode.get(), nullptr);
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
@@ -6178,7 +6178,7 @@ TEST_F(SdkTest, SyncRemoteNode)
         TestingWithLogErrorAllowanceGuard g;
         // Remove remote folder --> Sync fail
         LOG_verbose << "SyncRemoteNode :  Removing remote node with sync active.";
-        ASSERT_TRUE(doDeleteNode(0, remoteBaseNode.get()));                                //  <--- remote node deleted!!
+        ASSERT_EQ(API_OK, doDeleteNode(0, remoteBaseNode.get()));                                //  <--- remote node deleted!!
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_DELETED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_NODE_NOT_FOUND, sync->getError());

--- a/tests/integration/SdkTest_test.cpp
+++ b/tests/integration/SdkTest_test.cpp
@@ -287,7 +287,7 @@ void SdkTest::TearDown()
     out() << logTime() << "Test done, teardown starts" << endl;
     // do some cleanup
 
-    for (size_t i = 0; i < gSessionIDs.size(); ++i)
+    for (size_t i = 0; i < megaApi.size(); ++i)
     {
         if (gResumeSessions && megaApi[i] && gSessionIDs[i].empty())
         {
@@ -993,10 +993,14 @@ void SdkTest::getAccountsForTest(unsigned howMany)
     }
 
     // wait for logins to complete:
+    bool anyLoginFailed = false;
     for (unsigned index = 0; index < howMany; ++index)
     {
-        ASSERT_EQ(API_OK, trackers[index]->waitForResult()) << " Failed to establish a login/session for accout " << index;
+        auto loginResult = trackers[index]->waitForResult();
+        EXPECT_EQ(API_OK, loginResult) << " Failed to establish a login/session for accout " << index;
+        if (loginResult != API_OK) anyLoginFailed = true;
     }
+    ASSERT_FALSE(anyLoginFailed);
 
     // perform parallel fetchnodes for each
     for (unsigned index = 0; index < howMany; ++index)
@@ -1006,10 +1010,14 @@ void SdkTest::getAccountsForTest(unsigned howMany)
     }
 
     // wait for fetchnodes to complete:
+    bool anyFetchnodesFailed = false;
     for (unsigned index = 0; index < howMany; ++index)
     {
-        ASSERT_EQ(API_OK, trackers[index]->waitForResult()) << " Failed to fetchnodes for accout " << index;
+        auto fetchnodesResult = trackers[index]->waitForResult();
+        EXPECT_EQ(API_OK, fetchnodesResult) << " Failed to fetchnodes for accout " << index;
+        anyFetchnodesFailed = anyFetchnodesFailed || (fetchnodesResult != API_OK);
     }
+    ASSERT_FALSE(anyFetchnodesFailed);
 
     // In case the last test exited without cleaning up (eg, debugging etc)
     out() << logTime() << "Cleaning up account 0" << endl;
@@ -1163,46 +1171,6 @@ void SdkTest::createFolder(unsigned int apiIndex, const char *name, MegaNode *n,
     ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Cannot create a folder (error: " << mApi[apiIndex].lastError << ")";
 }
 
-void SdkTest::deleteNode(unsigned int apiIndex, MegaNode *n, int timeout)
-{
-    mApi[apiIndex].requestFlags[MegaRequest::TYPE_REMOVE] = false;
-    mApi[apiIndex].megaApi->remove(n);
-
-    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_REMOVE], timeout) )
-            << "Removing node failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Cannot remove a node (error: " << mApi[apiIndex].lastError << ")";
-}
-
-void SdkTest::renameNode(unsigned int apiIndex, MegaNode *n, std::string newFolderName, int timeout)
-{
-    mApi[apiIndex].requestFlags[MegaRequest::TYPE_RENAME] = false;
-    mApi[apiIndex].megaApi->renameNode(n,newFolderName.c_str());
-
-    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_RENAME], timeout) )
-            << "Renaming node failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Cannot rename a node (error: " << mApi[apiIndex].lastError << ")";
-}
-
-void SdkTest::moveNode(unsigned int apiIndex, MegaNode *n, MegaNode *newParent, int timeout)
-{
-    mApi[apiIndex].requestFlags[MegaRequest::TYPE_MOVE] = false;
-    mApi[apiIndex].megaApi->moveNode(n,newParent);
-
-    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_MOVE], timeout) )
-            << "Moving node failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Cannot move a node (error: " << mApi[apiIndex].lastError << ")";
-}
-
-void SdkTest::copyNode(unsigned int apiIndex, MegaNode *n, MegaNode *newParent, const char* newName, int timeout)
-{
-    mApi[apiIndex].requestFlags[MegaRequest::TYPE_COPY] = false;
-    mApi[apiIndex].megaApi->copyNode(n, newParent, newName);
-
-    ASSERT_TRUE( waitForResponse(&mApi[apiIndex].requestFlags[MegaRequest::TYPE_COPY], timeout) )
-            << "Copying node failed after " << timeout  << " seconds";
-    ASSERT_EQ(MegaError::API_OK, mApi[apiIndex].lastError) << "Cannot copy a node (error: " << mApi[apiIndex].lastError << ")";
-}
-
 void SdkTest::getRegisteredContacts(const std::map<std::string, std::string>& contacts)
 {
     int apiIndex = 0;
@@ -1271,7 +1239,7 @@ void SdkTest::getUserAttribute(MegaUser *u, int type, int timeout, int apiIndex)
  */
 TEST_F(SdkTest, DISABLED_SdkTestCreateAccount)
 {
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     string email1 = "user@domain.com";
     string pwd = "pwd";
@@ -1326,7 +1294,7 @@ TEST_F(SdkTest, SdkTestKillSession)
     auto passwords = makeScopedValue(envVarPass, string_vector(2, "MEGA_PWD"));
 
     // Get two sessions for the same account.
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // Make sure the sessions aren't reused.
     gSessionIDs[0] = "invalid";
@@ -1384,7 +1352,7 @@ TEST_F(SdkTest, SdkTestKillSession)
 TEST_F(SdkTest, SdkTestNodeAttributes)
 {
     LOG_info << "___TEST Node attributes___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     std::unique_ptr<MegaNode> rootnode{megaApi[0]->getRootNode()};
 
@@ -1601,13 +1569,30 @@ TEST_F(SdkTest, SdkTestNodeAttributes)
     lon = nimported->getLongitude();
     ASSERT_EQ(MegaNode::INVALID_COORDINATE, lat) << "Latitude value does not match";
     ASSERT_EQ(MegaNode::INVALID_COORDINATE, lon) << "Longitude value does not match";
+
+    // exercise all the cases for 'l' command:
+
+    // delete existing link on node
+    ASSERT_EQ(API_OK, doDisableExport(0, n2));
+
+    // create on existing node, no link yet
+    ASSERT_EQ(API_OK, doExportNode(0, n2));
+
+    // create on existing node, with link already  (different command response)
+    ASSERT_EQ(API_OK, doExportNode(0, n2));
+
+    gTestingInvalidArgs = true;
+    // create on non existent node
+    ASSERT_EQ(API_EARGS, doExportNode(0, nullptr));
+    gTestingInvalidArgs = false;
+
 }
 
 
 TEST_F(SdkTest, SdkTestExerciseOtherCommands)
 {
     LOG_info << "___TEST SdkTestExerciseOtherCommands___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     /*bool HttpReqCommandPutFA::procresult(Result r)
     bool CommandGetFA::procresult(Result r)
@@ -1704,7 +1689,7 @@ TEST_F(SdkTest, SdkTestExerciseOtherCommands)
 TEST_F(SdkTest, SdkTestResumeSession)
 {
     LOG_info << "___TEST Resume session___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     unique_ptr<char[]> session(dumpSession());
 
@@ -1733,7 +1718,7 @@ TEST_F(SdkTest, SdkTestResumeSession)
 TEST_F(SdkTest, SdkTestNodeOperations)
 {
     LOG_info <<  "___TEST Node operations___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // --- Create a new folder ---
 
@@ -1748,12 +1733,7 @@ TEST_F(SdkTest, SdkTestNodeOperations)
     MegaNode *n1 = megaApi[0]->getNodeByHandle(mApi[0].h);
     strcpy(name1, "Folder renamed");
 
-    mApi[0].requestFlags[MegaRequest::TYPE_RENAME] = false;
-    megaApi[0]->renameNode(n1, name1);
-    ASSERT_TRUE( waitForResponse(&mApi[0].requestFlags[MegaRequest::TYPE_RENAME]) )
-            << "Rename operation failed after " << maxTimeout << " seconds";
-    ASSERT_EQ(MegaError::API_OK, mApi[0].lastError) << "Cannot rename a node (error: " << mApi[0].lastError << ")";
-
+    ASSERT_EQ(MegaError::API_OK, doRenameNode(0, n1, name1));
 
     // --- Copy a node ---
 
@@ -1867,7 +1847,7 @@ TEST_F(SdkTest, SdkTestNodeOperations)
 TEST_F(SdkTest, SdkTestTransfers)
 {
     LOG_info << "___TEST Transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     LOG_info << cwd();
 
@@ -2061,7 +2041,7 @@ TEST_F(SdkTest, SdkTestTransfers)
 TEST_F(SdkTest, SdkTestContacts)
 {
     LOG_info << "___TEST Contacts___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
 
     // --- Check my email and the email of the contact ---
@@ -2418,7 +2398,7 @@ bool SdkTest::checkAlert(int apiIndex, const string& title, handle h, int n)
 TEST_F(SdkTest, SdkTestShares)
 {
     LOG_info << "___TEST Shares___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     MegaShareList *sl;
     MegaShare *s;
@@ -2722,7 +2702,7 @@ TEST_F(SdkTest, SdkTestShares)
 TEST_F(SdkTest, SdkTestShareKeys)
 {
     LOG_info << "___TEST ShareKeys___";
-    getAccountsForTest(3);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(3));
 
     // Three user scenario, with nested shares and new nodes created that need keys to be shared to the other users.
     // User A creates folder and shares it with user B
@@ -2814,7 +2794,7 @@ LocalPath fspathToLocal(const fs::path& p, FSACCESS_CLASS& fsa)
 
 TEST_F(SdkTest, SdkTestFolderIteration)
 {
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     for (int testcombination = 0; testcombination < 2; testcombination++)
     {
@@ -3096,7 +3076,7 @@ bool cmp(const autocomplete::CompletionState& c, std::vector<std::string>& s)
 
 TEST_F(SdkTest, SdkTestConsoleAutocomplete)
 {
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
     using namespace autocomplete;
 
     {
@@ -3156,7 +3136,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
         }
     }
 
-    ::mega::handle megaCurDir = UNDEF;
+    ::mega::NodeHandle megaCurDir;
 
     MegaApiImpl* impl = *((MegaApiImpl**)(((char*)megaApi[0].get()) + sizeof(*megaApi[0].get())) - 1); //megaApi[0]->pImpl;
     MegaClient* client = impl->getMegaClient();
@@ -3447,7 +3427,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
     ASSERT_NO_FATAL_FAILURE(createFolder(0, "test_autocomplete_megafs", rootnode));
     MegaNode *n0 = megaApi[0]->getNodeByHandle(mApi[0].h);
 
-    megaCurDir = mApi[0].h;
+    megaCurDir = NodeHandle().set6byte(mApi[0].h);
 
     ASSERT_NO_FATAL_FAILURE(createFolder(0, "dir1", n0));
     MegaNode *n1 = megaApi[0]->getNodeByHandle(mApi[0].h);
@@ -3726,7 +3706,7 @@ TEST_F(SdkTest, SdkTestConsoleAutocomplete)
 TEST_F(SdkTest, SdkTestChat)
 {
     LOG_info << "___TEST Chat___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // --- Send a new contact request ---
 
@@ -3870,7 +3850,7 @@ public:
 TEST_F(SdkTest, SdkTestFingerprint)
 {
     LOG_info << "___TEST fingerprint stream/file___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     int filesizes[] = { 10, 100, 1000, 10000, 100000, 10000000 };
     string expected[] = {
@@ -4077,7 +4057,7 @@ namespace mega
 TEST_F(SdkTest, SdkTestCloudraidTransfers)
 {
     LOG_info << "___TEST Cloudraid transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -4218,7 +4198,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransfers)
 TEST_F(SdkTest, SdkTestCloudraidTransferWithConnectionFailures)
 {
     LOG_info << "___TEST Cloudraid transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -4273,7 +4253,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransferWithConnectionFailures)
 TEST_F(SdkTest, SdkTestCloudraidTransferWithSingleChannelTimeouts)
 {
     LOG_info << "___TEST Cloudraid transfers___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -4325,7 +4305,7 @@ TEST_F(SdkTest, SdkTestCloudraidTransferWithSingleChannelTimeouts)
 TEST_F(SdkTest, SdkTestOverquotaNonCloudraid)
 {
     LOG_info << "___TEST SdkTestOverquotaNonCloudraid";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     //for (int i = 0; i < 1000; ++i) {
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
@@ -4402,7 +4382,7 @@ TEST_F(SdkTest, SdkTestOverquotaNonCloudraid)
 TEST_F(SdkTest, SdkTestOverquotaCloudraid)
 {
     LOG_info << "___TEST SdkTestOverquotaCloudraid";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
 
@@ -4566,7 +4546,7 @@ CheckStreamedFile_MegaTransferListener* StreamRaidFilePart(MegaApi* megaApi, m_o
 TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
 {
     LOG_info << "___TEST SdkCloudraidStreamingSoakTest";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
 #ifdef MEGASDK_DEBUG_TEST_HOOKS_ENABLED
     ASSERT_TRUE(DebugTestHook::resetForTests()) << "SDK test hooks are not enabled in release mode";
@@ -4721,7 +4701,7 @@ TEST_F(SdkTest, SdkCloudraidStreamingSoakTest)
 TEST_F(SdkTest, SdkRecentsTest)
 {
     LOG_info << "___TEST SdkRecentsTest___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     MegaNode *rootnode = megaApi[0]->getRootNode();
 
@@ -4784,7 +4764,7 @@ TEST_F(SdkTest, SdkRecentsTest)
 TEST_F(SdkTest, SdkMediaUploadRequestURL)
 {
     LOG_info << "___TEST MediaUploadRequestURL___";
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
 
     // Create a "media upload" instance
     int apiIndex = 0;
@@ -4803,7 +4783,7 @@ TEST_F(SdkTest, SdkMediaUploadRequestURL)
 
 TEST_F(SdkTest, SdkGetBanners)
 {
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     LOG_info << "___TEST GetBanners___";
 
     auto err = synchronousGetBanners(0);
@@ -4812,7 +4792,7 @@ TEST_F(SdkTest, SdkGetBanners)
 
 TEST_F(SdkTest, SdkBackupFolder)
 {
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     LOG_info << "___TEST BackupFolder___";
 
     // Attempt to get My Backups folder;
@@ -4944,7 +4924,7 @@ TEST_F(SdkTest, SdkBackupFolder)
 
 TEST_F(SdkTest, SdkSimpleCommands)
 {
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     LOG_info << "___TEST SimpleCommands___";
 
     // fetchTimeZone() test
@@ -4958,7 +4938,7 @@ TEST_F(SdkTest, SdkSimpleCommands)
     ASSERT_EQ(MegaError::API_OK, err) << "Get misc flags failed (error: " << err << ")";
 
     // getUserEmail() test
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     std::unique_ptr<MegaUser> user(megaApi[0]->getMyUser());
     ASSERT_TRUE(!!user); // some simple validation
 
@@ -4978,7 +4958,7 @@ TEST_F(SdkTest, SdkSimpleCommands)
 
 TEST_F(SdkTest, SdkHeartbeatCommands)
 {
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     LOG_info << "___TEST HeartbeatCommands___";
     mBackupNameToBackupId.clear();
 
@@ -5094,7 +5074,7 @@ TEST_F(SdkTest, SdkHeartbeatCommands)
 
 TEST_F(SdkTest, SdkFavouriteNodes)
 {
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     LOG_info << "___TEST SDKFavourites___";
 
     unique_ptr<MegaNode> rootnodeA(megaApi[0]->getRootNode());
@@ -5122,9 +5102,9 @@ TEST_F(SdkTest, SdkFavouriteNodes)
     
     err = synchronousGetFavourites(0, subFolderA.get(), 0);
     ASSERT_EQ(MegaError::API_OK, err) << "synchronousGetFavourites (error: " << err << ")";
-    ASSERT_EQ(mMegaFavNodeList->size(), 2) << "synchronousGetFavourites failed...";
+    ASSERT_EQ(mMegaFavNodeList->size(), 2u) << "synchronousGetFavourites failed...";
     err = synchronousGetFavourites(0, nullptr, 1);
-    ASSERT_EQ(mMegaFavNodeList->size(), 1) << "synchronousGetFavourites failed...";
+    ASSERT_EQ(mMegaFavNodeList->size(), 1u) << "synchronousGetFavourites failed...";
     unique_ptr<MegaNode> favNode(megaApi[0]->getNodeByHandle(mMegaFavNodeList->get(0)));
     ASSERT_EQ(favNode->getName(), UPFILE) << "synchronousGetFavourites failed with node passed nullptr";
 }
@@ -5176,7 +5156,7 @@ TEST_F(SdkTest, DISABLED_SdkUserAlias)
 TEST_F(SdkTest, SdkGetCountryCallingCodes)
 {
     LOG_info << "___TEST SdkGetCountryCallingCodes___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     getCountryCallingCodes();
     ASSERT_NE(nullptr, stringListMap);
@@ -5195,7 +5175,7 @@ TEST_F(SdkTest, SdkGetCountryCallingCodes)
 TEST_F(SdkTest, SdkGetRegisteredContacts)
 {
     LOG_info << "___TEST SdkGetRegisteredContacts___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     const std::string js1 = "+0000000010";
     const std::string js2 = "+0000000011";
@@ -5237,7 +5217,7 @@ TEST_F(SdkTest, SdkGetRegisteredContacts)
 TEST_F(SdkTest, DISABLED_invalidFileNames)
 {
     LOG_info << "___TEST invalidFileNames___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     FSACCESS_CLASS fsa;
     auto aux = LocalPath::fromPath(fs::current_path().u8string(), fsa);
@@ -5424,7 +5404,7 @@ TEST_F(SdkTest, DISABLED_invalidFileNames)
 TEST_F(SdkTest, RecursiveUploadWithLogout)
 {
     LOG_info << "___TEST RecursiveUploadWithLogout___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // this one used to cause a double-delete
 
@@ -5455,7 +5435,7 @@ TEST_F(SdkTest, RecursiveUploadWithLogout)
 TEST_F(SdkTest, DISABLED_RecursiveDownloadWithLogout)
 {
     LOG_info << "___TEST RecursiveDownloadWithLogout";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     // this one used to cause a double-delete
 
@@ -5498,7 +5478,7 @@ TEST_F(SdkTest, DISABLED_RecursiveDownloadWithLogout)
 TEST_F(SdkTest, QueryGoogleAds)
 {
     LOG_info << "___TEST QueryGoogleAds";
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     int err = synchronousQueryGoogleAds(0, MegaApi::GOOGLE_ADS_FORCE_ADS);
     ASSERT_EQ(MegaError::API_OK, err) << "Query Google Ads failed (error: " << err << ")";
 }
@@ -5506,7 +5486,7 @@ TEST_F(SdkTest, QueryGoogleAds)
 TEST_F(SdkTest, FetchGoogleAds)
 {
     LOG_info << "___TEST FetchGoogleAds";
-    getAccountsForTest(1);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(1));
     std::unique_ptr<MegaStringList> stringList = std::unique_ptr<MegaStringList>(MegaStringList::createInstance());
     stringList->add("and0");
     stringList->add("ios0");
@@ -5845,7 +5825,7 @@ struct MegaListenerDeregisterer
 TEST_F(SdkTest, SyncResumptionAfterFetchNodes)
 {
     LOG_info << "___TEST SyncResumptionAfterFetchNodes___";
-    getAccountsForTest(2);
+    ASSERT_NO_FATAL_FAILURE(getAccountsForTest(2));
 
     SyncListener syncListener0, syncListener1;
     MegaListenerDeregisterer mld1(megaApi[0].get(), &syncListener0), mld2(megaApi[1].get(), &syncListener1);
@@ -6112,13 +6092,13 @@ TEST_F(SdkTest, SyncRemoteNode)
         // Rename remote folder --> Sync fail
         LOG_verbose << "SyncRemoteNode :  Rename remote node with sync active.";
         std::string basePathRenamed = "SyncRemoteNodeRenamed";
-        ASSERT_NO_FATAL_FAILURE(renameNode(0, remoteBaseNode.get(), basePathRenamed.c_str()));
+        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), basePathRenamed.c_str()));
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_PATH_HAS_CHANGED, sync->getError());
 
         LOG_verbose << "SyncRemoteNode :  Restoring remote folder name.";
-        ASSERT_NO_FATAL_FAILURE(renameNode(0, remoteBaseNode.get(), basePath.u8string().c_str()));
+        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), basePath.u8string().c_str()));
         ASSERT_NE(remoteBaseNode.get(), nullptr);
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
@@ -6142,13 +6122,13 @@ TEST_F(SdkTest, SyncRemoteNode)
     {
         TestingWithLogErrorAllowanceGuard g;
         LOG_verbose << "SyncRemoteNode :  Move remote node with sync active to the secondary folder.";
-        ASSERT_NO_FATAL_FAILURE(moveNode(0, remoteBaseNode.get(), remoteMoveNodeParent.get()));
+        ASSERT_TRUE(doMoveNode(0, remoteBaseNode.get(), remoteMoveNodeParent.get()));
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_PATH_HAS_CHANGED, sync->getError());
 
         LOG_verbose << "SyncRemoteNode :  Moving back the remote node.";
-        ASSERT_NO_FATAL_FAILURE(moveNode(0, remoteBaseNode.get(), remoteRootNode.get()));
+        ASSERT_TRUE(doMoveNode(0, remoteBaseNode.get(), remoteRootNode.get()));
         ASSERT_NE(remoteBaseNode.get(), nullptr);
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
@@ -6168,13 +6148,13 @@ TEST_F(SdkTest, SyncRemoteNode)
         TestingWithLogErrorAllowanceGuard g;
         LOG_verbose << "SyncRemoteNode :  Rename remote node.";
         std::string renamedBasePath = basePath.u8string() + "Renamed";
-        ASSERT_NO_FATAL_FAILURE(renameNode(0, remoteBaseNode.get(), renamedBasePath));
+        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), renamedBasePath.c_str()));
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_PATH_HAS_CHANGED, sync->getError());
 
         LOG_verbose << "SyncRemoteNode :  Renaming back the remote node.";
-        ASSERT_NO_FATAL_FAILURE(renameNode(0, remoteBaseNode.get(), basePath.u8string()));
+        ASSERT_TRUE(doRenameNode(0, remoteBaseNode.get(), basePath.u8string().c_str()));
         ASSERT_NE(remoteBaseNode.get(), nullptr);
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_HAS_CHANGED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
@@ -6198,7 +6178,7 @@ TEST_F(SdkTest, SyncRemoteNode)
         TestingWithLogErrorAllowanceGuard g;
         // Remove remote folder --> Sync fail
         LOG_verbose << "SyncRemoteNode :  Removing remote node with sync active.";
-        ASSERT_NO_FATAL_FAILURE(deleteNode(0, remoteBaseNode.get()));                                //  <--- remote node deleted!!
+        ASSERT_TRUE(doDeleteNode(0, remoteBaseNode.get()));                                //  <--- remote node deleted!!
         sync = waitForSyncState(megaApi[0].get(), backupId, false, false, MegaSync::REMOTE_PATH_DELETED);
         ASSERT_TRUE(sync && !sync->isEnabled() && !sync->isActive());
         ASSERT_EQ(MegaSync::REMOTE_NODE_NOT_FOUND, sync->getError());
@@ -6495,7 +6475,7 @@ TEST_F(SdkTest, SyncOQTransitions)
 
     for (int i=1; i < filesNeeded; i++)
     {
-        ASSERT_NO_FATAL_FAILURE(copyNode(0, remote1GBFile.get(), remoteFillNode.get(), (remote1GBFile->getName() + to_string(i)).c_str()));
+        ASSERT_EQ(API_OK, doCopyNode(0, remote1GBFile.get(), remoteFillNode.get(), (remote1GBFile->getName() + to_string(i)).c_str()));
     }
     std::unique_ptr<MegaNode> last1GBFileNode(megaApi[0]->getChildNode(remoteFillNode.get(), (remote1GBFile->getName() + to_string(filesNeeded-1)).c_str()));
 
@@ -6543,7 +6523,7 @@ TEST_F(SdkTest, SyncOQTransitions)
     ASSERT_NO_FATAL_FAILURE(locallogout());
 
     std::unique_ptr<MegaNode> remote1GBFile2nd(megaApi[1]->getChildNode(inshareNode, remote1GBFile->getName()));
-    ASSERT_NO_FATAL_FAILURE(copyNode(1, remote1GBFile2nd.get(), inshareNode, (remote1GBFile2nd->getName() + to_string(filesNeeded-1)).c_str()));
+    ASSERT_EQ(API_OK, doCopyNode(1, remote1GBFile2nd.get(), inshareNode, (remote1GBFile2nd->getName() + to_string(filesNeeded-1)).c_str()));
 
     {
         TestingWithLogErrorAllowanceGuard g;

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -317,12 +317,16 @@ public:
     template<typename ... requestArgs> int doSetFileVersionsOption(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->setFileVersionsOption(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int doMoveNode(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->moveNode(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int doCopyNode(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->copyNode(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doRenameNode(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->renameNode(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doDeleteNode(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->remove(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int synchronousSyncFolder(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->syncFolder(args..., &rt); rt.waitForResult(); mApi[apiIndex].lastSyncError = rt.request->getNumDetails() ; return rt.result; }
     template<typename ... requestArgs> int synchronousRemoveSync(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->removeSync(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int synchronousDisableSync(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->disableSync(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int synchronousEnableSync(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->enableSync(args..., &rt); rt.waitForResult(); mApi[apiIndex].lastSyncError = rt.request->getNumDetails() ; return rt.result; }
     template<typename ... requestArgs> int synchronousKillSession(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->killSession(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int synchronousSetBackup(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get());  megaApi[apiIndex]->setBackup(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doExportNode(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->exportNode(args..., &rt); return rt.waitForResult(); }
+    template<typename ... requestArgs> int doDisableExport(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get()); megaApi[apiIndex]->disableExport(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int synchronousSetNodeFavourite(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get());  megaApi[apiIndex]->setNodeFavourite(args..., &rt); return rt.waitForResult(); }
     template<typename ... requestArgs> int synchronousGetFavourites(unsigned apiIndex, requestArgs... args) { RequestTracker rt(megaApi[apiIndex].get());  megaApi[apiIndex]->getFavourites(args..., &rt); return rt.waitForResult(); }
 
@@ -349,10 +353,6 @@ public:
     void getContactRequest(unsigned int apiIndex, bool outgoing, int expectedSize = 1);
 
     void createFolder(unsigned int apiIndex, const char * name, MegaNode *n, int timeout = maxTimeout);
-    void deleteNode(unsigned int apiIndex, MegaNode *n, int timeout = maxTimeout);
-    void renameNode(unsigned int apiIndex, MegaNode *n, std::string newFolderName, int timeout = maxTimeout);
-    void moveNode(unsigned int apiIndex, MegaNode *n, MegaNode *newParent, int timeout = maxTimeout);
-    void copyNode(unsigned int apiIndex, MegaNode *n, MegaNode *newParent, const char* newName, int timeout = maxTimeout);
 
     void getRegisteredContacts(const std::map<std::string, std::string>& contacts);
 

--- a/tests/integration/Sync_test.cpp
+++ b/tests/integration/Sync_test.cpp
@@ -1109,7 +1109,7 @@ struct StandardClient : public MegaApp
             File* f = new File();
             // full local path
             f->localname = LocalPath::fromPath(p.u8string(), *client.fsaccess);
-            f->h = target->nodehandle;
+            f->h = target->nodeHandle();
             f->name = p.filename().u8string();
             client.startxfer(PUT, f, committer);
         }

--- a/tests/unit/File_test.cpp
+++ b/tests/unit/File_test.cpp
@@ -66,7 +66,7 @@ TEST(File, serialize_unserialize)
     mega::File file;
     file.name = "foo";
     file.localname = ::mega::LocalPath::fromPath(file.name, fsaccess);
-    file.h = 42;
+    file.h.set6byte(42);
     file.hprivate = true;
     file.hforeign = true;
     file.syncxfer = true;
@@ -96,7 +96,7 @@ TEST(File, unserialize_32bit)
     mega::File file;
     file.name = "foo";
     file.localname = ::mega::LocalPath::fromPath(file.name, fsaccess);
-    file.h = 42;
+    file.h.set6byte(42);
     file.hprivate = true;
     file.hforeign = true;
     file.syncxfer = true;


### PR DESCRIPTION
This PR is starting to merge some improvements back from the sync rework branch
 - adding NodeHandle class.  It wraps up 6 byte node handles, to avoid accidental 8 byte usages, and avoid common mistakes with compiler errors/warnings, and asserts.
 - Fix some test cases where the listeners were not being used, and race conditions caused the tests to get confused.
 - The File class is updated to use NodeHandle - it's a good place to start as the handle contained there is not referenced by too many lines.
 - Over time other usages should migrate to NodeHandle also, and eventually we should be able to do away with the (deliberately awkward) set6byte() and as8byte() members.