### PR TITLE
WIP: SDK-1400. Endless loop checking path while syncing on HFS (hotfix to v.3.8.2)

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1087,9 +1087,9 @@ void Sync::changestate(syncstate_t newstate, SyncError newSyncError, bool newEna
     }
 }
 
-// walk path and return corresponding LocalNode and its parent
-// path must be relative to l or start with the root prefix if l == NULL
-// path must be a full sync path, i.e. start with localroot->localname
+// walk localpath and return corresponding LocalNode and its parent
+// localpath must be relative to l or start with the root prefix if l == NULL
+// localpath must be a full sync path, i.e. start with localroot->localname
 // NULL: no match, optionally returns residual path
 LocalNode* Sync::localnodebypath(LocalNode* l, const LocalPath& localpath, LocalNode** parent, LocalPath* outpath)
 {
@@ -1801,10 +1801,11 @@ LocalNode* Sync::checkpath(LocalNode* l, LocalPath* input_localpath, string* con
             // fopen() signals that the failure is potentially transient - do
             // nothing and request a recheck
             LOG_warn << "File blocked. Adding notification to the retry queue: " << path;
-            dirnotify->notify(DirNotify::RETRY, ll, LocalPath(*localpathNew));
+            LocalPath *path = l ? localpathNew : input_localpath;
+            dirnotify->notify(DirNotify::RETRY, ll, LocalPath(*path));
             client->syncfslockretry = true;
             client->syncfslockretrybt.backoff(SCANNING_DELAY_DS);
-            client->blockedfile = *localpathNew;
+            client->blockedfile = *path;
         }
         else if (l)
         {


### PR DESCRIPTION
In HFS+ in MacOS, when a new file is added to a synced folder, `fsevents` notifies it and the `FileAccess::fopen()` cannot read it
(yet) until it's fully written to disk (see usage of `kMagicBusyCreationDate`). Since it's taken as a transient error, a notification is added to the `notifyq[RETRY]`. However, since the `LocalNode` doesn't exist, the filename to notify should not include the absolute path to the sync, but only the leaf name. Otherwise, when the notification is processed later in `checkpath()`, it will build a new name repeating the root of the sync.
Ie. if you have the synced folder `A` and a new file `myfile.bin` is copied into that folder, the notification from `fsevents` is `n=myfile.bin` (and `l=<localnode_of_A_folder>`). When the notification to retry is queued, it should be `myfile.bin`. If we use the `localpathNew`, which is `A/myfile.bin`, then the next processing of the notification will result on `A//myfile.bin`, and next one will be `A/A/myfile.bin`.