### PR TITLE
add stat command to magacli (sdk example)

### DIFF
--- a/contrib/cmake/modules/sdklib_target.cmake
+++ b/contrib/cmake/modules/sdklib_target.cmake
@@ -303,6 +303,7 @@ target_compile_definitions(SDKlib
     $<$<BOOL:${ENABLE_CHAT}>:ENABLE_CHAT>
     $<$<BOOL:${ENABLE_SYNC}>:ENABLE_SYNC>
     $<$<BOOL:${USE_LIBUV}>:HAVE_LIBUV>
+    $<$<BOOL:${USE_FREEIMAGE}>:USE_FREEIMAGE>
 )
 
 set_target_properties(SDKlib PROPERTIES

--- a/examples/megacli.h
+++ b/examples/megacli.h
@@ -302,6 +302,7 @@ void exec_cancelsignup(autocomplete::ACState& s);
 void exec_session(autocomplete::ACState& s);
 void exec_mount(autocomplete::ACState& s);
 void exec_ls(autocomplete::ACState& s);
+void exec_stat(autocomplete::ACState& s);
 void exec_cd(autocomplete::ACState& s);
 void exec_pwd(autocomplete::ACState& s);
 void exec_lcd(autocomplete::ACState& s);


### PR DESCRIPTION
This is a command named `stat` very much similar to common linux utility `du`.

Examples of how to use this command:

```
MEGAcli> stat -h
Invalid Syntax
stat [-s|-a] [-S] [-P] [-tofile <filename>] [remotefolder]
```

By default - we will gets "stat"s for all folder
```
MEGAcli> stat
/A/B: { nBytes: 2542997, nFiles: 3, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A/Z: { nBytes: 55, nFiles: 2, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A/X: { nBytes: 47, nFiles: 2, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0 }
/: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0 }
```

To get "summary":
```
MEGAcli> stat -s
/: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0 }
```

To get details for "all" files as well as directories:
```
MEGAcli> stat -a
/A/B/Doxygen_docs.zip: { nBytes: 985472, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/B/9VJzYYetsZ.pdf: { nBytes: 1486647, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/B/My Resume.pdf: { nBytes: 70878, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/B: { nBytes: 2542997, nFiles: 3, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A/Z/NNN.txt: { nBytes: 37, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/Z/MMM.txt: { nBytes: 18, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/Z: { nBytes: 55, nFiles: 2, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A/UUUU.txt: { nBytes: 31, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/TTTT.txt: { nBytes: 22, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/X/T.txt: { nBytes: 19, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/X/U.txt: { nBytes: 28, nFiles: 1, nFileVersions: 0, nFolders: 0, nDeleted: 0 }
/A/X: { nBytes: 47, nFiles: 2, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0 }
/: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0 }
```

Stat for a particular folder
```
MEGAcli> stat /A
/A/B: { nBytes: 2542997, nFiles: 3, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A/Z: { nBytes: 55, nFiles: 2, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A/X: { nBytes: 47, nFiles: 2, nFileVersions: 0, nFolders: 1, nDeleted: 0 }
/A: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0 }
```

Summary stats for a particular folder
```
MEGAcli> stat -s /A
/A: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0 }
```

Get more stats - sharing stats:
```
MEGAcli> stat -s -S /A
/A: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0, nFoldersSharedWithMe: 0, nSharedFolders_Temporal: 0, nSharedFolders_Permanent: 0, nSharedFolderUsers: 1, nSharedFolderUsers_Pending: 0, nSharedFileLinks_Temporal: 0, nSharedFileLinks_Permanent: 1 }
```

Get more stats - password node stats
```
MEGAcli> stat -s -S -P /A
/A: { nBytes: 2543152, nFiles: 9, nFileVersions: 0, nFolders: 4, nDeleted: 0, nPasswordNodes: 0, nPasswordNodeFolders: 0, nFoldersSharedWithMe: 0, nSharedFolders_Temporal: 0, nSharedFolders_Permanent: 0, nSharedFolderUsers: 1, nSharedFolderUsers_Pending: 0, nSharedFileLinks_Temporal: 0, nSharedFileLinks_Permanent: 1 }
```
