### PR TITLE
Make copying by using the existing file's encryption credentials (AES…

### DIFF
--- a/include/mega/file.h
+++ b/include/mega/file.h
@@ -330,6 +330,8 @@ struct DelayedSyncUpload
     {}
 };
 
-} // namespace
+Node* findCloneFileCandidate(MegaClient& mc, const File& file);
+
+} // namespace mega
 
 #endif


### PR DESCRIPTION
1. As the clone mechanism in Synchronization systems was done, Only implement the clone mechanism in Transfer .
2. Make copying (as opposed to reuploading)  by using the existing file's encryption credentials (AES-128 key + nonce) to read and encrypt the potentially matching local file. Compute the MAC while doing so. Add code to skip uploading the file and instead copy the remote file if the resulting MAC matches.
