### PR TITLE
MEGAcli - add tree command

### DIFF
--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -297,6 +297,7 @@ void exec_cancelsignup(autocomplete::ACState& s);
 void exec_session(autocomplete::ACState& s);
 void exec_mount(autocomplete::ACState& s);
 void exec_ls(autocomplete::ACState& s);
+void exec_tree(autocomplete::ACState& s);
 void exec_cd(autocomplete::ACState& s);
 void exec_pwd(autocomplete::ACState& s);
 void exec_lcd(autocomplete::ACState& s);


### PR DESCRIPTION
- Add `tree` command for MEGAcli to present the hierarchy of remote folders in the cout.
- Report of total number of directories at the end.