### PR TITLE
Fix missing ICU i18n linkage in non-vcpkg build path

### DIFF
--- a/cmake/modules/sdklib_libraries.cmake
+++ b/cmake/modules/sdklib_libraries.cmake
@@ -110,8 +110,8 @@ macro(load_sdklib_libraries)
         pkg_check_modules(curl REQUIRED IMPORTED_TARGET libcurl)
         target_link_libraries(SDKlib PRIVATE PkgConfig::curl)
 
-        find_package(ICU COMPONENTS uc data REQUIRED)
-        target_link_libraries(SDKlib PRIVATE ICU::uc ICU::data)
+        find_package(ICU COMPONENTS i18n uc data REQUIRED)
+        target_link_libraries(SDKlib PRIVATE ICU::i18n ICU::uc ICU::data)
 
         if(USE_OPENSSL)
             find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
## Summary

The non-vcpkg (system dependency) code path in `sdklib_libraries.cmake` links `ICU::uc` and `ICU::data` but omits `ICU::i18n`, which is required for `icu::Collator::createInstance()` used in `sdk/src/utils.cpp`. This causes an undefined reference error at link time:

```
undefined reference to `icu_78::Collator::createInstance(icu_78::Locale const&, UErrorCode&)'
```

The vcpkg code path correctly includes all three components (`i18n`, `uc`, `data`), but the system dependency path was missed.

This was introduced in 1f5c9cf8bd98a165aa65a9b05a6db118e35353e9.

## Fix

Add `ICU::i18n` to both the `find_package` and `target_link_libraries` calls in the non-vcpkg section, matching what the vcpkg section already does.
