### PR TITLE
Set periodic scan with fallback classes at buildtime on BSDs

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -10,6 +10,12 @@
 #cmakedefine ENABLE_SYNC 1
 #endif
 
+/* Defined to use periodic scan instead of filesystem notification */
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)) && \
+     defined(ENABLE_SYNC)
+#define USE_PERIODIC 1
+#endif
+
 #ifndef ENABLE_LOG_PERFORMANCE
 #cmakedefine ENABLE_LOG_PERFORMANCE 1
 #endif
@@ -226,7 +232,8 @@
 #define USE_DB 0
 
 /* Use inotify API */
-#if !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && \
+    !defined(__NetBSD__) && !defined(__DragonFly__)
 #define USE_INOTIFY 1
 #endif
 

--- a/include/mega/posix/megafs.h
+++ b/include/mega/posix/megafs.h
@@ -259,6 +259,29 @@ private:
 
 #endif // ENABLE_SYNC
 
+#elif defined(USE_PERIODIC)
+
+#define FSACCESS_CLASS FallbackFileSystemAccess
+
+class FallbackFileSystemAccess : public PosixFileSystemAccess
+{
+public:
+    DirNotify* newdirnotify(LocalNode& root,
+                            const LocalPath& rootPath,
+                            Waiter* waiter) override;
+
+    void addevents(Waiter*, int) override;
+
+    int checkevents(Waiter*) override;
+
+}; // class FallbackFileSystemAccess
+
+class FallbackDirNotify : public DirNotify
+{
+public:
+    FallbackDirNotify(const LocalPath& rootPath);
+};
+
 #endif // __linux__
 
 } // namespace

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -224,10 +224,14 @@ public:
                                const MegaClient& client) const;
 
     // How should the engine detect filesystem changes?
+#ifdef USE_PERIODIC
+    ChangeDetectionMethod mChangeDetectionMethod = CDM_PERIODIC_SCANNING;
+#else
     ChangeDetectionMethod mChangeDetectionMethod = CDM_NOTIFICATIONS;
+#endif
 
     // Only meaningful when a sync is in CDM_PERIODIC_SCANNING mode.
-    unsigned mScanIntervalSec = 0;
+    unsigned mScanIntervalSec = 60;
 
     // enum to string conversion
     static const char* synctypename(const Type type);

--- a/include/megaapi_impl.h
+++ b/include/megaapi_impl.h
@@ -91,6 +91,8 @@ class MegaSemaphore : public CppSemaphore {};
     class MegaWaiter : public PosixWaiter {};
     #ifdef __APPLE__
     class MegaFileSystemAccess : public MacFileSystemAccess {};
+    #elif defined(USE_PERIODIC)
+    class MegaFileSystemAccess : public FallbackFileSystemAccess {};
     #else
     class MegaFileSystemAccess : public LinuxFileSystemAccess {};
     #endif

--- a/src/posix/fs.cpp
+++ b/src/posix/fs.cpp
@@ -1004,6 +1004,18 @@ int LinuxFileSystemAccess::checkevents([[maybe_unused]] Waiter* waiter)
     return result;
 }
 
+#elif defined(USE_PERIODIC)
+
+void FallbackFileSystemAccess::addevents([[maybe_unused]] Waiter* waiter, int /*flags*/)
+{
+    //Nothing
+}
+
+int FallbackFileSystemAccess::checkevents([[maybe_unused]] Waiter* waiter)
+{
+    return 0;
+}
+
 #endif //  __linux__
 
 
@@ -1727,6 +1739,16 @@ void LinuxDirNotify::removeWatch(WatchMapIterator entry)
 }
 
 #endif // USE_INOTIFY
+
+#elif defined(USE_PERIODIC)
+
+FallbackDirNotify::FallbackDirNotify(const LocalPath& rootPath):
+    DirNotify(rootPath)
+{
+    // Let the engine know everything's ok.
+    setFailed(0, "");
+}
+
 #endif // __linux__
 
 #endif //ENABLE_SYNC
@@ -2421,6 +2443,15 @@ DirNotify* LinuxFileSystemAccess::newdirnotify(LocalNode& root,
     return new LinuxDirNotify(*this, root, rootPath);
 }
 #endif
+
+#elif defined(USE_PERIODIC)
+DirNotify* FallbackFileSystemAccess::newdirnotify(LocalNode& root,
+    const LocalPath& rootPath,
+    Waiter*)
+{
+    return new FallbackDirNotify(rootPath);
+}
+
 #endif
 
 bool PosixFileSystemAccess::issyncsupported(const LocalPath& localpathArg, bool& isnetwork, SyncError& syncError, SyncWarning& syncWarning)


### PR DESCRIPTION
Following #2661.
I found issues on BSDs with the inotify filesystem notification feature. BSDs use the libinotify-kqueue to provide  compatible layer to the linux only inotify filesystem notification, but I got sync issues, and if I used more sync job, I got crash. While I don't find the problem with libinotify-kqueue, I built sdk for myself with periodic scan as default sync method. 

With this changes megacmd-2.1.1 & sdk-9.1.1 builds and works fine for me. The modifications don't break the things in the current sdk, I tried to do my best, I hope you find these acceptable.