### PR TITLE
Add BSD filesystem type support

### DIFF
--- a/include/mega/localpath.h
+++ b/include/mega/localpath.h
@@ -33,6 +33,10 @@ enum FileSystemType
     FS_SMB = 12,
     FS_SMB2 = 13,
     FS_LIFS = 14,
+    FS_FFS = 15,
+    FS_HAMMER = 16,
+    FS_UFS = 17,
+    FS_ZFS = 18,
 };
 
 #ifdef WIN32

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -605,8 +605,12 @@ const char *FileSystemAccess::fstypetostring(FileSystemType type)
             return "EXFAT";
         case FS_FAT32:
             return "FAT32";
+        case FS_FFS:
+            return "FFS";
         case FS_EXT:
             return "EXT";
+        case FS_HAMMER:
+            return "HAMMER";
         case FS_HFS:
             return "HFS";
         case FS_APFS:
@@ -629,6 +633,10 @@ const char *FileSystemAccess::fstypetostring(FileSystemType type)
             return "SMB2";
         case FS_LIFS:
             return "LIFS";
+        case FS_UFS:
+            return "UFS";
+        case FS_ZFS:
+            return "ZFS";
         case FS_UNKNOWN:    // fall through
             return "UNKNOWN FS";
     }
@@ -694,7 +702,11 @@ bool FileSystemAccess::islocalfscompatible(const int character, const FileSystem
     case FS_APFS:
     case FS_EXT:
     case FS_F2FS:
+    case FS_FFS:
+    case FS_HAMMER:
+    case FS_UFS:
     case FS_XFS:
+    case FS_ZFS:
         return character != '/';
     case FS_EXFAT:
     case FS_FAT32:

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -2495,17 +2495,25 @@ bool PosixFileSystemAccess::getlocalfstype(const LocalPath& path, FileSystemType
     }
 #endif /* __linux__ || __ANDROID__ */
 
-#if defined(__APPLE__) || defined(USE_IOS)
+#if defined(__APPLE__) || defined(USE_IOS)) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
+    defined(__NetBSD__) || defined(__DragonFly__)
     static const map<string, FileSystemType> filesystemTypes = {
         {"apfs",        FS_APFS},
         {"exfat",       FS_EXFAT},
+        {"ext2fs",      FS_EXT},
+        {"ffs",         FS_FFS},  // NetBSD, OpenBSD
+        {"hammer",      FS_HAMMER},  // DragonFly BSD
+        {"hammer2",     FS_HAMMER},  // DragonFly BSD
         {"hfs",         FS_HFS},
         {"msdos",       FS_FAT32},
+        {"msdosfs",     FS_FAT32},
         {"nfs",         FS_NFS},
         {"ntfs",        FS_NTFS}, // Apple NTFS
         {"smbfs",       FS_SMB},
         {"tuxera_ntfs", FS_NTFS}, // Tuxera NTFS for Mac
         {"ufsd_NTFS",   FS_NTFS},  // Paragon NTFS for Mac
+        {"ufs",         FS_UFS},  // FreeBSD
+        {"zfs",         FS_ZFS},
         {"lifs",        FS_LIFS},  // on macos (in Ventura at least), external USB with exFAT are reported as "lifs"
     }; /* filesystemTypes */
 
@@ -2524,7 +2532,7 @@ bool PosixFileSystemAccess::getlocalfstype(const LocalPath& path, FileSystemType
         type = FS_UNKNOWN;
         return true;
     }
-#endif /* __APPLE__ || USE_IOS */
+#endif /* __APPLE__ || USE_IOS || BSDs */
 
     type = FS_UNKNOWN;
     return false;


### PR DESCRIPTION
Following #2661, I made changes to detect the various BSDs filesystem types. I tested with megacmd-2.1.1 & sdk-9.1.1, seems works fine, I don't find any issues. 