### PR TITLE
SDK-1399 - Clear the cacheable status map before populating it from the database.

### DIFF
--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -11424,6 +11424,7 @@ bool MegaClient::fetchsc(DbTable* sctable)
 
     LOG_info << "Loading session from local cache";
 
+    mCachedStatus.clear();
     sctable->rewind();
 
     bool hasNext = sctable->next(&id, &data, &key);


### PR DESCRIPTION
This change-set corrects a bug where the cacheable status map is not cleared before populating it from the database, resulting in an assertion periodically tripping during testing.

This bug caused transient failures of several SDK Integration tests.