### PR TITLE
Fix style by removing the unnecessary semicolon

### DIFF
--- a/include/mega/common/task_executor.h
+++ b/include/mega/common/task_executor.h
@@ -51,10 +51,10 @@ class TaskExecutor
     WorkerList mWorkers;
 
     // Called on worker thread start
-    virtual void workerStarted(std::thread::id){};
+    virtual void workerStarted(std::thread::id){}
 
     // Called on worker thread stop
-    virtual void workerStopped(std::thread::id){};
+    virtual void workerStopped(std::thread::id){}
 
 public:
     explicit TaskExecutor(const TaskExecutorFlags& flags,

--- a/include/mega/gfx/external.h
+++ b/include/mega/gfx/external.h
@@ -43,7 +43,7 @@ class GfxProviderExternal : public IGfxLocalProvider
 public:
     GfxProviderExternal() = default;
     GfxProviderExternal(MegaGfxProcessor* gfxProcessor):
-        processor(gfxProcessor){};
+        processor(gfxProcessor){}
     void setProcessor(MegaGfxProcessor* gfxProcessor);
 };
 } // namespace

--- a/include/mega/localpath.h
+++ b/include/mega/localpath.h
@@ -122,7 +122,7 @@ private:
 class MEGA_API PlatformURIHelper
 {
 public:
-    virtual ~PlatformURIHelper(){};
+    virtual ~PlatformURIHelper(){}
     // Returns true if string is an URI
     virtual bool isURI(const string_type& URI) = 0;
     // Returns the name of file/directory pointed by the URI

--- a/include/mega/mega_csv.h
+++ b/include/mega/mega_csv.h
@@ -5922,7 +5922,7 @@ namespace csv {
         template<typename T>
         class ThreadSafeDeque {
         public:
-            ThreadSafeDeque(size_t notify_size = 100) : _notify_size(notify_size) {};
+            ThreadSafeDeque(size_t notify_size = 100) : _notify_size(notify_size) {}
             ThreadSafeDeque(const ThreadSafeDeque& other) {
                 this->data = other.data;
                 this->_notify_size = other._notify_size;
@@ -6026,7 +6026,7 @@ namespace csv {
             IBasicCSVParser() = default;
             IBasicCSVParser(const CSVFormat&, const ColNamesPtr&);
             IBasicCSVParser(const ParseFlagMap& parse_flags, const WhitespaceMap& ws_flags
-            ) : _parse_flags(parse_flags), _ws_flags(ws_flags) {};
+            ) : _parse_flags(parse_flags), _ws_flags(ws_flags) {}
 
             virtual ~IBasicCSVParser() {}
 
@@ -6134,7 +6134,7 @@ namespace csv {
             StreamParser(TStream& source,
                 const CSVFormat& format,
                 const ColNamesPtr& col_names = nullptr
-            ) : IBasicCSVParser(format, col_names), _source(std::move(source)) {};
+            ) : IBasicCSVParser(format, col_names), _source(std::move(source)) {}
 
             StreamParser(
                 TStream& source,
@@ -6142,7 +6142,7 @@ namespace csv {
                 internals::WhitespaceMap ws_flags) :
                 IBasicCSVParser(parse_flags, ws_flags),
                 _source(std::move(source))
-            {};
+            {}
 
             ~StreamParser() {}
 
@@ -6207,7 +6207,7 @@ namespace csv {
             ) : IBasicCSVParser(format, col_names) {
                 this->_filename = filename.data();
                 this->source_size = get_file_size(filename);
-            };
+            }
 
             ~MmapParser() {}
 
@@ -6277,7 +6277,7 @@ namespace csv {
             #endif
 
             iterator() = default;
-            iterator(CSVReader* reader) : daddy(reader) {};
+            iterator(CSVReader* reader) : daddy(reader) {}
             iterator(CSVReader*, CSVRow&&);
 
             /** Access the CSVRow held by the iterator */
@@ -6346,7 +6346,7 @@ namespace csv {
         HEDLEY_CONST iterator end() const noexcept;
 
         /** Returns true if we have reached end of file */
-        bool eof() const noexcept { return this->parser->eof(); };
+        bool eof() const noexcept { return this->parser->eof(); }
         ///@}
 
         /** @name CSV Metadata */
@@ -6724,7 +6724,7 @@ namespace csv {
          *
          *  @param[out] filename  File to write to
          */
-        DelimWriter(const std::string& filename) : DelimWriter(std::ifstream(filename)) {};
+        DelimWriter(const std::string& filename) : DelimWriter(std::ifstream(filename)) {}
 
         /** Destructor will flush remaining data
          *

--- a/include/mega/megaapp.h
+++ b/include/mega/megaapp.h
@@ -250,10 +250,10 @@ struct MEGA_API MegaApp
     virtual void getemaillink_result(error) {}
 
     // resend verification email
-    virtual void resendverificationemail_result(error) {};
+    virtual void resendverificationemail_result(error) {}
 
     // reset the verified phone number
-    virtual void resetSmsVerifiedPhoneNumber_result(error) {};
+    virtual void resetSmsVerifiedPhoneNumber_result(error) {}
 
     // confirm change email link result
     virtual void confirmemaillink_result(error) {}

--- a/include/mega/sync.h
+++ b/include/mega/sync.h
@@ -520,7 +520,7 @@ public:
         mCanChangeVault(canChangeVault)
     {}
 
-    virtual ~SyncThreadsafeState(){};
+    virtual ~SyncThreadsafeState(){}
 
     handle backupId() const
     {

--- a/include/mega/textchat.h
+++ b/include/mega/textchat.h
@@ -51,8 +51,8 @@ public:
     static constexpr unsigned int schedEmptyFlags = 0;
 
     ScheduledFlags() = default;
-    ScheduledFlags (const unsigned long numericValue) : mFlags(numericValue) {};
-    ScheduledFlags (const ScheduledFlags* flags)      : mFlags(flags ? flags->getNumericValue() : schedEmptyFlags) {};
+    ScheduledFlags (const unsigned long numericValue) : mFlags(numericValue) {}
+    ScheduledFlags (const ScheduledFlags* flags)      : mFlags(flags ? flags->getNumericValue() : schedEmptyFlags) {}
     virtual ~ScheduledFlags() = default;
     ScheduledFlags(const ScheduledFlags&) = delete;
     ScheduledFlags(const ScheduledFlags&&) = delete;

--- a/src/common/platform/posix/mega/common/platform/folder_locker.h
+++ b/src/common/platform/posix/mega/common/platform/folder_locker.h
@@ -19,7 +19,7 @@ public:
 
     FolderLocker& operator=(FolderLocker&&) = default;
 
-    void reset(){};
+    void reset(){}
 };
 
 } // platform

--- a/tests/integration/SdkTest_test.h
+++ b/tests/integration/SdkTest_test.h
@@ -446,7 +446,7 @@ public:
         mEndpointName{endpointName} {};
 
     MegaApiTestDeleter():
-        MegaApiTestDeleter(""){};
+        MegaApiTestDeleter(""){}
 
     void operator()(MegaApiTest* p) const;
 


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/language/class.html#Member_specification

> 2) Function definitions, which both declare and define [member functions](https://en.cppreference.com/w/cpp/language/member_functions.html) or [friend functions](https://en.cppreference.com/w/cpp/language/friend.html). A semicolon after a member function definition is optional.

Remove the extra semicolon for the consistency of the code style.

By the way, why hasn't this CPP source code followed the coding style defined in `.clang-format`? I saw a lot of inconsistencies in the source code.