### PR TITLE
Implement method truncate(size_t) in LocalPath to fix build error

### DIFF
--- a/include/mega/localpath.h
+++ b/include/mega/localpath.h
@@ -109,6 +109,9 @@ public:
 
     virtual string_type getRealPath() const = 0;
 
+    //added method to fix build error
+    virtual void truncate(size_t bytePos) = 0;
+
 private:
     virtual bool findNextSeparator(size_t& separatorBytePos) const = 0;
 };
@@ -194,6 +197,14 @@ public:
     void setImpl(std::unique_ptr<AbstractLocalPath>&& imp)
     {
         mImplementation = std::move(imp);
+    }
+
+    void truncate(size_t bytePos)
+    {
+        if (mImplementation)
+        {
+            mImplementation->truncate(bytePos);
+        }
     }
 
     // path2local / local2path are much more natural here than in FileSystemAccess

--- a/src/localpath.cpp
+++ b/src/localpath.cpp
@@ -213,7 +213,7 @@ public:
     {
         return PathType::URI_PATH;
     }
-
+    void truncate(size_t bytePos) override;
     bool extension(std::string& extension) const override;
     std::string extension() const override;
 
@@ -1755,6 +1755,14 @@ std::string PathURI::leafOrParentName() const
     }
 
     return {};
+}
+
+void PathURI::truncate(size_t bytePos)
+{
+    if (bytePos < mUri.size())
+    {
+        mUri.resize(bytePos);
+    }
 }
 
 void PathURI::append(const LocalPath& additionalPath)


### PR DESCRIPTION
Hi !

This patch implements the missing virtual method truncate(size_t) in the
LocalPath and PathURI classes.

The absence of this method caused linkage and build errors in projects
depending on the SDK (such as MegaCMD). The implementation safely truncates
the internal URI string, ensuring consistent behavior across platforms.

This is another pull for megacmd because the adjustments were made to integrate the two packages into the same build.
https://github.com/meganz/MEGAcmd/pull/1096

I hope I am contributing to the project.

