### PR TITLE
SDK-1406. Add detection for HFS+ (HFS Extended)

### DIFF
--- a/examples/megacli.cpp
+++ b/examples/megacli.cpp
@@ -8495,6 +8495,12 @@ void exec_synclist(autocomplete::ACState& s)
         return;
     }
 
+    if (client->syncs.numSyncs() == 0)
+    {
+        cout << "No syncs configured yet" << endl;
+        return;
+     }
+
     client->syncs.forEachUnifiedSync(
       [](UnifiedSync& us)
       {

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -522,6 +522,7 @@ struct Syncs
 
     bool hasRunningSyncs();
     unsigned numRunningSyncs();
+    unsigned numSyncs();    // includes non-running syncs, but configured
     Sync* firstRunningSync();
     Sync* runningSyncByBackupId(handle backupId) const;
     SyncConfig* syncConfigByBackupId(handle backupId) const;

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -59,6 +59,10 @@ extern JavaVM *MEGAjvm;
 #define HFS_SUPER_MAGIC 0x4244
 #endif /* ! HFS_SUPER_MAGIC */
 
+#ifndef HFSPLUS_SUPER_MAGIC
+#define HFSPLUS_SUPER_MAGIC 0x482B
+#endif /* ! HFSPLUS_SUPER_MAGIC */
+
 #ifndef NTFS_SB_MAGIC
 #define NTFS_SB_MAGIC 0x5346544E
 #endif /* ! NTFS_SB_MAGIC */
@@ -1929,6 +1933,7 @@ bool PosixFileSystemAccess::getlocalfstype(const LocalPath& path, FileSystemType
             type = FS_FAT32;
             break;
         case HFS_SUPER_MAGIC:
+        case HFSPLUS_SUPER_MAGIC:
             type = FS_HFS;
             break;
         case NTFS_SB_MAGIC:
@@ -1974,14 +1979,17 @@ bool PosixFileSystemAccess::getlocalfstype(const LocalPath& path, FileSystemType
 
         if (it != filesystemTypes.end())
         {
-            return type = it->second, true;
+            type = it->second;
+            return true;
         }
 
-        return type = FS_UNKNOWN, true;
+        type = FS_UNKNOWN;
+        return true;
     }
 #endif /* __APPLE__ || USE_IOS */
 
-    return type = FS_UNKNOWN, false;
+    type = FS_UNKNOWN;
+    return false;
 }
 
 bool PosixDirAccess::dopen(LocalPath* path, FileAccess* f, bool doglob)

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -2590,6 +2590,11 @@ unsigned Syncs::numRunningSyncs()
     return n;
 }
 
+unsigned Syncs::numSyncs()
+{
+    return mSyncVec.size();
+}
+
 Sync* Syncs::firstRunningSync()
 {
     for (auto& s : mSyncVec)


### PR DESCRIPTION
In Linux, the `statfs` returns `f_type=0x482B` instead of `0x4244`, so we need to add the declaration.
Note: HFS+ is managed like HFS or APFS, since they all use the same prohibited charset: `:` and `/`
See https://github.com/meganz/sdk/pull/2038/files#diff-15272dca8f6a6ace72e1e8f5a8da7b21ae676b16775021e484f24505b7bd1400R195