### PR TITLE
Fix spelling errors in the codebase

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -11124,7 +11124,7 @@ bool CommandExportSet::procresult(Result r, JSON& json)
         mSet->setChanged(Set::CH_EXPORTED);
         if (!client->updateSet(std::move(*mSet)))
         {
-            LOG_warn << "Sets: comand 'ass' succeeded, but Set was not found";
+            LOG_warn << "Sets: command 'ass' succeeded, but Set was not found";
             e = API_ENOENT;
         }
     }

--- a/src/mediafileattribute.cpp
+++ b/src/mediafileattribute.cpp
@@ -917,7 +917,7 @@ void MediaProperties::extractMediaPropertyFileAttributes(LocalPath& localFilenam
         }
         catch (std::exception& e)
         {
-            LOG_err << "exception caught reading media file attibutes: " << e.what();
+            LOG_err << "exception caught reading media file attributes: " << e.what();
         }
         catch (...)
         {

--- a/src/megaapi_impl.cpp
+++ b/src/megaapi_impl.cpp
@@ -1272,7 +1272,7 @@ char *MegaBackgroundMediaUploadPrivate::encryptFile(const char* inputFilepath, i
 {
     if (startPos != ChunkedHash::chunkfloor(startPos))
     {
-        LOG_err << "non-chunk start postion supplied";
+        LOG_err << "non-chunk start position supplied";
         return nullptr;
     }
 
@@ -32654,7 +32654,7 @@ size_t StreamingBuffer::append(const char *buf, size_t len)
     {
         size_t num = static_cast<size_t>(static_cast<int>(len) - remaining);
         LOG_debug << getLogName()
-                  << "[Streaming] Length exceeds limits of circular buffer. Writting a piece of "
+                  << "[Streaming] Length exceeds limits of circular buffer. Writing a piece of "
                   << num << " bytes to the end and the others " << remaining
                   << " bytes from the beginning"
                   << " [current index = " << currentIndex << ", len = " << len

--- a/src/megaclient.cpp
+++ b/src/megaclient.cpp
@@ -6555,7 +6555,7 @@ bool MegaClient::sc_checkActionPacket(Node* lastAPDeletedNode)
             {
                 // special case for actionpackets from the move command - the 'd'+'t' sequence has the tag on 'd' but not 't'.
                 // However we must process the 't' as part of the move, and only call the command completion after.
-                LOG_verbose << clientname << "st tag implicity not changing for moves";
+                LOG_verbose << clientname << "st tag implicitly not changing for moves";
                 return true;
             }
             else
@@ -7345,7 +7345,7 @@ void MegaClient::sc_userattr()
                                         // a V3 request, false in any other case.
                                         if (mCurrentSeqtagSeen)
                                         {
-                                            LOG_debug << "Skiping " << User::attr2string(type)
+                                            LOG_debug << "Skipping " << User::attr2string(type)
                                                       << " self action packet. Will be managed by "
                                                          "the command response.";
                                         }
@@ -16108,7 +16108,7 @@ void MegaClient::loadAuthrings()
                         if (records)
                         {
                             mAuthRings.emplace(at, AuthRing(at, *records));
-                            LOG_info << "Authring succesfully loaded from cache: "
+                            LOG_info << "Authring successfully loaded from cache: "
                                      << User::attr2string(at);
                         }
                         else
@@ -16409,7 +16409,7 @@ error MegaClient::trackSignature(attr_t signatureType, handle uh, const std::str
     bool signatureVerified = EdDSA::verifyKey((unsigned char*) pubKey->data(), pubKey->size(), (string*)&signature, (unsigned char*) signingPubKey->data());
     if (signatureVerified)
     {
-        LOG_debug << "Signature " << User::attr2string(signatureType) << " succesfully verified for user " << user->uid;
+        LOG_debug << "Signature " << User::attr2string(signatureType) << " successfully verified for user " << user->uid;
 
         // check if user's key is already being tracked in the authring
         if (keyTracked)
@@ -16708,7 +16708,7 @@ error MegaClient::resetCredentials(handle uh, std::function<void(Error)> complet
         return API_ENOENT;
     }
     assert(authMethod == AUTH_METHOD_FINGERPRINT); // Ed25519 authring cannot be at AUTH_METHOD_SIGNATURE
-    LOG_debug << "Reseting credentials for user " << uidB64 << "...";
+    LOG_debug << "Resetting credentials for user " << uidB64 << "...";
 
     mKeyManager.commit(
         [this, uh, uidB64]()

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -2367,7 +2367,7 @@ void LocalNode::initiateScanBlocked(bool folderBlocked, bool containsFingerprint
     {
         rare().scanBlocked->folderUnreadable = true;
 
-        LOG_verbose << sync->syncname << "Directory scan has become inaccesible for path: " << getLocalPath();
+        LOG_verbose << sync->syncname << "Directory scan has become inaccessible for path: " << getLocalPath();
 
         // Mark all immediate children as requiring refingerprinting.
         for (auto& childIt : children)
@@ -3295,7 +3295,7 @@ bool LocalNode::transferResetUnlessMatched(const direction_t dir,
         return !uploadPtr->putnodesStarted;
     }
 
-    LOG_debug << sync->syncname << "Cancelling superceded transfer of "
+    LOG_debug << sync->syncname << "Cancelling superseded transfer of "
               << transferSP->getLocalname() << ". Reason: "
               << (transferDirectionNeedsToChange ?
                       "Transfer direction needs to change." :

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -3141,7 +3141,7 @@ bool Sync::checkForCompletedCloudMoveToHere(SyncRow& row,
             {
                 // just alert us to this an double check the case in the debugger
                 // resetting the movePtrs should cause re-evaluation
-                LOG_debug << syncname << "We found the soure move node, but the source movePtr is no longer there." << sourceSyncNode->getCloudPath(true) << logTriplet(row, fullPath);
+                LOG_debug << syncname << "We found the source move node, but the source movePtr is no longer there." << sourceSyncNode->getCloudPath(true) << logTriplet(row, fullPath);
                 assert(false);
             }
             else


### PR DESCRIPTION
Hi!
I'm packaging megacmd for Debian. Since the SDK is a submodule of this package, I found some spelling errors and decided to contribute these corrections to the project.
Hope this helps!