### PR TITLE
Enable USE_POLL on desktop Linux and make the poll waiter match select() semantics

### DIFF
--- a/cmake/modules/sdklib_target.cmake
+++ b/cmake/modules/sdklib_target.cmake
@@ -383,7 +383,7 @@ target_compile_definitions(SDKlib
     $<$<BOOL:${ENABLE_SYNC}>:ENABLE_SYNC>
     $<$<BOOL:${USE_LIBUV}>:HAVE_LIBUV>
     $<$<PLATFORM_ID:iOS>:USE_IOS>
-    $<$<PLATFORM_ID:Android>:USE_POLL>
+    $<$<OR:$<PLATFORM_ID:Android>,$<PLATFORM_ID:Linux>>:USE_POLL>
     $<$<PLATFORM_ID:Android>:USE_INOTIFY>
     $<$<PLATFORM_ID:Android>:HAVE_SDK_CONFIG_H>
 )

--- a/src/posix/waiter.cpp
+++ b/src/posix/waiter.cpp
@@ -121,6 +121,7 @@ int PosixWaiter::wait()
     {
         fds[polli].fd = fd;
         fds[polli].events = POLLIN_SET;
+        fds[polli].revents = 0;
         polli++;
     }
 
@@ -128,6 +129,7 @@ int PosixWaiter::wait()
     {
         fds[polli].fd = fd;
         fds[polli].events = POLLOUT_SET;
+        fds[polli].revents = 0;
         polli++;
     }
 
@@ -135,9 +137,44 @@ int PosixWaiter::wait()
     {
         fds[polli].fd = fd;
         fds[polli].events = POLLEX_SET;
+        fds[polli].revents = 0;
         polli++;
     }
     numfd = poll(fds, total, timeoutInMs);
+
+    // Mirror select(): rewrite rfds/wfds/efds to hold only the fds that are
+    // actually ready, so post-wait MEGA_FD_ISSET() means "ready", not
+    // "registered". poll() only reports requested events (plus
+    // POLLERR/POLLHUP/POLLNVAL), so any nonzero revents marks the fd ready
+    // for the set it was registered in - including POLLNVAL, which select()
+    // surfaces as EBADF and must trigger exec() so stale fds get cleaned up.
+    {
+        const size_t nr = rfds.size();
+        const size_t nw = nr + wfds.size();
+        mega_fd_set_t readyr, readyw, readye;
+        for (size_t i = 0; i < total; i++)
+        {
+            if (!fds[i].revents)
+            {
+                continue;
+            }
+            if (i < nr)
+            {
+                readyr.insert(fds[i].fd);
+            }
+            else if (i < nw)
+            {
+                readyw.insert(fds[i].fd);
+            }
+            else
+            {
+                readye.insert(fds[i].fd);
+            }
+        }
+        rfds = std::move(readyr);
+        wfds = std::move(readyw);
+        efds = std::move(readye);
+    }
 #else
     numfd = select(maxfd + 1, &rfds, &wfds, &efds, EVER(maxds) ? &tv : NULL);
 #endif
@@ -165,7 +202,10 @@ int PosixWaiter::wait()
 #ifdef USE_POLL
     for (unsigned int i = 0 ; i < total ; i++)
     {
-        if  ((fds[i].revents & (POLLIN_SET | POLLOUT_SET | POLLEX_SET) )  && !MEGA_FD_ISSET(fds[i].fd, &ignorefds) )
+        // Any event counts, POLLNVAL included: a stale fd must wake exec()
+        // for cleanup (select() reports it as EBADF -> NEEDEXEC), otherwise
+        // poll() returns instantly forever without ever running exec().
+        if  (fds[i].revents  && !MEGA_FD_ISSET(fds[i].fd, &ignorefds) )
         {
             return NEEDEXEC;
         }


### PR DESCRIPTION
### Problem

On desktop Linux the SDK's `PosixWaiter` uses `select()`/`fd_set`, which cannot represent file descriptors >= `FD_SETSIZE` (1024). Under a heavy sync load (tens of thousands of files; CloudRAID opens ~6 connections per transfer) a desktop client reaches fd numbers above 1023 quickly, and glibc's `_FORTIFY_SOURCE` then aborts the process inside `FD_SET` (`*** bit out of range 0 - FD_SETSIZE on fd_set ***`).

This puts Linux users in an unwinnable position:
- `RLIMIT_NOFILE` soft limit > 1024 → instant SIGABRT via `__fdelt_chk` (observed: ~20 s into a large sync).
- soft limit <= 1024 → fd exhaustion instead; the process dies later on `EMFILE` (observed: GLib abort creating a GWakeup pipe), plus misleading "local folder is unavailable" sync errors when `open()` fails.

No limit value avoids both. MEGAsync 6.5.1.0 on Arch Linux reproduces this reliably syncing two folders totalling ~23k files.

### Fix

The SDK already contains the cure: the `USE_POLL` implementation of `PosixWaiter::wait()`, shipped on Android since 2020 — and previously reached for on macOS for exactly this reason (ccb12d227, "the socket numbers are getting quite large"). This PR enables it for Linux and closes three semantic gaps between the poll and select branches so the rest of the SDK behaves identically on both:

1. **`cmake/modules/sdklib_target.cmake`**: `USE_POLL` generator expression Android → Android|Linux. (`USE_INOTIFY`/`HAVE_SDK_CONFIG_H` deliberately untouched.)
2. **Ready-set write-back** (`src/posix/waiter.cpp`): `select()` rewrites `rfds/wfds/efds` in place, so post-wait `MEGA_FD_ISSET()` means "ready". The poll branch never wrote results back, so consumers that read the sets after `wait()` — `CurlHttpIO::processcurlevents` (`src/posix/net.cpp`), the inotify check in `src/posix/fs.cpp` — saw every registered fd as permanently ready, causing a spurious `curl_multi_socket_action` sweep over all sockets on every wakeup. After `poll()` returns, the sets are now rebuilt to contain only fds with nonzero `revents`, restoring "ISSET == ready" for every consumer without touching any of them.
3. **`POLLNVAL` wakes `exec()`**: the wakeup test previously masked `revents` with `POLLIN_SET|POLLOUT_SET|POLLEX_SET`, which excludes `POLLNVAL`. A stale fd therefore made `poll()` return instantly while `wait()` returned 0 — a 100% CPU spin in which `exec()` (the only cleanup path) never runs. `select()` surfaces the same state as `EBADF` → `NEEDEXEC`. The test now treats any nonzero `revents` as a wakeup reason.
4. **`revents` zero-init** in the pollfd construction loops: the kernel does not write `revents` on pre-poll error returns (`EINVAL`/`ENOMEM`/`EFAULT`), so the write-back would otherwise read uninitialized stack.

### Testing

Built into MEGAsync 6.5.1.0 on Arch Linux (glibc 2.44, curl 8.21) with `RLIMIT_NOFILE=65536`. The client ran with fd numbers up to ~1400 — past the old crash line — through a full two-way sync of a 7.9k-file / 68 GiB folder: no aborts, no busy-loop (CPU ~3% steady), stable memory, and the resulting binary imports `__poll_chk` with no `__fdelt_chk`/`select` references (`nm -D -u`). The prior binary on the same workload crashed within seconds (limit >1024) or ~2 hours (limit <=1024).
